### PR TITLE
Various changes to close a bunch of open issues

### DIFF
--- a/.analysis_options
+++ b/.analysis_options
@@ -2,32 +2,27 @@ analyzer:
   strong-mode: true
 linter:
   rules:
+    # Errors
     - avoid_empty_else
-    - comment_references
     - control_flow_in_finally
     - empty_statements
-    - hash_and_equals
-    - iterable_contains_unrelated_type
-    - list_remove_unrelated_type
     - test_types_in_equals
     - throw_in_finally
-    - unrelated_type_equality_checks
     - valid_regexps
-    - always_declare_return_types
+
+    # Style
     - annotate_overrides
     - avoid_init_to_null
     - avoid_return_types_on_setters
     - await_only_futures
     - camel_case_types
-    - constant_identifier_names
+    - comment_references
     - empty_catches
     - empty_constructor_bodies
-    - library_names
+    - hash_and_equals
     - library_prefixes
-    - only_throw_errors
-    - overridden_fields
-    - package_prefixed_library_names
+    - non_constant_identifier_names
     - prefer_is_not_empty
     - slash_for_doc_comments
     - type_init_formals
-    - unnecessary_getters_setters
+    - unrelated_type_equality_checks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.0.0-alpha+1
+
+- Slight updates to confusing documentation.
+- Added support for null-aware assignments.
+- Added `show` and `hide` support to `ImportBuilder`
+- Added `deferred` support to `ImportBuilder`
+- Added `ExportBuilder`
+- Added `list` and `map` literals that support generic types
+
 ## 1.0.0-alpha
 
 - Large refactor that makes the library more feature complete.

--- a/lib/code_builder.dart
+++ b/lib/code_builder.dart
@@ -6,10 +6,11 @@ export 'src/builders/annotation.dart' show AnnotationBuilder;
 export 'src/builders/class.dart'
     show asStatic, clazz, extend, implement, mixin, ClassBuilder;
 export 'src/builders/expression.dart'
-    show literal, ExpressionBuilder, InvocationBuilder;
+    show literal, list, map, ExpressionBuilder, InvocationBuilder;
 export 'src/builders/field.dart'
     show varConst, varField, varFinal, FieldBuilder;
-export 'src/builders/file.dart' show ImportBuilder, LibraryBuilder, PartBuilder;
+export 'src/builders/file.dart'
+    show ExportBuilder, ImportBuilder, LibraryBuilder, PartBuilder;
 export 'src/builders/method.dart'
     show
         constructor,

--- a/lib/dart/async.dart
+++ b/lib/dart/async.dart
@@ -35,6 +35,12 @@ class DartAsync {
   /// References [dart_async.Future].
   final ReferenceBuilder Future = _ref('Future');
 
+  /// References [dart_async.Stream].
+  final ReferenceBuilder Stream = _ref('Stream');
+
+  /// References [dart_async.StreamSubscription].
+  final ReferenceBuilder StreamSubscription = _ref('StreamSubscription');
+
   DartAsync._();
 
   static ReferenceBuilder _ref(String name) => reference(name, 'dart:async');

--- a/lib/dart/core.dart
+++ b/lib/dart/core.dart
@@ -213,6 +213,11 @@ class DartCore {
   /// References [dart_core.UriData].
   final ReferenceBuilder UriData = _ref('UriData');
 
+  /// References `dynamic` type for returning any in a method.
+  ///
+  /// **NOTE**: As a language limitation, this cannot be named `dynamic`.
+  final TypeBuilder $dynamic = new TypeBuilder('dynamic');
+
   /// References `void` type for returning nothing in a method.
   ///
   /// **NOTE**: As a language limitation, this cannot be named `void`.

--- a/lib/src/builders/expression/assert.dart
+++ b/lib/src/builders/expression/assert.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 part of code_builder.src.builders.expression;
 
 class _AsAssert implements StatementBuilder {

--- a/lib/src/builders/expression/assign.dart
+++ b/lib/src/builders/expression/assign.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 part of code_builder.src.builders.expression;
 
 class _AsAssign extends AbstractExpressionMixin {

--- a/lib/src/builders/expression/invocation.dart
+++ b/lib/src/builders/expression/invocation.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 part of code_builder.src.builders.expression;
 
 /// Partial implementation of [InvocationBuilder].

--- a/lib/src/builders/expression/negate.dart
+++ b/lib/src/builders/expression/negate.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 part of code_builder.src.builders.expression;
 
 class _NegateExpression extends AbstractExpressionMixin {

--- a/lib/src/builders/expression/operators.dart
+++ b/lib/src/builders/expression/operators.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 part of code_builder.src.builders.expression;
 
 class _AsBinaryExpression extends Object with AbstractExpressionMixin {

--- a/lib/src/builders/expression/return.dart
+++ b/lib/src/builders/expression/return.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 part of code_builder.src.builders.expression;
 
 class _AsReturn implements StatementBuilder {

--- a/lib/src/builders/field.dart
+++ b/lib/src/builders/field.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'package:analyzer/analyzer.dart';
 import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/src/dart/ast/token.dart';

--- a/lib/src/builders/file.dart
+++ b/lib/src/builders/file.dart
@@ -131,25 +131,120 @@ class _LibraryDirectiveBuilder implements AstBuilder<LibraryDirective> {
 class ImportBuilder implements AstBuilder<ImportDirective> {
   final String _prefix;
   final String _uri;
+  final bool _deferred;
 
-  factory ImportBuilder(String path, {String prefix}) {
-    return new ImportBuilder._(path, prefix);
+  final Set<String> _show = new Set<String>();
+  final Set<String> _hide = new Set<String>();
+
+  factory ImportBuilder(String path, {bool deferred: false, String prefix}) {
+    return new ImportBuilder._(path, prefix, deferred);
   }
 
-  ImportBuilder._(this._uri, this._prefix);
+  ImportBuilder._(this._uri, this._prefix, this._deferred);
+
+  void hide(String identifier) {
+    _hide.add(identifier);
+  }
+
+  void hideAll(Iterable<String> identifiers) {
+    _hide.addAll(identifiers);
+  }
+
+  void show(String identifier) {
+    _show.add(identifier);
+  }
+
+  void showAll(Iterable<String> identifier) {
+    _show.addAll(identifier);
+  }
 
   @override
   ImportDirective buildAst([_]) {
+    var combinators = <Combinator>[];
+    if (_show.isNotEmpty) {
+      combinators.add(
+        new ShowCombinator(
+          $show,
+          _show.map(stringIdentifier).toList(),
+        ),
+      );
+    }
+    if (_hide.isNotEmpty) {
+      combinators.add(
+        new HideCombinator(
+          $hide,
+          _hide.map(stringIdentifier).toList(),
+        ),
+      );
+    }
     return new ImportDirective(
       null,
       null,
       null,
       new SimpleStringLiteral(stringToken("'$_uri'"), _uri),
       null,
-      null,
+      _deferred ? $deferred : null,
       _prefix != null ? $as : null,
       _prefix != null ? stringIdentifier(_prefix) : null,
+      combinators,
+      $semicolon,
+    );
+  }
+}
+
+/// Lazily builds an [ExportDirective] AST when built.
+class ExportBuilder implements AstBuilder<ExportDirective> {
+  final String _uri;
+
+  final Set<String> _show = new Set<String>();
+  final Set<String> _hide = new Set<String>();
+
+  factory ExportBuilder(String path) = ExportBuilder._;
+
+  ExportBuilder._(this._uri);
+
+  void hide(String identifier) {
+    _hide.add(identifier);
+  }
+
+  void hideAll(Iterable<String> identifiers) {
+    _hide.addAll(identifiers);
+  }
+
+  void show(String identifier) {
+    _show.add(identifier);
+  }
+
+  void showAll(Iterable<String> identifier) {
+    _show.addAll(identifier);
+  }
+
+  @override
+  ExportDirective buildAst([_]) {
+    var combinators = <Combinator>[];
+    if (_show.isNotEmpty) {
+      combinators.add(
+        new ShowCombinator(
+          $show,
+          _show.map(stringIdentifier).toList(),
+        ),
+      );
+    }
+    if (_hide.isNotEmpty) {
+      combinators.add(
+        new HideCombinator(
+          $hide,
+          _hide.map(stringIdentifier).toList(),
+        ),
+      );
+    }
+    return new ExportDirective(
       null,
+      null,
+      null,
+      new SimpleStringLiteral(stringToken("'$_uri'"), _uri),
+      null,
+      combinators,
       $semicolon,
     );
   }

--- a/lib/src/builders/statement/block.dart
+++ b/lib/src/builders/statement/block.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'package:analyzer/analyzer.dart';
 import 'package:code_builder/src/builders/shared.dart';
 import 'package:code_builder/src/builders/statement.dart';

--- a/lib/src/builders/statement/if.dart
+++ b/lib/src/builders/statement/if.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:code_builder/src/builders/expression.dart';
 import 'package:code_builder/src/builders/shared.dart';

--- a/lib/src/builders/type/new_instance.dart
+++ b/lib/src/builders/type/new_instance.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 part of code_builder.src.builders.type;
 
 /// Lazily builds an [InstanceCreationExpression] AST when built.

--- a/lib/src/tokens.dart
+++ b/lib/src/tokens.dart
@@ -35,6 +35,9 @@ final Token $colon = new Token(TokenType.COLON, 0);
 /// The `const` token.
 final Token $const = new KeywordToken(Keyword.CONST, 0);
 
+/// The `deferred` token.
+final Token $deferred = new KeywordToken(Keyword.DEFERRED, 0);
+
 /// The `/` token.
 final Token $divide = new Token(TokenType.SLASH, 0);
 
@@ -63,6 +66,9 @@ final Token $gt = new Token(TokenType.GT, 0);
 final Token $if = new KeywordToken(Keyword.IF, 0);
 
 // Simple tokens
+
+/// The `hide` token.
+final Token $hide = new StringToken(TokenType.KEYWORD, 'hide', 0);
 
 /// The `implements` token.
 final Token $implements = new KeywordToken(Keyword.IMPLEMENTS, 0);
@@ -120,6 +126,9 @@ final Token $return = new KeywordToken(Keyword.RETURN, 0);
 
 /// The ';' token.
 final Token $semicolon = new Token(TokenType.SEMICOLON, 0);
+
+/// The `show` token.
+final Token $show = new StringToken(TokenType.KEYWORD, 'show', 0);
 
 /// The `static` token.
 final Token $static = new KeywordToken(Keyword.STATIC, 0);

--- a/test/builders/expression_test.dart
+++ b/test/builders/expression_test.dart
@@ -37,8 +37,31 @@ void main() {
       expect(literal([1, 2, 3]), equalsSource(r'[1, 2, 3]'));
     });
 
+    test('should emit a typed list', () {
+      expect(
+        list([1, 2, 3], type: lib$core.int),
+        equalsSource(r'<int> [1, 2, 3]'),
+      );
+    });
+
     test('should emit a map', () {
       expect(literal({1: 2, 2: 3}), equalsSource(r'{1 : 2, 2 : 3}'));
+    });
+
+    test('should emit a typed map', () {
+      expect(
+        map(
+          {
+            1: '2',
+            2: '3',
+          },
+          keyType: lib$core.int,
+          valueType: lib$core.String,
+        ),
+        equalsSource(r'''
+          <int, String> {1 : '2', 2 : '3'}
+        '''),
+      );
     });
   });
 

--- a/test/builders/field_test.dart
+++ b/test/builders/field_test.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'package:code_builder/code_builder.dart';
 import 'package:code_builder/dart/core.dart';
 import 'package:code_builder/testing.dart';

--- a/test/builders/file_test.dart
+++ b/test/builders/file_test.dart
@@ -1,0 +1,62 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:code_builder/code_builder.dart';
+import 'package:code_builder/testing.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('$ImportBuilder', () {
+    test('should support "show"', () {
+      expect(
+        new ImportBuilder('package:foo/foo.dart')..show('Foo'),
+        equalsSource(r'''
+          import 'package:foo/foo.dart' show Foo;
+        '''),
+      );
+    });
+
+    test('should support "show"', () {
+      expect(
+        new ImportBuilder('package:foo/foo.dart')..hide('Bar'),
+        equalsSource(r'''
+          import 'package:foo/foo.dart' hide Bar;
+        '''),
+      );
+    });
+
+    test('should support "deferred as"', () {
+      expect(
+        new ImportBuilder(
+          'package:foo/foo.dart',
+          deferred: true,
+          prefix: 'foo',
+        ),
+        equalsSource(r'''
+          import 'package:foo/foo.dart' deferred as foo;
+        '''),
+      );
+    });
+  });
+
+  group('$ExportBuilder', () {
+    test('should support "show"', () {
+      expect(
+        new ExportBuilder('package:foo/foo.dart')..show('Foo'),
+        equalsSource(r'''
+          export 'package:foo/foo.dart' show Foo;
+        '''),
+      );
+    });
+
+    test('should support "show"', () {
+      expect(
+        new ExportBuilder('package:foo/foo.dart')..hide('Bar'),
+        equalsSource(r'''
+          export 'package:foo/foo.dart' hide Bar;
+        '''),
+      );
+    });
+  });
+}

--- a/test/builders/reference_test.dart
+++ b/test/builders/reference_test.dart
@@ -1,9 +1,0 @@
-// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
-// for details. All rights reserved. Use of this source code is governed by a
-// BSD-style license that can be found in the LICENSE file.
-
-import 'package:test/test.dart';
-
-void main() {
-  group('reference', () {});
-}

--- a/test/builders/shared_test.dart
+++ b/test/builders/shared_test.dart
@@ -2,6 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'package:code_builder/src/builders/shared.dart';
 import 'package:code_builder/src/tokens.dart';
 import 'package:test/test.dart';

--- a/test/builders/statement_test.dart
+++ b/test/builders/statement_test.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'package:code_builder/code_builder.dart';
 import 'package:code_builder/dart/core.dart';
 import 'package:code_builder/testing.dart';

--- a/test/builders/type_test.dart
+++ b/test/builders/type_test.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'package:code_builder/code_builder.dart';
 import 'package:code_builder/dart/core.dart';
 import 'package:code_builder/testing.dart';

--- a/test/scope_test.dart
+++ b/test/scope_test.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'package:analyzer/analyzer.dart';
 import 'package:code_builder/src/scope.dart';
 import 'package:test/test.dart';

--- a/tool/presubmit.sh
+++ b/tool/presubmit.sh
@@ -14,7 +14,7 @@ echo "PASSED"
 
 # Make sure we pass the analyzer
 echo "Checking dartanalyzer..."
-FAILS_ANALYZER="$(find lib test -name "*.dart" | xargs dartanalyzer --options analysis_options.yaml)"
+FAILS_ANALYZER="$(find lib test -name "*.dart" | xargs dartanalyzer --options .analysis_options)"
 if [[ $FAILS_ANALYZER == *"[error]"* ]]
 then
   echo "FAILED"


### PR DESCRIPTION
## 1.0.0-alpha+1

- Slight updates to confusing documentation.
- Added support for null-aware assignments.
- Added `show` and `hide` support to `ImportBuilder`
- Added `deferred` support to `ImportBuilder`
- Added `ExportBuilder`
- Added `list` and `map` literals that support generic types

---

Closes https://github.com/dart-lang/code_builder/issues/17
Closes https://github.com/dart-lang/code_builder/issues/18
Closes https://github.com/dart-lang/code_builder/issues/19
Closes https://github.com/dart-lang/code_builder/issues/20

/cc @alorenzen 