### PR TITLE
Begin taking advantage of analyzer's new AstFactory class.

### DIFF
--- a/lib/src/builders/class.dart
+++ b/lib/src/builders/class.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:analyzer/analyzer.dart';
+import 'package:analyzer/dart/ast/standard_ast_factory.dart';
 import 'package:code_builder/dart/core.dart';
 import 'package:code_builder/src/builders/annotation.dart';
 import 'package:code_builder/src/builders/field.dart';
@@ -200,7 +201,7 @@ class _ClassBuilderImpl extends Object
     if (extend == null && _with.isNotEmpty) {
       extend = lib$core.Object;
     }
-    final clazz = new ClassDeclaration(
+    final clazz = astFactory.classDeclaration(
       null,
       buildAnnotations(scope),
       _asAbstract ? $abstract : null,
@@ -208,19 +209,19 @@ class _ClassBuilderImpl extends Object
       stringIdentifier(_name),
       null,
       extend != null
-          ? new ExtendsClause(
+          ? astFactory.extendsClause(
               $extends,
               extend.buildType(scope),
             )
           : null,
       _with.isNotEmpty
-          ? new WithClause(
+          ? astFactory.withClause(
               $with,
               _with.map/*<TypeName>*/((w) => w.buildType(scope)).toList(),
             )
           : null,
       _implements.isNotEmpty
-          ? new ImplementsClause(
+          ? astFactory.implementsClause(
               $implements,
               _implements.map/*<TypeName>*/((i) => i.buildType(scope)).toList(),
             )

--- a/lib/src/builders/expression.dart
+++ b/lib/src/builders/expression.dart
@@ -5,6 +5,7 @@ library code_builder.src.builders.expression;
 
 import 'package:analyzer/analyzer.dart';
 import 'package:analyzer/dart/ast/token.dart';
+import 'package:analyzer/dart/ast/standard_ast_factory.dart';
 import 'package:analyzer/src/dart/ast/token.dart';
 import 'package:code_builder/dart/core.dart';
 import 'package:code_builder/src/builders/method.dart';
@@ -24,11 +25,11 @@ part 'expression/negate.dart';
 part 'expression/operators.dart';
 part 'expression/return.dart';
 
-final _false = new BooleanLiteral(new KeywordToken(Keyword.FALSE, 0), true);
+final _false = astFactory.booleanLiteral(new KeywordToken(Keyword.FALSE, 0), true);
 
-final _null = new NullLiteral(new KeywordToken(Keyword.NULL, 0));
+final _null = astFactory.nullLiteral(new KeywordToken(Keyword.NULL, 0));
 
-final _true = new BooleanLiteral(new KeywordToken(Keyword.TRUE, 0), true);
+final _true = astFactory.booleanLiteral(new KeywordToken(Keyword.TRUE, 0), true);
 
 /// Returns a pre-defined literal expression of [value].
 ///
@@ -71,11 +72,11 @@ Literal _literal(value) {
   } else if (value is bool) {
     return value ? _true : _false;
   } else if (value is String) {
-    return new SimpleStringLiteral(stringToken("'$value'"), value);
+    return astFactory.simpleStringLiteral(stringToken("'$value'"), value);
   } else if (value is int) {
-    return new IntegerLiteral(stringToken('$value'), value);
+    return astFactory.integerLiteral(stringToken('$value'), value);
   } else if (value is double) {
-    return new DoubleLiteral(stringToken('$value'), value);
+    return astFactory.doubleLiteral(stringToken('$value'), value);
   }
   throw new ArgumentError.value(value, 'Unsupported');
 }
@@ -381,7 +382,7 @@ class _AsStatement extends TopLevelMixin implements StatementBuilder {
 
   @override
   Statement buildStatement([Scope scope]) {
-    return new ExpressionStatement(
+    return astFactory.expressionStatement(
       _expression.buildExpression(scope),
       $semicolon,
     );
@@ -400,7 +401,7 @@ class _MemberExpression extends Object
 
   @override
   Expression buildExpression([Scope scope]) {
-    return new PropertyAccess(
+    return astFactory.propertyAccess(
       _target.buildExpression(scope),
       $period,
       stringIdentifier(_name),
@@ -432,7 +433,7 @@ class _ParenthesesExpression extends Object
 
   @override
   Expression buildExpression([Scope scope]) {
-    return new ParenthesizedExpression(
+    return astFactory.parenthesizedExpression(
       $openParen,
       _expression.buildExpression(scope),
       $closeParen,
@@ -470,10 +471,10 @@ class _TypedListExpression extends Object
 
   @override
   Expression buildExpression([Scope scope]) {
-    return new ListLiteral(
+    return astFactory.listLiteral(
       _asConst ? $const : null,
       _type != null
-          ? new TypeArgumentList(
+          ? astFactory.typeArgumentList(
               $openBracket,
               [_type.buildType(scope)],
               $closeBracket,
@@ -517,10 +518,10 @@ class _TypedMapExpression extends Object
 
   @override
   Expression buildExpression([Scope scope]) {
-    return new MapLiteral(
+    return astFactory.mapLiteral(
       _asConst ? $const : null,
       _keyType != null
-          ? new TypeArgumentList(
+          ? astFactory.typeArgumentList(
               $openBracket,
               [
                 _keyType.buildType(scope),
@@ -531,7 +532,7 @@ class _TypedMapExpression extends Object
           : null,
       $openBracket,
       _values.keys.map((k) {
-        return new MapLiteralEntry(
+        return astFactory.mapLiteralEntry(
           k.buildExpression(scope),
           $colon,
           _values[k].buildExpression(scope),

--- a/lib/src/builders/expression.dart
+++ b/lib/src/builders/expression.dart
@@ -25,11 +25,13 @@ part 'expression/negate.dart';
 part 'expression/operators.dart';
 part 'expression/return.dart';
 
-final _false = astFactory.booleanLiteral(new KeywordToken(Keyword.FALSE, 0), true);
+final _false =
+    astFactory.booleanLiteral(new KeywordToken(Keyword.FALSE, 0), true);
 
 final _null = astFactory.nullLiteral(new KeywordToken(Keyword.NULL, 0));
 
-final _true = astFactory.booleanLiteral(new KeywordToken(Keyword.TRUE, 0), true);
+final _true =
+    astFactory.booleanLiteral(new KeywordToken(Keyword.TRUE, 0), true);
 
 /// Returns a pre-defined literal expression of [value].
 ///

--- a/lib/src/builders/expression/assert.dart
+++ b/lib/src/builders/expression/assert.dart
@@ -14,7 +14,7 @@ class _AsAssert extends TopLevelMixin implements StatementBuilder {
 
   @override
   Statement buildStatement([Scope scope]) {
-    return new AssertStatement(
+    return astFactory.assertStatement(
       $assert,
       $openParen,
       _expression.buildExpression(scope),

--- a/lib/src/builders/expression/assign.dart
+++ b/lib/src/builders/expression/assign.dart
@@ -17,7 +17,7 @@ class _AsAssign extends AbstractExpressionMixin with TopLevelMixin {
 
   @override
   Expression buildExpression([Scope scope]) {
-    return new AssignmentExpression(
+    return astFactory.assignmentExpression(
       _target != null
           ? _target.property(_name).buildExpression(scope)
           : stringIdentifier(_name),
@@ -40,14 +40,14 @@ class _AsAssignNew extends TopLevelMixin implements StatementBuilder {
 
   @override
   Statement buildStatement([Scope scope]) {
-    return new VariableDeclarationStatement(
-      new VariableDeclarationList(
+    return astFactory.variableDeclarationStatement(
+      astFactory.variableDeclarationList(
         null,
         null,
         _type == null || _modifier != $var ? _modifier : null,
         _type?.buildType(scope),
         [
-          new VariableDeclaration(
+          astFactory.variableDeclaration(
             stringIdentifier(_name),
             $equals,
             _value.buildExpression(scope),
@@ -60,16 +60,16 @@ class _AsAssignNew extends TopLevelMixin implements StatementBuilder {
 
   @override
   CompilationUnitMember buildTopLevelAst([Scope scope]) {
-    return new TopLevelVariableDeclaration(
+    return astFactory.topLevelVariableDeclaration(
       null,
       null,
-      new VariableDeclarationList(
+      astFactory.variableDeclarationList(
         null,
         null,
         _type == null || _modifier != $var ? _modifier : null,
         _type?.buildType(scope),
         [
-          new VariableDeclaration(
+          astFactory.variableDeclaration(
             stringIdentifier(_name),
             $equals,
             _value.buildExpression(scope),

--- a/lib/src/builders/expression/cascade.dart
+++ b/lib/src/builders/expression/cascade.dart
@@ -15,7 +15,7 @@ class _CascadeExpression extends TopLevelMixin with AbstractExpressionMixin {
 
   @override
   Expression buildExpression([Scope scope]) {
-    return new CascadeExpression(
+    return astFactory.cascadeExpression(
       _target.buildExpression(scope),
       _cascades.map((e) => e.buildExpression(scope)).toList(),
     );

--- a/lib/src/builders/expression/invocation.dart
+++ b/lib/src/builders/expression/invocation.dart
@@ -25,15 +25,15 @@ abstract class AbstractInvocationBuilderMixin implements InvocationBuilder {
     allArguments.addAll(
         _positional.map/*<Expression>*/((e) => e.buildExpression(scope)));
     _named.forEach((name, e) {
-      allArguments.add(new NamedExpression(
-        new Label(
+      allArguments.add(astFactory.namedExpression(
+        astFactory.label(
           stringIdentifier(name),
           $colon,
         ),
         e.buildExpression(scope),
       ));
     });
-    return new ArgumentList(
+    return astFactory.argumentList(
       $openParen,
       allArguments,
       $closeParen,
@@ -71,7 +71,7 @@ class _FunctionInvocationBuilder extends Object
 
   @override
   Expression buildExpression([Scope scope]) {
-    return new FunctionExpressionInvocation(
+    return astFactory.functionExpressionInvocation(
       _target.buildExpression(scope),
       null,
       buildArgumentList(scope),
@@ -89,7 +89,7 @@ class _MethodInvocationBuilder extends Object
 
   @override
   Expression buildExpression([Scope scope]) {
-    return new MethodInvocation(
+    return astFactory.methodInvocation(
       _target.buildExpression(scope),
       $period,
       stringIdentifier(_method),

--- a/lib/src/builders/expression/negate.dart
+++ b/lib/src/builders/expression/negate.dart
@@ -14,7 +14,7 @@ class _NegateExpression extends AbstractExpressionMixin with TopLevelMixin {
 
   @override
   Expression buildExpression([Scope scope]) {
-    return new PrefixExpression(
+    return astFactory.prefixExpression(
       $not,
       _expression.parentheses().buildExpression(scope),
     );
@@ -31,7 +31,7 @@ class _NegativeExpression extends AbstractExpressionMixin with TopLevelMixin {
 
   @override
   Expression buildExpression([Scope scope]) {
-    return new PrefixExpression(
+    return astFactory.prefixExpression(
       $minus,
       _expression.parentheses().buildExpression(scope),
     );

--- a/lib/src/builders/expression/operators.dart
+++ b/lib/src/builders/expression/operators.dart
@@ -17,7 +17,7 @@ class _AsBinaryExpression extends Object
 
   @override
   Expression buildExpression([Scope scope]) {
-    return new BinaryExpression(
+    return astFactory.binaryExpression(
       _left.buildExpression(scope),
       _operator,
       _right.buildExpression(scope),

--- a/lib/src/builders/expression/return.dart
+++ b/lib/src/builders/expression/return.dart
@@ -14,7 +14,7 @@ class _AsReturn extends TopLevelMixin implements StatementBuilder {
 
   @override
   Statement buildStatement([Scope scope]) {
-    return new ReturnStatement(
+    return astFactory.returnStatement(
       $return,
       _value.buildExpression(),
       $semicolon,

--- a/lib/src/builders/field.dart
+++ b/lib/src/builders/field.dart
@@ -4,6 +4,7 @@
 
 import 'package:analyzer/analyzer.dart';
 import 'package:analyzer/dart/ast/token.dart';
+import 'package:analyzer/dart/ast/standard_ast_factory.dart';
 import 'package:analyzer/src/dart/ast/token.dart';
 import 'package:code_builder/src/builders/annotation.dart';
 import 'package:code_builder/src/builders/class.dart';
@@ -129,7 +130,7 @@ class _FieldBuilderImpl extends TopLevelMixin
 
   @override
   FieldDeclaration buildField(bool static, [Scope scope]) {
-    return new FieldDeclaration(
+    return astFactory.fieldDeclaration(
       null,
       buildAnnotations(scope),
       static ? $static : null,
@@ -140,7 +141,7 @@ class _FieldBuilderImpl extends TopLevelMixin
 
   @override
   Statement buildStatement([Scope scope]) {
-    return new VariableDeclarationStatement(
+    return astFactory.variableDeclarationStatement(
       _buildVariableList(scope),
       $semicolon,
     );
@@ -148,7 +149,7 @@ class _FieldBuilderImpl extends TopLevelMixin
 
   @override
   TopLevelVariableDeclaration buildTopLevel([Scope scope]) {
-    return new TopLevelVariableDeclaration(
+    return astFactory.topLevelVariableDeclaration(
       null,
       null,
       _buildVariableList(scope),
@@ -157,13 +158,13 @@ class _FieldBuilderImpl extends TopLevelMixin
   }
 
   VariableDeclarationList _buildVariableList([Scope scope]) {
-    return new VariableDeclarationList(
+    return astFactory.variableDeclarationList(
       null,
       null,
       _keyword != null ? new KeywordToken(_keyword, 0) : null,
       _type?.buildType(scope),
       [
-        new VariableDeclaration(
+        astFactory.variableDeclaration(
           stringIdentifier(_name),
           _value != null ? $equals : null,
           _value?.buildExpression(scope),

--- a/lib/src/builders/file.dart
+++ b/lib/src/builders/file.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:analyzer/analyzer.dart';
+import 'package:analyzer/dart/ast/standard_ast_factory.dart';
 import 'package:code_builder/src/builders/shared.dart';
 import 'package:code_builder/src/builders/statement.dart';
 import 'package:code_builder/src/tokens.dart';
@@ -69,7 +70,7 @@ class LibraryBuilder extends FileBuilder {
     var directives = <Directive>[]
       ..addAll(_scope.toImports().map((d) => d.buildAst()))
       ..addAll(_directives.map((d) => d.buildAst()));
-    return new CompilationUnit(
+    return astFactory.compilationUnit(
       null,
       null,
       directives,
@@ -90,17 +91,17 @@ class PartBuilder extends FileBuilder {
 
   @override
   CompilationUnit buildAst([_]) {
-    return new CompilationUnit(
+    return astFactory.compilationUnit(
       null,
       null,
       [
-        new PartOfDirective(
+        astFactory.partOfDirective(
           null,
           null,
           $part,
           $of,
-          new LibraryIdentifier([
-            new SimpleIdentifier(stringToken(_name)),
+          astFactory.libraryIdentifier([
+            astFactory.simpleIdentifier(stringToken(_name)),
           ]),
           $semicolon,
         )
@@ -123,12 +124,12 @@ class _LibraryDirectiveBuilder implements AstBuilder<LibraryDirective> {
 
   @override
   LibraryDirective buildAst([_]) {
-    return new LibraryDirective(
+    return astFactory.libraryDirective(
       null,
       null,
       $library,
-      new LibraryIdentifier([
-        new SimpleIdentifier(
+      astFactory.libraryIdentifier([
+        astFactory.simpleIdentifier(
           stringToken(_name),
         ),
       ]),
@@ -173,7 +174,7 @@ class ImportBuilder implements AstBuilder<ImportDirective> {
     var combinators = <Combinator>[];
     if (_show.isNotEmpty) {
       combinators.add(
-        new ShowCombinator(
+        astFactory.showCombinator(
           $show,
           _show.map(stringIdentifier).toList(),
         ),
@@ -181,17 +182,17 @@ class ImportBuilder implements AstBuilder<ImportDirective> {
     }
     if (_hide.isNotEmpty) {
       combinators.add(
-        new HideCombinator(
+        astFactory.hideCombinator(
           $hide,
           _hide.map(stringIdentifier).toList(),
         ),
       );
     }
-    return new ImportDirective(
+    return astFactory.importDirective(
       null,
       null,
       null,
-      new SimpleStringLiteral(stringToken("'$_uri'"), _uri),
+      astFactory.simpleStringLiteral(stringToken("'$_uri'"), _uri),
       null,
       _deferred ? $deferred : null,
       _prefix != null ? $as : null,
@@ -234,7 +235,7 @@ class ExportBuilder implements AstBuilder<ExportDirective> {
     var combinators = <Combinator>[];
     if (_show.isNotEmpty) {
       combinators.add(
-        new ShowCombinator(
+        astFactory.showCombinator(
           $show,
           _show.map(stringIdentifier).toList(),
         ),
@@ -242,17 +243,17 @@ class ExportBuilder implements AstBuilder<ExportDirective> {
     }
     if (_hide.isNotEmpty) {
       combinators.add(
-        new HideCombinator(
+        astFactory.hideCombinator(
           $hide,
           _hide.map(stringIdentifier).toList(),
         ),
       );
     }
-    return new ExportDirective(
+    return astFactory.exportDirective(
       null,
       null,
       null,
-      new SimpleStringLiteral(stringToken("'$_uri'"), _uri),
+      astFactory.simpleStringLiteral(stringToken("'$_uri'"), _uri),
       null,
       combinators,
       $semicolon,

--- a/lib/src/builders/file.dart
+++ b/lib/src/builders/file.dart
@@ -100,6 +100,7 @@ class PartBuilder extends FileBuilder {
           null,
           $part,
           $of,
+          null,
           astFactory.libraryIdentifier([
             astFactory.simpleIdentifier(stringToken(_name)),
           ]),

--- a/lib/src/builders/method.dart
+++ b/lib/src/builders/method.dart
@@ -4,6 +4,7 @@
 
 import 'package:analyzer/analyzer.dart';
 import 'package:analyzer/dart/ast/token.dart';
+import 'package:analyzer/dart/ast/standard_ast_factory.dart';
 import 'package:analyzer/src/dart/ast/token.dart';
 import 'package:code_builder/code_builder.dart';
 import 'package:code_builder/dart/core.dart';
@@ -330,10 +331,10 @@ class _LambdaMethodBuilder extends Object
   }
 
   FunctionExpression _buildExpression(Scope scope, {bool isStatement}) {
-    return new FunctionExpression(
+    return astFactory.functionExpression(
       null,
       _property != Keyword.GET ? buildParameterList(scope) : null,
-      new ExpressionFunctionBody(
+      astFactory.expressionFunctionBody(
         null,
         null,
         _expression.buildExpression(scope),
@@ -344,7 +345,7 @@ class _LambdaMethodBuilder extends Object
 
   @override
   FunctionDeclaration buildFunction([Scope scope]) {
-    return new FunctionDeclaration(
+    return astFactory.functionDeclaration(
       null,
       buildAnnotations(scope),
       null,
@@ -357,7 +358,7 @@ class _LambdaMethodBuilder extends Object
 
   @override
   MethodDeclaration buildMethod(bool static, [Scope scope]) {
-    return new MethodDeclaration(
+    return astFactory.methodDeclaration(
       null,
       buildAnnotations(scope),
       null,
@@ -368,7 +369,7 @@ class _LambdaMethodBuilder extends Object
       stringIdentifier(_name),
       null,
       _property != Keyword.GET ? buildParameterList(scope) : null,
-      new ExpressionFunctionBody(
+      astFactory.expressionFunctionBody(
         null,
         null,
         _expression.buildExpression(scope),
@@ -411,10 +412,10 @@ class _MethodBuilderImpl extends Object
 
   @override
   Expression buildExpression([Scope scope]) {
-    return new FunctionExpression(
+    return astFactory.functionExpression(
       null,
       _property != Keyword.GET ? buildParameterList(scope) : null,
-      new BlockFunctionBody(
+      astFactory.blockFunctionBody(
         null,
         null,
         buildBlock(scope),
@@ -424,7 +425,7 @@ class _MethodBuilderImpl extends Object
 
   @override
   FunctionDeclaration buildFunction([Scope scope]) {
-    return new FunctionDeclaration(
+    return astFactory.functionDeclaration(
       null,
       buildAnnotations(scope),
       null,
@@ -437,7 +438,7 @@ class _MethodBuilderImpl extends Object
 
   @override
   MethodDeclaration buildMethod(bool static, [Scope scope]) {
-    return new MethodDeclaration(
+    return astFactory.methodDeclaration(
       null,
       buildAnnotations(scope),
       null,
@@ -448,7 +449,7 @@ class _MethodBuilderImpl extends Object
       identifier(scope, _name),
       null,
       _property != Keyword.GET ? buildParameterList(scope) : null,
-      new BlockFunctionBody(
+      astFactory.blockFunctionBody(
         null,
         null,
         buildBlock(scope),
@@ -485,7 +486,7 @@ class _NormalConstructorBuilder extends Object
   @override
   ConstructorDeclaration buildConstructor(TypeBuilder returnType,
       [Scope scope]) {
-    return new ConstructorDeclaration(
+    return astFactory.constructorDeclaration(
       null,
       buildAnnotations(scope),
       null,
@@ -499,8 +500,8 @@ class _NormalConstructorBuilder extends Object
       null,
       null,
       !hasStatements
-          ? new EmptyFunctionBody($semicolon)
-          : new BlockFunctionBody(
+          ? astFactory.emptyFunctionBody($semicolon)
+          : astFactory.blockFunctionBody(
               null,
               null,
               buildBlock(scope),

--- a/lib/src/builders/parameter.dart
+++ b/lib/src/builders/parameter.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:analyzer/analyzer.dart';
+import 'package:analyzer/dart/ast/standard_ast_factory.dart';
 import 'package:code_builder/code_builder.dart';
 import 'package:code_builder/src/builders/annotation.dart';
 import 'package:code_builder/src/builders/method.dart';
@@ -66,7 +67,7 @@ abstract class HasParametersMixin implements HasParameters {
 
   /// Builds a [FormalParameterList].
   FormalParameterList buildParameterList([Scope scope]) {
-    return new FormalParameterList(
+    return astFactory.formalParameterList(
       $openParen,
       _parameters
           .map/*<FormalParameter>*/((p) => p.buildParameter(scope))
@@ -122,7 +123,7 @@ class _OptionalParameterBuilder extends Object
 
   @override
   FormalParameter buildNamed(bool field, [Scope scope]) {
-    return new DefaultFormalParameter(
+    return astFactory.defaultFormalParameter(
       _parameter.buildPositional(field, scope),
       ParameterKind.NAMED,
       _expression != null ? $colon : null,
@@ -132,7 +133,7 @@ class _OptionalParameterBuilder extends Object
 
   @override
   FormalParameter buildPositional(bool field, [Scope scope]) {
-    return new DefaultFormalParameter(
+    return astFactory.defaultFormalParameter(
       _parameter.buildPositional(field, scope),
       ParameterKind.POSITIONAL,
       _expression != null ? $equals : null,
@@ -190,7 +191,7 @@ class _SimpleParameterBuilder extends Object
   @override
   FormalParameter buildPositional(bool field, [Scope scope]) {
     if (field) {
-      return new FieldFormalParameter(
+      return astFactory.fieldFormalParameter(
         null,
         buildAnnotations(scope),
         null,
@@ -202,7 +203,7 @@ class _SimpleParameterBuilder extends Object
         null,
       );
     }
-    return new SimpleFormalParameter(
+    return astFactory.simpleFormalParameter(
       null,
       buildAnnotations(scope),
       null,

--- a/lib/src/builders/reference.dart
+++ b/lib/src/builders/reference.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:analyzer/analyzer.dart';
+import 'package:analyzer/dart/ast/standard_ast_factory.dart';
 import 'package:code_builder/src/builders/annotation.dart';
 import 'package:code_builder/src/builders/expression.dart';
 import 'package:code_builder/src/builders/shared.dart';
@@ -36,7 +37,7 @@ class ReferenceBuilder extends Object
 
   @override
   Annotation buildAnnotation([Scope scope]) {
-    return new Annotation(
+    return astFactory.annotation(
       $at,
       stringIdentifier(_name),
       null,

--- a/lib/src/builders/shared.dart
+++ b/lib/src/builders/shared.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:analyzer/analyzer.dart';
+import 'package:analyzer/dart/ast/standard_ast_factory.dart';
 import 'package:code_builder/src/scope.dart';
 import 'package:code_builder/src/tokens.dart';
 
@@ -10,7 +11,7 @@ export 'package:code_builder/src/scope.dart';
 
 /// Returns a string [Literal] from [value].
 Identifier stringIdentifier(String value) =>
-    new SimpleIdentifier(stringToken(value));
+    astFactory.simpleIdentifier(stringToken(value));
 
 /// Lazily builds an analyzer [AstNode] when [buildAst] is invoked.
 ///

--- a/lib/src/builders/statement.dart
+++ b/lib/src/builders/statement.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:analyzer/analyzer.dart';
+import 'package:analyzer/dart/ast/standard_ast_factory.dart';
 import 'package:code_builder/src/builders/method.dart';
 import 'package:code_builder/src/builders/shared.dart';
 import 'package:code_builder/src/builders/statement/if.dart';
@@ -36,7 +37,7 @@ abstract class HasStatementsMixin implements HasStatements {
 
   /// Returns a [Block] statement.
   Block buildBlock([Scope scope]) {
-    return new Block(
+    return astFactory.block(
       $openCurly,
       buildStatements(scope),
       $closeCurly,
@@ -92,7 +93,7 @@ class _ReturnStatementBuilder extends Object implements StatementBuilder {
 
   @override
   Statement buildStatement([_]) {
-    return new ReturnStatement($return, null, $semicolon);
+    return astFactory.returnStatement($return, null, $semicolon);
   }
 
   @override

--- a/lib/src/builders/statement/block.dart
+++ b/lib/src/builders/statement/block.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:analyzer/analyzer.dart';
+import 'package:analyzer/dart/ast/standard_ast_factory.dart';
 import 'package:code_builder/src/builders/shared.dart';
 import 'package:code_builder/src/builders/statement.dart';
 import 'package:code_builder/src/tokens.dart';
@@ -22,7 +23,7 @@ class _BlockStatementBuilder extends Object
 
   @override
   Statement buildStatement([Scope scope]) {
-    return new Block(
+    return astFactory.block(
       $openCurly,
       buildStatements(scope),
       $closeCurly,

--- a/lib/src/builders/statement/if.dart
+++ b/lib/src/builders/statement/if.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/standard_ast_factory.dart';
 import 'package:code_builder/src/builders/expression.dart';
 import 'package:code_builder/src/builders/shared.dart';
 import 'package:code_builder/src/builders/statement.dart';
@@ -72,7 +73,7 @@ class _BlockIfStatementBuilder extends Object
 
   @override
   Statement buildStatement([Scope scope]) {
-    return new IfStatement(
+    return astFactory.ifStatement(
       $if,
       $openParen,
       _condition.buildExpression(scope),

--- a/lib/src/builders/type.dart
+++ b/lib/src/builders/type.dart
@@ -6,6 +6,7 @@ library code_builder.src.builders.type;
 
 import 'package:analyzer/analyzer.dart';
 import 'package:analyzer/dart/ast/token.dart';
+import 'package:analyzer/dart/ast/standard_ast_factory.dart';
 import 'package:analyzer/src/dart/ast/token.dart';
 import 'package:code_builder/src/builders/annotation.dart';
 import 'package:code_builder/src/builders/expression.dart';
@@ -107,7 +108,7 @@ class TypeBuilder extends Object
 
   /// Returns an [TypeName] AST representing the builder.
   TypeName buildType([Scope scope]) {
-    return new TypeName(
+    return astFactory.typeName(
       identifier(
         scope,
         _name,
@@ -115,7 +116,7 @@ class TypeBuilder extends Object
       ),
       _generics.isEmpty
           ? null
-          : new TypeArgumentList(
+          : astFactory.typeArgumentList(
               $openBracket,
               _generics.map((t) => t.buildType(scope)).toList(),
               $closeBracket,

--- a/lib/src/builders/type/new_instance.dart
+++ b/lib/src/builders/type/new_instance.dart
@@ -33,7 +33,7 @@ class _NewInvocationBuilderImpl extends Object
 
   @override
   Annotation buildAnnotation([Scope scope]) {
-    return new Annotation(
+    return astFactory.annotation(
       $at,
       _type.buildType(scope).name,
       $period,
@@ -44,9 +44,9 @@ class _NewInvocationBuilderImpl extends Object
 
   @override
   Expression buildExpression([Scope scope]) {
-    return new InstanceCreationExpression(
+    return astFactory.instanceCreationExpression(
       new KeywordToken(_keyword, 0),
-      new ConstructorName(
+      astFactory.constructorName(
         _type.buildType(scope),
         _name != null ? $period : null,
         _name != null ? stringIdentifier(_name) : null,

--- a/lib/src/scope.dart
+++ b/lib/src/scope.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:analyzer/analyzer.dart';
+import 'package:analyzer/dart/ast/standard_ast_factory.dart';
 
 import 'builders/file.dart';
 import 'tokens.dart';
@@ -82,7 +83,7 @@ class _IdentityScope implements Scope {
 
   @override
   Identifier identifier(String name, [_]) {
-    return new SimpleIdentifier(stringToken(name));
+    return astFactory.simpleIdentifier(stringToken(name));
   }
 
   @override
@@ -100,7 +101,7 @@ class _IncrementingScope extends _IdentityScope {
       return super.identifier(name);
     }
     var newId = _imports.putIfAbsent(importFrom, () => _counter++);
-    return new PrefixedIdentifier(
+    return astFactory.prefixedIdentifier(
       super.identifier('_i$newId'),
       $period,
       super.identifier(name),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: '>=1.9.1 <2.0.0'
 
 dependencies:
-  analyzer: '>=0.28.1 <0.30.0'
+  analyzer: '>=0.29.1 <0.30.0'
   dart_style: ^0.2.10
   matcher: ^0.12.0+2
   meta: ^1.0.2


### PR DESCRIPTION
The old mechanism for creating analyzer ASTs (factory constructors on
the interface classes) will be going away in analyzer 0.30.