### PR TITLE
Fix inconsistency in scope.dart

### DIFF
--- a/lib/src/scope.dart
+++ b/lib/src/scope.dart
@@ -56,7 +56,7 @@ abstract class Scope {
   factory Scope.dedupe() => new _DeduplicatingScope();
 
   /// Given a [name] and and import path, returns an [Identifier].
-  Identifier identifier(String name, String importFrom);
+  Identifier identifier(String name, [String importFrom]);
 
   /// Return a list of import statements.
   List<ImportBuilder> toImports();


### PR DESCRIPTION
Change Scope.identifier() to make importFrom an optional parameter.

All subclasses of Scope.identifier already do this, so it is inconsistent for the actual interface to not..