### PR TITLE
rename MethodModifier constant names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.0-beta+2
+
+- BREAKING CHANGE: `MethodModifier.async`, `MethodModifier.asyncStar` and
+  `MethodModifier.syncStar` are now `MethodModifier.asAsync`,
+  `MethodModifier.asAsyncStar` and `MethodModifier.asSyncStar`
+
 ## 1.0.0-beta+1
 
 - Add support for `switch` statements

--- a/lib/src/builders/method.dart
+++ b/lib/src/builders/method.dart
@@ -34,9 +34,10 @@ ConstructorBuilder constructorNamed(
 
 /// Various types of modifiers for methods.
 class MethodModifier implements ValidMethodMember {
-  static const MethodModifier async = const MethodModifier._('async', false);
-  static const MethodModifier asyncStar = const MethodModifier._('async', true);
-  static const MethodModifier syncStar = const MethodModifier._('sync', true);
+  static const MethodModifier asAsync = const MethodModifier._('async', false);
+  static const MethodModifier asAsyncStar =
+      const MethodModifier._('async', true);
+  static const MethodModifier asSyncStar = const MethodModifier._('sync', true);
 
   final String _keyword;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: code_builder
-version: 1.0.0-beta+1
+version: 1.0.0-beta+2
 description: A fluent API for generating Dart code
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/code_builder

--- a/test/builders/method_test.dart
+++ b/test/builders/method_test.dart
@@ -172,7 +172,7 @@ void main() {
 
   test('should emit an async method', () {
     expect(
-      method('fetch', [MethodModifier.async]),
+      method('fetch', [MethodModifier.asAsync]),
       equalsSource(r'''
         fetch() async {}
       '''),
@@ -181,7 +181,7 @@ void main() {
 
   test('should emit an async* method', () {
     expect(
-      method('fetch', [MethodModifier.asyncStar]),
+      method('fetch', [MethodModifier.asAsyncStar]),
       equalsSource(r'''
         fetch() async* {}
       '''),
@@ -190,7 +190,7 @@ void main() {
 
   test('should emit an sync* method', () {
     expect(
-      method('fetch', [MethodModifier.syncStar]),
+      method('fetch', [MethodModifier.asSyncStar]),
       equalsSource(r'''
         fetch() sync* {}
       '''),


### PR DESCRIPTION
`async` identifier name is forbidden within `async` context. For example, the following is illegal Dart code:

```dart
test('illegal', () async {
  MethodModifier.async;
});
```