### PR TITLE
Allow quotes and newlines in string literal

### DIFF
--- a/lib/src/builders/expression.dart
+++ b/lib/src/builders/expression.dart
@@ -84,13 +84,23 @@ Literal _literal(value) {
   } else if (value is bool) {
     return value ? _true : _false;
   } else if (value is String) {
-    return astFactory.simpleStringLiteral(stringToken("'$value'"), value);
+    return astFactory.simpleStringLiteral(stringToken(_quote(value)), value);
   } else if (value is int) {
     return astFactory.integerLiteral(stringToken('$value'), value);
   } else if (value is double) {
     return astFactory.doubleLiteral(stringToken('$value'), value);
   }
   throw new ArgumentError.value(value, 'Unsupported');
+}
+
+/// Quotes the string literal. It is assumed that the [value] is meant to be
+/// the raw string, so all `\` are escaped.
+String _quote(String value) {
+  value = value.replaceAll(r'\', r'\\').replaceAll(r"'", r"\'");
+  if (value.contains('\n')) {
+    return "'''$value'''";
+  }
+  return "'$value'";
 }
 
 /// Implements much of [ExpressionBuilder].

--- a/test/builders/expression_test.dart
+++ b/test/builders/expression_test.dart
@@ -29,8 +29,30 @@ void main() {
       expect(literal(5.5), equalsSource(r'5.5'));
     });
 
-    test('should emit a string', () {
-      expect(literal('Hello'), equalsSource(r"'Hello'"));
+    group('should emit a string', () {
+      test('simple', () {
+        expect(literal('Hello'), equalsSource(r"'Hello'"));
+      });
+
+      test("with a '", () {
+        expect(literal("Hello'"), equalsSource(r"'Hello\''"));
+      });
+
+      test(r"with a \'", () {
+        expect(literal(r"Hello\'"), equalsSource(r"'Hello\\\''"));
+      });
+
+      test(r"with a \\'", () {
+        expect(literal(r"Hello\\'"), equalsSource(r"'Hello\\\\\''"));
+      });
+
+      test(r"with a newline", () {
+        expect(literal("Hello\nworld"), equalsSource("'''Hello\nworld'''"));
+      });
+
+      test(r"with a newline and ending with a '", () {
+        expect(literal("Hello\nworld'"), equalsSource("'''Hello\nworld\\''''"));
+      });
     });
 
     test('should emit a list', () {


### PR DESCRIPTION
Allows creating string literals like “hello 'world'” and multiline string literals:

    var s = '''hello
    world''';

This change assumes that users of this package provide string literals like they would provide raw text (`r"text"` in normal Dart). Since we escape `'`, we also escape `\`, and therefore every other magic sequence (including `\n`, `\t` etc.). I think that's a reasonable assumption.