### PR TITLE
Update analyzer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2
+
+* update internals to use newer analyzer API
+
 ## 1.0.1
 
 * Support the latest version of `package:dart_style`.

--- a/lib/src/builders/method.dart
+++ b/lib/src/builders/method.dart
@@ -35,19 +35,19 @@ ConstructorBuilder constructorNamed(
 /// Various types of modifiers for methods.
 class MethodModifier implements ValidMethodMember {
   static const MethodModifier asAsync = const MethodModifier._(
-    'async',
+    Keyword.ASYNC,
     false,
   );
   static const MethodModifier asAsyncStar = const MethodModifier._(
-    'async',
+    Keyword.ASYNC,
     true,
   );
   static const MethodModifier asSyncStar = const MethodModifier._(
-    'sync',
+    Keyword.SYNC,
     true,
   );
 
-  final String _keyword;
+  final Keyword _keyword;
 
   const MethodModifier._(this._keyword, this.isStar);
 
@@ -56,7 +56,7 @@ class MethodModifier implements ValidMethodMember {
 
   final bool isStar;
 
-  Token keyword() => new StringToken(TokenType.KEYWORD, _keyword, 0);
+  Token keyword() => new KeywordToken(_keyword, 0);
 }
 
 /// Short-hand for `new MethodBuilder.getter(...)`.

--- a/lib/src/tokens.dart
+++ b/lib/src/tokens.dart
@@ -15,13 +15,13 @@ final Token $as = new KeywordToken(Keyword.AS, 0);
 final Token $assert = new KeywordToken(Keyword.ASSERT, 0);
 
 /// The `async` token.
-final Token $async = new StringToken(TokenType.KEYWORD, 'async', 0);
+final Token $async = new KeywordToken(Keyword.ASYNC, 0);
 
 /// The `@` token.
 final Token $at = new Token(TokenType.AT, 0);
 
 /// The `await` token.
-final Token $await = new StringToken(TokenType.KEYWORD, 'await', 0);
+final Token $await = new KeywordToken(Keyword.AWAIT, 0);
 
 /// The `break` token.
 final Token $break = new KeywordToken(Keyword.BREAK, 0);
@@ -96,7 +96,7 @@ final Token $switch = new KeywordToken(Keyword.SWITCH, 0);
 final Token $super = new KeywordToken(Keyword.SUPER, 0);
 
 /// The `yield` token.
-final Token $yield = new StringToken(TokenType.KEYWORD, 'yield', 0);
+final Token $yield = new KeywordToken(Keyword.YIELD, 0);
 
 /// The `while` keyword.
 final Token $while = new KeywordToken(Keyword.WHILE, 0);
@@ -110,7 +110,7 @@ final Token $and = new Token(TokenType.AMPERSAND_AMPERSAND, 0);
 final Token $star = $multiply;
 
 /// The `hide` token.
-final Token $hide = new StringToken(TokenType.KEYWORD, 'hide', 0);
+final Token $hide = new KeywordToken(Keyword.HIDE, 0);
 
 /// The `implements` token.
 final Token $implements = new KeywordToken(Keyword.IMPLEMENTS, 0);
@@ -149,7 +149,7 @@ final Token $null = new KeywordToken(Keyword.NULL, 0);
 final Token $nullAwareEquals = new Token(TokenType.QUESTION_QUESTION_EQ, 0);
 
 /// The `of` token.
-final Token $of = new StringToken(TokenType.KEYWORD, 'of', 0);
+final Token $of = new KeywordToken(Keyword.OF, 0);
 
 /// The `||` token.
 final Token $or = new Token(TokenType.BAR_BAR, 0);
@@ -182,7 +182,7 @@ final Token $return = new KeywordToken(Keyword.RETURN, 0);
 final Token $semicolon = new Token(TokenType.SEMICOLON, 0);
 
 /// The `show` token.
-final Token $show = new StringToken(TokenType.KEYWORD, 'show', 0);
+final Token $show = new KeywordToken(Keyword.SHOW, 0);
 
 /// The `static` token.
 final Token $static = new KeywordToken(Keyword.STATIC, 0);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: code_builder
-version: 1.0.1
+version: 1.0.2
 description: A fluent API for generating Dart code
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/code_builder

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: '>=1.22.0 <2.0.0'
 
 dependencies:
-  analyzer: '>=0.29.1 <0.30.0'
+  analyzer: '>=0.29.11 <0.30.0'
   dart_style: '>=0.2.10 <2.0.0'
   func: ^0.1.0
   matcher: ^0.12.0+2

--- a/test/e2e_test.dart
+++ b/test/e2e_test.dart
@@ -88,9 +88,8 @@ void main() {
         ..addMethod(new MethodBuilder(
           'instantiateAndReturnNamedThing',
           returnType: thingRef,
-        )
-          ..addStatement(
-              thingRef.newInstance([], constructor: 'named').asReturn())));
+        )..addStatement(
+            thingRef.newInstance([], constructor: 'named').asReturn())));
     expect(
       lib,
       equalsSource(

--- a/tool/presubmit.sh
+++ b/tool/presubmit.sh
@@ -12,6 +12,8 @@ if [ "$TRAVIS_DART_VERSION" = "stable" ]; then
     exit 1
   fi
   echo "PASSED"
+else
+  echo "SKIPPED"
 fi
 
 # Make sure we pass the analyzer

--- a/tool/presubmit.sh
+++ b/tool/presubmit.sh
@@ -3,14 +3,16 @@
 # Make sure dartfmt is run on everything
 # This assumes you have dart_style as a dev_dependency
 echo "Checking dartfmt..."
-NEEDS_DARTFMT="$(find lib test -name "*.dart" | xargs dartfmt -n)"
-if [[ ${NEEDS_DARTFMT} != "" ]]
-then
-  echo "FAILED"
-  echo "${NEEDS_DARTFMT}"
-  exit 1
+if [ "$TRAVIS_DART_VERSION" = "stable" ]; then
+  NEEDS_DARTFMT="$(find lib test -name "*.dart" | xargs dartfmt -n)"
+  if [[ ${NEEDS_DARTFMT} != "" ]]
+  then
+    echo "FAILED"
+    echo "${NEEDS_DARTFMT}"
+    exit 1
+  fi
+  echo "PASSED"
 fi
-echo "PASSED"
 
 # Make sure we pass the analyzer
 echo "Checking dartanalyzer..."


### PR DESCRIPTION
This change updates the internals to use the newer analyzer API so that code_builder can be used with both analyzer 0.29.11 and 0.30.
