### PR TITLE
Use Reference instead of TypeReference.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ cache:
   directories:
     - $HOME/.pub-cache
 
+# TODO: Use chrome in --headless mode once supported by pub run test.
+dist: trusty
+addons:
+  chrome: stable
+
 branches:
   only: [master, v2]
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ branches:
 
 # Check for analysis issues, run the test cases, and ensure `dartfmt` is run.
 dart_task:
-  - test: --platform vm,chrome
+  - test: --platform vm
   - dartanalyzer
   - dartfmt
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ branches:
 
 # Check for analysis issues, run the test cases, and ensure `dartfmt` is run.
 dart_task:
-  - test: --platform vm
+  - test: --platform vm,chrome
   - dartanalyzer
   - dartfmt
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## 2.0.0-alpha+1
+
+* Removed `Reference.localScope`. Just use `Reference(symbol)` now.
+* Allow `Reference` instead of an explicit `TypeReference` in most APIs.
+  * `toType()` is performed for you as part the emitter process
+
+```dart
+final animal = new Class((b) => b
+  ..name = 'Animal'
+  // Used to need a suffix of .toType().
+  ..extend = const Reference('Organism')
+  ..methods.add(new Method.returnsVoid((b) => b
+    ..name = 'eat'
+    ..lambda = true
+    ..body = new Code((b) => b..code = 'print(\'Yum\')'))));
+```
+
+* We now support the Dart 2.0 pre-release SDKs (`<2.0.0-dev.infinity`)
+
 ## 2.0.0-alpha
 
 * Complete re-write to not use `package:analyzer`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ final animal = new Class((b) => b
 ```
 
 * We now support the Dart 2.0 pre-release SDKs (`<2.0.0-dev.infinity`)
+* Removed the ability to treat `Class` as a `TypeReference`.
+  * Was required for compilation to `dart2js`, which is now tested on travis.
 
 ## 2.0.0-alpha
 

--- a/README.md
+++ b/README.md
@@ -63,11 +63,11 @@ void main() {
         new Method((b) => b
           ..body = new Code((b) => b.code = '')
           ..name = 'doThing'
-          ..returns = const Reference('Thing', 'package:a/a.dart').toType()),
+          ..returns = const Reference('Thing', 'package:a/a.dart')),
         new Method((b) => b
           ..body = new Code((b) => b..code = '')
           ..name = 'doOther'
-          ..returns = const Reference('Other', 'package:b/b.dart').toType()),
+          ..returns = const Reference('Other', 'package:b/b.dart')),
       ]));
   final emitter = new DartEmitter(new Allocator.simplePrefixing());
   print(new DartFormatter().format('${library.accept(emitter)}'));

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ import 'package:dart_style/dart_style.dart';
 void main() {
   final animal = new Class((b) => b
     ..name = 'Animal'
-    ..extend = const Reference.localScope('Organism').toType()
+    ..extend = const Reference('Organism').toType()
     ..methods.add(new Method.returnsVoid((b) => b
       ..name = 'eat'
       ..lambda = true

--- a/example/animal.dart
+++ b/example/animal.dart
@@ -8,7 +8,7 @@ import 'package:dart_style/dart_style.dart';
 void main() {
   final animal = new Class((b) => b
     ..name = 'Animal'
-    ..extend = const Reference.localScope('Organism').toType()
+    ..extend = const Reference('Organism')
     ..methods.add(new Method.returnsVoid((b) => b
       ..name = 'eat'
       ..lambda = true

--- a/example/scope.dart
+++ b/example/scope.dart
@@ -10,11 +10,11 @@ void main() {
         new Method((b) => b
           ..body = new Code((b) => b.code = '')
           ..name = 'doThing'
-          ..returns = const Reference('Thing', 'package:a/a.dart').toType()),
+          ..returns = const Reference('Thing', 'package:a/a.dart')),
         new Method((b) => b
           ..body = new Code((b) => b..code = '')
           ..name = 'doOther'
-          ..returns = const Reference('Other', 'package:b/b.dart').toType()),
+          ..returns = const Reference('Other', 'package:b/b.dart')),
       ]));
   final emitter = new DartEmitter(new Allocator.simplePrefixing());
   print(new DartFormatter().format('${library.accept(emitter)}'));

--- a/lib/src/emitter.dart
+++ b/lib/src/emitter.dart
@@ -44,20 +44,22 @@ class DartEmitter implements SpecVisitor<StringSink> {
       output.write('abstract ');
     }
     output.write('class ${spec.name}');
-    visitTypeParameters(spec.types, output);
+    visitTypeParameters(spec.types.map((r) => r.toType()), output);
     if (spec.extend != null) {
       output.write(' extends ');
-      visitType(spec.extend, output);
+      visitType(spec.extend.toType(), output);
     }
     if (spec.mixins.isNotEmpty) {
       output
         ..write(' with ')
-        ..writeAll(spec.mixins.map<StringSink>(visitType), ',');
+        ..writeAll(
+            spec.mixins.map<StringSink>((m) => visitType(m.toType())), ',');
     }
     if (spec.implements.isNotEmpty) {
       output
         ..write(' implements ')
-        ..writeAll(spec.implements.map<StringSink>(visitType), ',');
+        ..writeAll(
+            spec.implements.map<StringSink>((m) => visitType(m.toType())), ',');
     }
     output.write(' {');
     spec.constructors.forEach((c) => visitConstructor(c, spec.name, output));
@@ -204,7 +206,7 @@ class DartEmitter implements SpecVisitor<StringSink> {
         break;
     }
     if (spec.type != null) {
-      visitType(spec.type, output);
+      visitType(spec.type.toType(), output);
       output.write(' ');
     }
     output.write(spec.name);
@@ -247,7 +249,7 @@ class DartEmitter implements SpecVisitor<StringSink> {
       output.write('static ');
     }
     if (spec.returns != null) {
-      visitType(spec.returns, output);
+      visitType(spec.returns.toType(), output);
       output.write(' ');
     }
     if (spec.type == MethodType.getter) {
@@ -257,7 +259,7 @@ class DartEmitter implements SpecVisitor<StringSink> {
         output.write('set ');
       }
       output.write(spec.name);
-      visitTypeParameters(spec.types, output);
+      visitTypeParameters(spec.types.map((r) => r.toType()), output);
       output.write('(');
       if (spec.requiredParameters.isNotEmpty) {
         var count = 0;
@@ -321,7 +323,7 @@ class DartEmitter implements SpecVisitor<StringSink> {
     spec.docs.forEach(output.writeln);
     spec.annotations.forEach((a) => visitAnnotation(a, output));
     if (spec.type != null) {
-      visitType(spec.type, output);
+      visitType(spec.type.toType(), output);
       output.write(' ');
     }
     if (spec.toThis) {
@@ -352,9 +354,9 @@ class DartEmitter implements SpecVisitor<StringSink> {
     visitReference(spec, output);
     if (spec.bound != null) {
       output.write(' extends ');
-      visitType(spec.bound, output);
+      visitType(spec.bound.toType(), output);
     }
-    visitTypeParameters(spec.types, output);
+    visitTypeParameters(spec.types.map((r) => r.toType()), output);
     return output;
   }
 

--- a/lib/src/mixins/generics.dart
+++ b/lib/src/mixins/generics.dart
@@ -4,14 +4,14 @@
 
 import 'package:built_collection/built_collection.dart';
 
-import '../specs/type_reference.dart';
+import '../specs/reference.dart';
 
 abstract class HasGenerics {
   /// Generic type parameters.
-  BuiltList<TypeReference> get types;
+  BuiltList<Reference> get types;
 }
 
 abstract class HasGenericsBuilder {
   /// Generic type parameters.
-  ListBuilder<TypeReference> types;
+  ListBuilder<Reference> types;
 }

--- a/lib/src/specs/class.dart
+++ b/lib/src/specs/class.dart
@@ -17,6 +17,7 @@ import 'annotation.dart';
 import 'constructor.dart';
 import 'field.dart';
 import 'method.dart';
+import 'reference.dart';
 import 'type_reference.dart';
 
 part 'class.g.dart';
@@ -39,14 +40,14 @@ abstract class Class extends Object
   BuiltList<String> get docs;
 
   @nullable
-  TypeReference get extend;
+  Reference get extend;
 
-  BuiltList<TypeReference> get implements;
+  BuiltList<Reference> get implements;
 
-  BuiltList<TypeReference> get mixins;
+  BuiltList<Reference> get mixins;
 
   @override
-  BuiltList<TypeReference> get types;
+  BuiltList<Reference> get types;
 
   BuiltList<Constructor> get constructors;
   BuiltList<Method> get methods;
@@ -87,13 +88,13 @@ abstract class ClassBuilder extends Object
   @override
   ListBuilder<String> docs = new ListBuilder<String>();
 
-  TypeReference extend;
+  Reference extend;
 
-  ListBuilder<TypeReference> implements = new ListBuilder<TypeReference>();
-  ListBuilder<TypeReference> mixins = new ListBuilder<TypeReference>();
+  ListBuilder<Reference> implements = new ListBuilder<Reference>();
+  ListBuilder<Reference> mixins = new ListBuilder<Reference>();
 
   @override
-  ListBuilder<TypeReference> types = new ListBuilder<TypeReference>();
+  ListBuilder<Reference> types = new ListBuilder<Reference>();
 
   ListBuilder<Constructor> constructors = new ListBuilder<Constructor>();
   ListBuilder<Method> methods = new ListBuilder<Method>();
@@ -103,10 +104,10 @@ abstract class ClassBuilder extends Object
   String name;
 
   @override
-  TypeReference get bound => null;
+  Reference get bound => null;
 
   @override
-  set bound(TypeReference bound) => throw new UnsupportedError('');
+  set bound(Reference bound) => throw new UnsupportedError('');
 
   @override
   String get url => null;

--- a/lib/src/specs/class.dart
+++ b/lib/src/specs/class.dart
@@ -18,14 +18,13 @@ import 'constructor.dart';
 import 'field.dart';
 import 'method.dart';
 import 'reference.dart';
-import 'type_reference.dart';
 
 part 'class.g.dart';
 
 @immutable
 abstract class Class extends Object
     with HasAnnotations, HasDartDocs, HasGenerics
-    implements Built<Class, ClassBuilder>, TypeReference, Spec {
+    implements Built<Class, ClassBuilder>, Spec {
   factory Class([void updates(ClassBuilder b)]) = _$Class;
 
   Class._();
@@ -57,24 +56,12 @@ abstract class Class extends Object
   String get name;
 
   @override
-  TypeReference get bound => null;
-
-  @override
-  String get url => null;
-
-  @override
-  String get symbol => name;
-
-  @override
   R accept<R>(SpecVisitor<R> visitor) => visitor.visitClass(this);
-
-  @override
-  TypeReference toType() => this;
 }
 
 abstract class ClassBuilder extends Object
     with HasAnnotationsBuilder, HasDartDocsBuilder, HasGenericsBuilder
-    implements Builder<Class, ClassBuilder>, TypeReferenceBuilder {
+    implements Builder<Class, ClassBuilder> {
   factory ClassBuilder() = _$ClassBuilder;
 
   ClassBuilder._();
@@ -102,22 +89,4 @@ abstract class ClassBuilder extends Object
 
   /// Name of the class.
   String name;
-
-  @override
-  Reference get bound => null;
-
-  @override
-  set bound(Reference bound) => throw new UnsupportedError('');
-
-  @override
-  String get url => null;
-
-  @override
-  set url(String url) => throw new UnsupportedError('');
-
-  @override
-  set symbol(String symbol) => name = symbol;
-
-  @override
-  String get symbol => name;
 }

--- a/lib/src/specs/class.g.dart
+++ b/lib/src/specs/class.g.dart
@@ -15,13 +15,13 @@ class _$Class extends Class {
   @override
   final BuiltList<String> docs;
   @override
-  final TypeReference extend;
+  final Reference extend;
   @override
-  final BuiltList<TypeReference> implements;
+  final BuiltList<Reference> implements;
   @override
-  final BuiltList<TypeReference> mixins;
+  final BuiltList<Reference> mixins;
   @override
-  final BuiltList<TypeReference> types;
+  final BuiltList<Reference> types;
   @override
   final BuiltList<Constructor> constructors;
   @override
@@ -165,49 +165,49 @@ class _$ClassBuilder extends ClassBuilder {
   }
 
   @override
-  TypeReference get extend {
+  Reference get extend {
     _$this;
     return super.extend;
   }
 
   @override
-  set extend(TypeReference extend) {
+  set extend(Reference extend) {
     _$this;
     super.extend = extend;
   }
 
   @override
-  ListBuilder<TypeReference> get implements {
+  ListBuilder<Reference> get implements {
     _$this;
-    return super.implements ??= new ListBuilder<TypeReference>();
+    return super.implements ??= new ListBuilder<Reference>();
   }
 
   @override
-  set implements(ListBuilder<TypeReference> implements) {
+  set implements(ListBuilder<Reference> implements) {
     _$this;
     super.implements = implements;
   }
 
   @override
-  ListBuilder<TypeReference> get mixins {
+  ListBuilder<Reference> get mixins {
     _$this;
-    return super.mixins ??= new ListBuilder<TypeReference>();
+    return super.mixins ??= new ListBuilder<Reference>();
   }
 
   @override
-  set mixins(ListBuilder<TypeReference> mixins) {
+  set mixins(ListBuilder<Reference> mixins) {
     _$this;
     super.mixins = mixins;
   }
 
   @override
-  ListBuilder<TypeReference> get types {
+  ListBuilder<Reference> get types {
     _$this;
-    return super.types ??= new ListBuilder<TypeReference>();
+    return super.types ??= new ListBuilder<Reference>();
   }
 
   @override
-  set types(ListBuilder<TypeReference> types) {
+  set types(ListBuilder<Reference> types) {
     _$this;
     super.types = types;
   }

--- a/lib/src/specs/field.dart
+++ b/lib/src/specs/field.dart
@@ -46,7 +46,7 @@ abstract class Field extends Object
   String get name;
 
   @nullable
-  TypeReference get type;
+  Reference get type;
 
   FieldModifier get modifier;
 
@@ -93,7 +93,7 @@ abstract class FieldBuilder extends Object
   /// Name of the field.
   String name;
 
-  TypeReference type;
+  Reference type;
 
   FieldModifier modifier = FieldModifier.var$;
 }

--- a/lib/src/specs/field.g.dart
+++ b/lib/src/specs/field.g.dart
@@ -19,7 +19,7 @@ class _$Field extends Field {
   @override
   final String name;
   @override
-  final TypeReference type;
+  final Reference type;
   @override
   final FieldModifier modifier;
 
@@ -154,13 +154,13 @@ class _$FieldBuilder extends FieldBuilder {
   }
 
   @override
-  TypeReference get type {
+  Reference get type {
     _$this;
     return super.type;
   }
 
   @override
-  set type(TypeReference type) {
+  set type(Reference type) {
     _$this;
     super.type = type;
   }

--- a/lib/src/specs/method.dart
+++ b/lib/src/specs/method.dart
@@ -20,7 +20,7 @@ import 'type_reference.dart';
 
 part 'method.g.dart';
 
-final TypeReference _$void = const Reference.localScope('void').toType();
+final Reference _$void = const Reference('void');
 
 @immutable
 abstract class Method extends Object
@@ -46,7 +46,7 @@ abstract class Method extends Object
   BuiltList<String> get docs;
 
   @override
-  BuiltList<TypeReference> get types;
+  BuiltList<Reference> get types;
 
   /// Optional parameters.
   BuiltList<Parameter> get optionalParameters;
@@ -77,7 +77,7 @@ abstract class Method extends Object
   MethodType get type;
 
   @nullable
-  TypeReference get returns;
+  Reference get returns;
 
   @override
   String get symbol => name;
@@ -106,7 +106,7 @@ abstract class MethodBuilder extends Object
   ListBuilder<String> docs = new ListBuilder<String>();
 
   @override
-  ListBuilder<TypeReference> types = new ListBuilder<TypeReference>();
+  ListBuilder<Reference> types = new ListBuilder<Reference>();
 
   /// Optional parameters.
   ListBuilder<Parameter> optionalParameters = new ListBuilder<Parameter>();
@@ -134,7 +134,7 @@ abstract class MethodBuilder extends Object
   /// Whether this is a getter or setter.
   MethodType type;
 
-  TypeReference returns;
+  Reference returns;
 }
 
 enum MethodType {
@@ -171,11 +171,11 @@ abstract class Parameter extends Object
   BuiltList<String> get docs;
 
   @override
-  BuiltList<TypeReference> get types;
+  BuiltList<Reference> get types;
 
   /// Type of the parameter;
   @nullable
-  TypeReference get type;
+  Reference get type;
 }
 
 abstract class ParameterBuilder extends Object
@@ -206,8 +206,8 @@ abstract class ParameterBuilder extends Object
   ListBuilder<String> docs = new ListBuilder<String>();
 
   @override
-  ListBuilder<TypeReference> types = new ListBuilder<TypeReference>();
+  ListBuilder<Reference> types = new ListBuilder<Reference>();
 
   /// Type of the parameter;
-  TypeReference type;
+  Reference type;
 }

--- a/lib/src/specs/method.g.dart
+++ b/lib/src/specs/method.g.dart
@@ -13,7 +13,7 @@ class _$Method extends Method {
   @override
   final BuiltList<String> docs;
   @override
-  final BuiltList<TypeReference> types;
+  final BuiltList<Reference> types;
   @override
   final BuiltList<Parameter> optionalParameters;
   @override
@@ -31,7 +31,7 @@ class _$Method extends Method {
   @override
   final MethodType type;
   @override
-  final TypeReference returns;
+  final Reference returns;
 
   factory _$Method([void updates(MethodBuilder b)]) =>
       (new MethodBuilder()..update(updates)).build() as _$Method;
@@ -161,13 +161,13 @@ class _$MethodBuilder extends MethodBuilder {
   }
 
   @override
-  ListBuilder<TypeReference> get types {
+  ListBuilder<Reference> get types {
     _$this;
-    return super.types ??= new ListBuilder<TypeReference>();
+    return super.types ??= new ListBuilder<Reference>();
   }
 
   @override
-  set types(ListBuilder<TypeReference> types) {
+  set types(ListBuilder<Reference> types) {
     _$this;
     super.types = types;
   }
@@ -269,13 +269,13 @@ class _$MethodBuilder extends MethodBuilder {
   }
 
   @override
-  TypeReference get returns {
+  Reference get returns {
     _$this;
     return super.returns;
   }
 
   @override
-  set returns(TypeReference returns) {
+  set returns(Reference returns) {
     _$this;
     super.returns = returns;
   }
@@ -352,9 +352,9 @@ class _$Parameter extends Parameter {
   @override
   final BuiltList<String> docs;
   @override
-  final BuiltList<TypeReference> types;
+  final BuiltList<Reference> types;
   @override
-  final TypeReference type;
+  final Reference type;
 
   factory _$Parameter([void updates(ParameterBuilder b)]) =>
       (new ParameterBuilder()..update(updates)).build() as _$Parameter;
@@ -505,25 +505,25 @@ class _$ParameterBuilder extends ParameterBuilder {
   }
 
   @override
-  ListBuilder<TypeReference> get types {
+  ListBuilder<Reference> get types {
     _$this;
-    return super.types ??= new ListBuilder<TypeReference>();
+    return super.types ??= new ListBuilder<Reference>();
   }
 
   @override
-  set types(ListBuilder<TypeReference> types) {
+  set types(ListBuilder<Reference> types) {
     _$this;
     super.types = types;
   }
 
   @override
-  TypeReference get type {
+  Reference get type {
     _$this;
     return super.type;
   }
 
   @override
-  set type(TypeReference type) {
+  set type(Reference type) {
     _$this;
     super.type = type;
   }

--- a/lib/src/specs/reference.dart
+++ b/lib/src/specs/reference.dart
@@ -26,10 +26,7 @@ class Reference implements Spec {
   final String symbol;
 
   /// Create a reference to [symbol] in [url].
-  const Reference(this.symbol, this.url);
-
-  /// Create a reference to [symbol] in the same library (no import statement).
-  const Reference.localScope(this.symbol) : url = null;
+  const Reference(this.symbol, [this.url]);
 
   @override
   R accept<R>(SpecVisitor<R> visitor) => visitor.visitReference(this);

--- a/lib/src/specs/type_reference.dart
+++ b/lib/src/specs/type_reference.dart
@@ -34,10 +34,10 @@ abstract class TypeReference extends Object
 
   /// Optional bound generic.
   @nullable
-  TypeReference get bound;
+  Reference get bound;
 
   @override
-  BuiltList<TypeReference> get types;
+  BuiltList<Reference> get types;
 
   @override
   R accept<R>(SpecVisitor<R> visitor) => visitor.visitType(this);
@@ -58,8 +58,8 @@ abstract class TypeReferenceBuilder extends Object
   String url;
 
   /// Optional bound generic.
-  TypeReference bound;
+  Reference bound;
 
   @override
-  ListBuilder<TypeReference> types = new ListBuilder<TypeReference>();
+  ListBuilder<Reference> types = new ListBuilder<Reference>();
 }

--- a/lib/src/specs/type_reference.g.dart
+++ b/lib/src/specs/type_reference.g.dart
@@ -13,9 +13,9 @@ class _$TypeReference extends TypeReference {
   @override
   final String url;
   @override
-  final TypeReference bound;
+  final Reference bound;
   @override
-  final BuiltList<TypeReference> types;
+  final BuiltList<Reference> types;
 
   factory _$TypeReference([void updates(TypeReferenceBuilder b)]) =>
       (new TypeReferenceBuilder()..update(updates)).build() as _$TypeReference;
@@ -90,25 +90,25 @@ class _$TypeReferenceBuilder extends TypeReferenceBuilder {
   }
 
   @override
-  TypeReference get bound {
+  Reference get bound {
     _$this;
     return super.bound;
   }
 
   @override
-  set bound(TypeReference bound) {
+  set bound(Reference bound) {
     _$this;
     super.bound = bound;
   }
 
   @override
-  ListBuilder<TypeReference> get types {
+  ListBuilder<Reference> get types {
     _$this;
-    return super.types ??= new ListBuilder<TypeReference>();
+    return super.types ??= new ListBuilder<Reference>();
   }
 
   @override
-  set types(ListBuilder<TypeReference> types) {
+  set types(ListBuilder<Reference> types) {
     _$this;
     super.types = types;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,3 +19,7 @@ dev_dependencies:
   built_value_generator: '>=1.0.0 <=1.1.4'
   source_gen: '>=0.5.0 <0.7.0'
   test: ^0.12.0
+
+transformers:
+  - test/pub_serve:
+      $include: test/**_test.dart

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,20 +1,21 @@
 name: code_builder
-version: 2.0.0-alpha
+version: 2.0.0-alpha+1
 description: A fluent API for generating Dart code
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/code_builder
 
 environment:
-  sdk: '>=1.22.0 <2.0.0'
+  sdk: '>=1.22.0 <2.0.0-dev.infinity'
 
 dependencies:
   built_collection: ^1.0.0
   built_value: ^1.0.0
+  dart_style: ^1.0.0
   matcher: ^0.12.0
   meta: ^1.0.5
 
 dev_dependencies:
   build_runner: ^0.3.0
   built_value_generator: '>=1.0.0 <=1.1.4'
-  dart_style: ^1.0.0
+  source_gen: '>=0.5.0 <0.7.0'
   test: ^0.12.0

--- a/test/allocator_test.dart
+++ b/test/allocator_test.dart
@@ -18,7 +18,7 @@ void main() {
       allocator = new Allocator()
         ..allocate(const Reference('List', 'dart:core'))
         ..allocate(const Reference('LinkedHashMap', 'dart:collection'))
-        ..allocate(const Reference.localScope('someSymbol'));
+        ..allocate(const Reference('someSymbol'));
       expect(allocator.imports.map((d) => d.url), [
         'dart:core',
         'dart:collection',

--- a/test/e2e/injection_test.dart
+++ b/test/e2e/injection_test.dart
@@ -14,7 +14,7 @@ void main() {
 
     final clazz = new ClassBuilder()
       ..name = 'Injector'
-      ..implements.add($App.toType())
+      ..implements.add($App)
       ..fields.add(new Field((b) => b
         ..modifier = FieldModifier.final$
         ..name = '_module'
@@ -29,7 +29,7 @@ void main() {
           ..code = 'new {{ThingRef}}(_module.get1(), _module.get2())'
           ..specs['ThingRef'] = () => $Thing)
         ..lambda = true
-        ..returns = $Thing.toType()
+        ..returns = $Thing
         ..annotations.add(new Annotation(
             (b) => b..code = new Code((b) => b.code = 'override')))));
 

--- a/test/specs/class_test.dart
+++ b/test/specs/class_test.dart
@@ -45,7 +45,7 @@ void main() {
   });
 
   test('should create a class with annotations', () {
-    final $deprecated = const Reference.localScope('deprecated');
+    final $deprecated = const Reference('deprecated');
     expect(
       new Class(
         (b) => b
@@ -74,7 +74,7 @@ void main() {
     expect(
       new Class((b) => b
         ..name = 'List'
-        ..types.add(const Reference.localScope('T').toType())),
+        ..types.add(const Reference('T'))),
       equalsDart(r'''
         class List<T> {}
       '''),
@@ -87,8 +87,8 @@ void main() {
         (b) => b
           ..name = 'Map'
           ..types.addAll([
-            const Reference.localScope('K').toType(),
-            const Reference.localScope('V').toType(),
+            const Reference('K'),
+            const Reference('V'),
           ]),
       ),
       equalsDart(r'''
@@ -105,7 +105,7 @@ void main() {
           ..symbol = 'T'
           ..bound = new TypeReference((b) => b
             ..symbol = 'Comparable'
-            ..types.add(const Reference.localScope('T').toType()))))),
+            ..types.add(const Reference('T').toType()))))),
       equalsDart(r'''
         class Comparable<T extends Comparable<T>> {}
       '''),
@@ -244,7 +244,7 @@ void main() {
         ..name = 'Foo'
         ..constructors.add(new Constructor((b) => b
           ..factory = true
-          ..redirect = const Reference.localScope('_Foo')))),
+          ..redirect = const Reference('_Foo')))),
       equalsDart(r'''
         class Foo {
           factory Foo() = _Foo;

--- a/test/specs/field_test.dart
+++ b/test/specs/field_test.dart
@@ -19,7 +19,7 @@ void main() {
     expect(
       new Field((b) => b
         ..name = 'foo'
-        ..type = const Reference.localScope('String').toType()),
+        ..type = const Reference('String')),
       equalsDart(r'''
         String foo;
       '''),

--- a/test/specs/method_test.dart
+++ b/test/specs/method_test.dart
@@ -44,7 +44,7 @@ void main() {
     expect(
       new Method((b) => b
         ..name = 'foo'
-        ..returns = const Reference.localScope('String').toType()),
+        ..returns = const Reference('String')),
       equalsDart(r'''
         String foo();
       '''),
@@ -64,7 +64,7 @@ void main() {
     expect(
       new Method((b) => b
         ..name = 'foo'
-        ..types.add(const Reference.localScope('T').toType())),
+        ..types.add(const Reference('T'))),
       equalsDart(r'''
         foo<T>();
       '''),
@@ -182,7 +182,7 @@ void main() {
             new Parameter(
               (b) => b
                 ..name = 'i'
-                ..type = const Reference.localScope('int').toType(),
+                ..type = const Reference('int').toType(),
             ),
           ),
       ),
@@ -199,18 +199,18 @@ void main() {
           ..name = 'foo'
           ..types.add(new TypeReference((b) => b
             ..symbol = 'T'
-            ..bound = const Reference.localScope('Iterable').toType()))
+            ..bound = const Reference('Iterable')))
           ..requiredParameters.addAll([
             new Parameter(
               (b) => b
                 ..name = 't'
-                ..type = const Reference.localScope('T').toType(),
+                ..type = const Reference('T'),
             ),
             new Parameter((b) => b
               ..name = 'x'
               ..type = new TypeReference((b) => b
                 ..symbol = 'X'
-                ..types.add(const Reference.localScope('T').toType()))),
+                ..types.add(const Reference('T')))),
           ]),
       ),
       equalsDart(r'''

--- a/tool/build.dart
+++ b/tool/build.dart
@@ -16,5 +16,6 @@ Future<Null> main() async {
       ]),
       new InputSet('code_builder', const ['lib/src/specs/**.dart']),
     ),
+    deleteFilesByDefault: true,
   );
 }

--- a/tool/watch.dart
+++ b/tool/watch.dart
@@ -16,5 +16,6 @@ Future<Null> main() async {
       ]),
       new InputSet('code_builder', const ['lib/src/specs/**.dart']),
     ),
+    deleteFilesByDefault: true,
   );
 }


### PR DESCRIPTION
This makes the API much cleaner without the implicit behavior hurting users.

## 2.0.0-alpha+1

* Removed `Reference.localScope`. Just use `Reference(symbol)` now.
* Allow `Reference` instead of an explicit `TypeReference` in most APIs.
  * `toType()` is performed for you as part the emitter process

```dart
final animal = new Class((b) => b
  ..name = 'Animal'
  // Used to need a suffix of .toType().
  ..extend = const Reference('Organism')
  ..methods.add(new Method.returnsVoid((b) => b
    ..name = 'eat'
    ..lambda = true
    ..body = new Code((b) => b..code = 'print(\'Yum\')'))));
```

* We now support the Dart 2.0 pre-release SDKs (`<2.0.0-dev.infinity`)

Closes https://github.com/dart-lang/code_builder/issues/120.