### PR TITLE
Escape single quotes in String literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.1.0
 
 * Added support for raw `String` literals.
+* Automatically escapes single quotes in now-raw `String` literals.
 
 ## 2.0.0
 

--- a/lib/src/specs/expression/literal.dart
+++ b/lib/src/specs/expression/literal.dart
@@ -48,9 +48,16 @@ Expression literalNum(num value) => new LiteralExpression._('$value');
 ///
 /// **NOTE**: The string is always formatted `'<value>'`.
 ///
-/// If [raw] is `true`, creates a raw String formatted `r'<value>'`.
-Expression literalString(String value, {bool raw: false}) =>
-    new LiteralExpression._("${raw ? 'r' : ''}'$value'");
+/// If [raw] is `true`, creates a raw String formatted `r'<value>'` and the
+/// value may not contain a single quote.
+/// If [raw] is `false` escapes single quotes in the value.
+Expression literalString(String value, {bool raw: false}) {
+  if (raw && value.contains('\'')) {
+    throw new ArgumentError('Cannot include a single quote in a raw string');
+  }
+  final escaped = value.replaceAll('\'', '\\\'');
+  return new LiteralExpression._("${raw ? 'r' : ''}'$escaped'");
+}
 
 /// Creates a literal list expression from [values].
 LiteralListExpression literalList(List<Object> values, [Reference type]) {

--- a/test/specs/code/expression_test.dart
+++ b/test/specs/code/expression_test.dart
@@ -18,6 +18,14 @@ void main() {
     expect(literalString(r'$monkey', raw: true), equalsDart(r"r'$monkey'"));
   });
 
+  test('should escape single quotes in a String', () {
+    expect(literalString(r"don't"), equalsDart(r"'don\'t'"));
+  });
+
+  test('does not allow single quote in raw string', () {
+    expect(() => literalString(r"don't", raw: true), throwsArgumentError);
+  });
+
   test('should emit a && expression', () {
     expect(literalTrue.and(literalFalse), equalsDart('true && false'));
   });


### PR DESCRIPTION
Closes #155

If there is an unescaped literal in a String the code would otherwise be
invalid.
If some code is doing the escaping before creating the literal this will
end up double-escaping.