### PR TITLE
Add '_i' to import prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.1.1-dev
+
+* Imports are prefixed with `_i1` rather than `_1` which satisfies the lint
+  `lowercase_with_underscores`.
+
 ## 2.1.0
 
 We now require the Dart 2.0-dev branch SDK (`>= 2.0.0-dev`).

--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ void main() {
 
 Outputs:
 ```dart
-import 'package:a/a.dart' as _1;
-import 'package:b/b.dart' as _2;
+import 'package:a/a.dart' as _i1;
+import 'package:b/b.dart' as _i2;
 
-_1.Thing doThing() {}
-_2.Other doOther() {}
+_i1.Thing doThing() {}
+_i2.Other doOther() {}
 ```

--- a/lib/src/allocator.dart
+++ b/lib/src/allocator.dart
@@ -23,6 +23,9 @@ abstract class Allocator {
   /// style and instead takes a conservative approach of prefixing _every_
   /// import except references to `dart:core` (which are considered always
   /// imported).
+  ///
+  /// The prefixes are not guaranteed to be stable and cannot be expected to
+  /// have any particular value.
   factory Allocator.simplePrefixing() = _PrefixedAllocator;
 
   /// Returns a reference string given a [reference] object.

--- a/lib/src/allocator.dart
+++ b/lib/src/allocator.dart
@@ -81,7 +81,7 @@ class _PrefixedAllocator implements Allocator {
     if (reference.url == null || _doNotPrefix.contains(reference.url)) {
       return symbol;
     }
-    return '_${_imports.putIfAbsent(reference.url, _nextKey)}.$symbol';
+    return '_i${_imports.putIfAbsent(reference.url, _nextKey)}.$symbol';
   }
 
   int _nextKey() => _keys++;
@@ -89,7 +89,7 @@ class _PrefixedAllocator implements Allocator {
   @override
   Iterable<Directive> get imports {
     return _imports.keys.map(
-      (u) => new Directive.import(u, as: '_${_imports[u]}'),
+      (u) => new Directive.import(u, as: '_i${_imports[u]}'),
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: code_builder
-version: 2.1.0
+version: 2.1.1-dev
 description: A fluent API for generating Dart code
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/code_builder

--- a/test/allocator_test.dart
+++ b/test/allocator_test.dart
@@ -39,10 +39,10 @@ void main() {
       );
       expect(
         allocator.allocate(refer('LinkedHashMap', 'dart:collection')),
-        '_1.LinkedHashMap',
+        '_i1.LinkedHashMap',
       );
       expect(allocator.imports.map((d) => '${d.url} as ${d.as}'), [
-        'dart:collection as _1',
+        'dart:collection as _i1',
       ]);
     });
   });

--- a/test/e2e/injection_test.dart
+++ b/test/e2e/injection_test.dart
@@ -51,13 +51,13 @@ void main() {
     expect(
       clazz.build(),
       equalsDart(r'''
-        class Injector implements _1.App {
+        class Injector implements _i1.App {
           Injector(this._module);
 
-          final _2.Module _module;
+          final _i2.Module _module;
 
           @override
-          _3.Thing getThing() => new _3.Thing(_module.get1(), _module.get2());
+          _i3.Thing getThing() => new _i3.Thing(_module.get1(), _module.get2());
         }
       ''', new DartEmitter(new Allocator.simplePrefixing())),
     );

--- a/test/specs/code/expression_test.dart
+++ b/test/specs/code/expression_test.dart
@@ -83,7 +83,7 @@ void main() {
   test('should emit a scoped type as an expression', () {
     expect(
       refer('Foo', 'package:foo/foo.dart'),
-      equalsDart('_1.Foo', new DartEmitter(new Allocator.simplePrefixing())),
+      equalsDart('_i1.Foo', new DartEmitter(new Allocator.simplePrefixing())),
     );
   });
 

--- a/test/specs/library_test.dart
+++ b/test/specs/library_test.dart
@@ -101,9 +101,9 @@ void main() {
             ..assignment =
                 new Code.scope((a) => 'new ${a($LinkedHashMap)}()')))),
         equalsDart(r'''
-          import 'dart:collection' as _1;
+          import 'dart:collection' as _i1;
           
-          final test = new _1.LinkedHashMap();
+          final test = new _i1.LinkedHashMap();
         ''', new DartEmitter(new Allocator.simplePrefixing())),
       );
     });


### PR DESCRIPTION
This matches old behavior and is a little more clear than just a digit.
This will also satisfy the lint on the latest SDK. See
https://github.com/dart-lang/linter/issues/684#issuecomment-343543273