### PR TITLE
Accept an Iterable in `literalList`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Imports are prefixed with `_i1` rather than `_1` which satisfies the lint
   `lowercase_with_underscores`.
+* `literalList` accepts an `Iterable` argument.
 
 ## 2.1.0
 

--- a/lib/src/specs/expression/literal.dart
+++ b/lib/src/specs/expression/literal.dart
@@ -60,8 +60,8 @@ Expression literalString(String value, {bool raw: false}) {
 }
 
 /// Creates a literal list expression from [values].
-LiteralListExpression literalList(List<Object> values, [Reference type]) {
-  return new LiteralListExpression._(false, values, type);
+LiteralListExpression literalList(Iterable<Object> values, [Reference type]) {
+  return new LiteralListExpression._(false, values.toList(), type);
 }
 
 /// Creates a literal `const` list expression from [values].


### PR DESCRIPTION
Since the LiteralListExpression is in the public API we shouldn't change
it's field type, so immediately call .toList()