### PR TITLE
Add EqualsDart and EqualsDart.format.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 ## 2.3.0-dev
 
+* Using `equalsDart` and expecting `dartfmt` by default is *deprecated*. This
+  requires this package to have a direct dependency on specific versions of
+  `dart_style` (and transitively `analyzer`), which is problematic just for
+  testing infrastructure. To future proof, we've exposed the `EqualsDart` class
+  with a `format` override:
+
+```dart
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:code_builder/code_builder.dart';
+import 'package:dart_style/dart_style.dart';
+
+final DartFormatter _dartfmt = new DartFormatter();
+String _format(String source) {
+  try {
+    return _dartfmt.format(source);
+  } on FormatException catch (_) {
+    return _dartfmt.formatStatement(source);
+  }
+}
+
+/// Should be invoked in `main()` of every test in `test/**_test.dart`.
+void useDartfmt() => EqualsDart.format = _format;
+```
+
 * Added `Expression.isA` and `Expression.isNotA`:
 
 ```dart

--- a/lib/code_builder.dart
+++ b/lib/code_builder.dart
@@ -5,7 +5,7 @@
 export 'src/allocator.dart' show Allocator;
 export 'src/base.dart' show lazySpec, Spec;
 export 'src/emitter.dart' show DartEmitter;
-export 'src/matchers.dart' show equalsDart;
+export 'src/matchers.dart' show equalsDart, EqualsDart;
 export 'src/specs/annotation.dart' show Annotation, AnnotationBuilder;
 export 'src/specs/class.dart' show Class, ClassBuilder;
 export 'src/specs/code.dart'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ web:
 dependencies:
   built_collection: ^1.0.0
   built_value: '>=2.0.0 <5.0.0'
+  # TODO: Remove in 3.0.0.
   dart_style: ^1.0.0
   matcher: ^0.12.0
   meta: ^1.0.5
@@ -21,6 +22,7 @@ dependencies:
 dev_dependencies:
   build_runner: '>=0.4.0 <0.6.0'
   built_value_generator: '>=2.0.0 <5.0.0'
+  dart_style: ^1.0.0
   source_gen: '^0.7.0'
   test: ^0.12.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ web:
 dependencies:
   built_collection: ^1.0.0
   built_value: '>=2.0.0 <5.0.0'
-  # TODO: Remove in 3.0.0.
+  # TODO: Move to dev_dependency in 3.0.0.
   dart_style: ^1.0.0
   matcher: ^0.12.0
   meta: ^1.0.5
@@ -22,7 +22,6 @@ dependencies:
 dev_dependencies:
   build_runner: '>=0.4.0 <0.6.0'
   built_value_generator: '>=2.0.0 <5.0.0'
-  dart_style: ^1.0.0
   source_gen: '^0.7.0'
   test: ^0.12.0
 

--- a/test/allocator_test.dart
+++ b/test/allocator_test.dart
@@ -5,7 +5,11 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:test/test.dart';
 
+import 'common.dart';
+
 void main() {
+  useDartfmt();
+
   group('Allocator', () {
     Allocator allocator;
 

--- a/test/common.dart
+++ b/test/common.dart
@@ -1,0 +1,18 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:code_builder/code_builder.dart';
+import 'package:dart_style/dart_style.dart';
+
+final DartFormatter _dartfmt = new DartFormatter();
+String _format(String source) {
+  try {
+    return _dartfmt.format(source);
+  } on FormatException catch (_) {
+    return _dartfmt.formatStatement(source);
+  }
+}
+
+/// Should be invoked in `main()` of every test in `test/**_test.dart`.
+void useDartfmt() => EqualsDart.format = _format;

--- a/test/e2e/injection_test.dart
+++ b/test/e2e/injection_test.dart
@@ -5,7 +5,11 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:test/test.dart';
 
+import '../common.dart';
+
 void main() {
+  useDartfmt();
+
   test('should generate a complex generated file', () {
     // Imports from an existing Dart library.
     final $App = refer('App', 'package:app/app.dart');

--- a/test/specs/class_test.dart
+++ b/test/specs/class_test.dart
@@ -5,7 +5,11 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:test/test.dart';
 
+import '../common.dart';
+
 void main() {
+  useDartfmt();
+
   test('should create a class', () {
     expect(
       new Class((b) => b..name = 'Foo'),

--- a/test/specs/code/expression_test.dart
+++ b/test/specs/code/expression_test.dart
@@ -5,7 +5,11 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:test/test.dart';
 
+import '../../common.dart';
+
 void main() {
+  useDartfmt();
+
   test('should emit a simple expression', () {
     expect(literalNull, equalsDart('null'));
   });

--- a/test/specs/code/statement_test.dart
+++ b/test/specs/code/statement_test.dart
@@ -5,7 +5,11 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:test/test.dart';
 
+import '../../common.dart';
+
 void main() {
+  useDartfmt();
+
   test('should emit a block of code', () {
     expect(
       new Block.of([

--- a/test/specs/field_test.dart
+++ b/test/specs/field_test.dart
@@ -5,7 +5,11 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:test/test.dart';
 
+import '../common.dart';
+
 void main() {
+  useDartfmt();
+
   test('should create a field', () {
     expect(
       new Field((b) => b..name = 'foo'),

--- a/test/specs/library_test.dart
+++ b/test/specs/library_test.dart
@@ -5,7 +5,11 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:test/test.dart';
 
+import '../common.dart';
+
 void main() {
+  useDartfmt();
+
   group('File', () {
     final $LinkedHashMap = refer('LinkedHashMap', 'dart:collection');
 

--- a/test/specs/method_test.dart
+++ b/test/specs/method_test.dart
@@ -5,7 +5,11 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:test/test.dart';
 
+import '../common.dart';
+
 void main() {
+  useDartfmt();
+
   test('should create a method', () {
     expect(
       new Method((b) => b..name = 'foo'),


### PR DESCRIPTION
The rationale here is to remove a dependency on `dart_style` and `analyzer` in `3.0.0`.

In reality it is only depended on for `equalsDart`, which is only for testing. If in the future we get modular packages or sub packages then it might be worth bringing back in some form, but this likely is to give more flexibility, especially around packages like `analyzer` that are almost impossible to revision against.

I've made the changes to make the tests in _this_ package future-proof.