### PR TITLE
Deprecate the Annotation class.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,29 @@ void main() {
 }
 ```
 
+* Deprecated `Annotation`. It is now legal to simply pass any `Expression` as
+  a metadata annotation to `Class`, `Method`, `Field,` and `Parameter`. In
+  `3.0.0`, the `Annotation` class will be completely removed:
+
+```dart
+void main() {
+  test('should create a class with a annotated constructor', () {
+    expect(
+      new Class((b) => b
+        ..name = 'Foo'
+        ..constructors.add(
+          new Constructor((b) => b..annotations.add(refer('deprecated'))))),
+      equalsDart(r'''
+        class Foo {
+          @deprecated
+          Foo();
+        }
+      '''),
+    );
+  });
+}
+```
+
 ## 2.2.0
 
 * Imports are prefixed with `_i1` rather than `_1` which satisfies the lint

--- a/lib/code_builder.dart
+++ b/lib/code_builder.dart
@@ -6,6 +6,7 @@ export 'src/allocator.dart' show Allocator;
 export 'src/base.dart' show lazySpec, Spec;
 export 'src/emitter.dart' show DartEmitter;
 export 'src/matchers.dart' show equalsDart;
+// ignore: deprecated_member_use
 export 'src/specs/annotation.dart' show Annotation, AnnotationBuilder;
 export 'src/specs/class.dart' show Class, ClassBuilder;
 export 'src/specs/code.dart'

--- a/lib/src/emitter.dart
+++ b/lib/src/emitter.dart
@@ -65,9 +65,13 @@ class DartEmitter extends Object
   }
 
   @override
-  visitAnnotation(Annotation spec, [StringSink output]) {
+  visitAnnotation(Expression spec, [StringSink output]) {
     (output ??= new StringBuffer()).write('@');
-    spec.code.accept(this, output);
+    if (spec is Annotation) {
+      spec.code.accept(this, output);
+    } else {
+      spec.accept(this, output);
+    }
     output.write(' ');
     return output;
   }
@@ -334,9 +338,7 @@ class DartEmitter extends Object
   visitMethod(Method spec, [StringSink output]) {
     output ??= new StringBuffer();
     spec.docs.forEach(output.writeln);
-    for (final annotation in spec.annotations) {
-      annotation.accept(this, output);
-    }
+    spec.annotations.forEach((a) => visitAnnotation(a, output));
     if (spec.external) {
       output.write('external ');
     }
@@ -429,9 +431,7 @@ class DartEmitter extends Object
     bool named: false,
   }) {
     spec.docs.forEach(output.writeln);
-    for (final annotation in spec.annotations) {
-      annotation.accept(this, output);
-    }
+    spec.annotations.forEach((a) => visitAnnotation(a, output));
     if (spec.type != null) {
       spec.type.type.accept(this, output);
       output.write(' ');

--- a/lib/src/mixins/annotations.dart
+++ b/lib/src/mixins/annotations.dart
@@ -4,12 +4,16 @@
 
 import 'package:built_collection/built_collection.dart';
 
-import '../specs/annotation.dart';
+import '../specs/expression.dart';
 
+/// A type of AST node that can have metadata [annotations].
 abstract class HasAnnotations {
-  BuiltList<Annotation> get annotations;
+  /// Annotations as metadata on the node.
+  BuiltList<Expression> get annotations;
 }
 
+/// Compliment to the [HasAnnotations] mixin for metadata [annotations].
 abstract class HasAnnotationsBuilder {
-  ListBuilder<Annotation> annotations;
+  /// Annotations as metadata on the node.
+  ListBuilder<Expression> annotations;
 }

--- a/lib/src/specs/annotation.dart
+++ b/lib/src/specs/annotation.dart
@@ -31,6 +31,7 @@ abstract class Annotation extends Expression
   /// This property exists in order to keep compatibility with having a concrete
   /// [Annotation] class, but also allow migrating to using [Expression] instead
   /// to add annotations.
+  @protected
   Code get codeForAnnotation;
 
   @override
@@ -50,5 +51,6 @@ abstract class AnnotationBuilder
   Code get code => codeForAnnotation;
   set code(Code code) => codeForAnnotation = code;
 
+  @protected
   Code codeForAnnotation;
 }

--- a/lib/src/specs/annotation.dart
+++ b/lib/src/specs/annotation.dart
@@ -10,29 +10,45 @@ import 'package:meta/meta.dart';
 import '../base.dart';
 import '../visitors.dart';
 import 'code.dart';
+import 'expression.dart';
 
 part 'annotation.g.dart';
 
+@Deprecated('Use an Expression node instead. Will be removed in 3.0.0.')
 @immutable
-abstract class Annotation
+abstract class Annotation extends Expression
     implements Built<Annotation, AnnotationBuilder>, Spec {
   factory Annotation([void updates(AnnotationBuilder b)]) = _$Annotation;
 
   Annotation._();
 
   /// Part after the `@` in annotation.
-  Code get code;
+  @override
+  Code get code => codeForAnnotation;
+
+  /// Use [code] instead.
+  ///
+  /// This property exists in order to keep compatibility with having a concrete
+  /// [Annotation] class, but also allow migrating to using [Expression] instead
+  /// to add annotations.
+  Code get codeForAnnotation;
 
   @override
-  R accept<R>(SpecVisitor<R> visitor, [R context]) =>
-      visitor.visitAnnotation(this, context);
+  R accept<R>(SpecVisitor<R> visitor, [R context]) {
+    return visitor.visitAnnotation(this, context);
+  }
 }
 
 abstract class AnnotationBuilder
-    implements Builder<Annotation, AnnotationBuilder> {
+    // ignore: deprecated_member_use
+    implements
+        Builder<Annotation, AnnotationBuilder> {
   factory AnnotationBuilder() = _$AnnotationBuilder;
 
   AnnotationBuilder._();
 
-  Code code;
+  Code get code => codeForAnnotation;
+  set code(Code code) => codeForAnnotation = code;
+
+  Code codeForAnnotation;
 }

--- a/lib/src/specs/annotation.g.dart
+++ b/lib/src/specs/annotation.g.dart
@@ -16,13 +16,14 @@ part of code_builder.src.specs.annotation;
 
 class _$Annotation extends Annotation {
   @override
-  final Code code;
+  final Code codeForAnnotation;
 
   factory _$Annotation([void updates(AnnotationBuilder b)]) =>
       (new AnnotationBuilder()..update(updates)).build() as _$Annotation;
 
-  _$Annotation._({this.code}) : super._() {
-    if (code == null) throw new ArgumentError.notNull('code');
+  _$Annotation._({this.codeForAnnotation}) : super._() {
+    if (codeForAnnotation == null)
+      throw new ArgumentError.notNull('codeForAnnotation');
   }
 
   @override
@@ -36,17 +37,18 @@ class _$Annotation extends Annotation {
   bool operator ==(dynamic other) {
     if (identical(other, this)) return true;
     if (other is! Annotation) return false;
-    return code == other.code;
+    return codeForAnnotation == other.codeForAnnotation;
   }
 
   @override
   int get hashCode {
-    return $jf($jc(0, code.hashCode));
+    return $jf($jc(0, codeForAnnotation.hashCode));
   }
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper('Annotation')..add('code', code))
+    return (newBuiltValueToStringHelper('Annotation')
+          ..add('codeForAnnotation', codeForAnnotation))
         .toString();
   }
 }
@@ -55,22 +57,22 @@ class _$AnnotationBuilder extends AnnotationBuilder {
   _$Annotation _$v;
 
   @override
-  Code get code {
+  Code get codeForAnnotation {
     _$this;
-    return super.code;
+    return super.codeForAnnotation;
   }
 
   @override
-  set code(Code code) {
+  set codeForAnnotation(Code codeForAnnotation) {
     _$this;
-    super.code = code;
+    super.codeForAnnotation = codeForAnnotation;
   }
 
   _$AnnotationBuilder() : super._();
 
   AnnotationBuilder get _$this {
     if (_$v != null) {
-      super.code = _$v.code;
+      super.codeForAnnotation = _$v.codeForAnnotation;
       _$v = null;
     }
     return this;
@@ -89,7 +91,8 @@ class _$AnnotationBuilder extends AnnotationBuilder {
 
   @override
   _$Annotation build() {
-    final _$result = _$v ?? new _$Annotation._(code: code);
+    final _$result =
+        _$v ?? new _$Annotation._(codeForAnnotation: codeForAnnotation);
     replace(_$result);
     return _$result;
   }

--- a/lib/src/specs/class.dart
+++ b/lib/src/specs/class.dart
@@ -13,8 +13,8 @@ import '../mixins/annotations.dart';
 import '../mixins/dartdoc.dart';
 import '../mixins/generics.dart';
 import '../visitors.dart';
-import 'annotation.dart';
 import 'constructor.dart';
+import 'expression.dart';
 import 'field.dart';
 import 'method.dart';
 import 'reference.dart';
@@ -33,7 +33,7 @@ abstract class Class extends Object
   bool get abstract;
 
   @override
-  BuiltList<Annotation> get annotations;
+  BuiltList<Expression> get annotations;
 
   @override
   BuiltList<String> get docs;
@@ -74,7 +74,7 @@ abstract class ClassBuilder extends Object
   bool abstract = false;
 
   @override
-  ListBuilder<Annotation> annotations = new ListBuilder<Annotation>();
+  ListBuilder<Expression> annotations = new ListBuilder<Expression>();
 
   @override
   ListBuilder<String> docs = new ListBuilder<String>();

--- a/lib/src/specs/class.g.dart
+++ b/lib/src/specs/class.g.dart
@@ -18,7 +18,7 @@ class _$Class extends Class {
   @override
   final bool abstract;
   @override
-  final BuiltList<Annotation> annotations;
+  final BuiltList<Expression> annotations;
   @override
   final BuiltList<String> docs;
   @override
@@ -148,13 +148,13 @@ class _$ClassBuilder extends ClassBuilder {
   }
 
   @override
-  ListBuilder<Annotation> get annotations {
+  ListBuilder<Expression> get annotations {
     _$this;
-    return super.annotations ??= new ListBuilder<Annotation>();
+    return super.annotations ??= new ListBuilder<Expression>();
   }
 
   @override
-  set annotations(ListBuilder<Annotation> annotations) {
+  set annotations(ListBuilder<Expression> annotations) {
     _$this;
     super.annotations = annotations;
   }

--- a/lib/src/specs/constructor.dart
+++ b/lib/src/specs/constructor.dart
@@ -10,8 +10,8 @@ import 'package:meta/meta.dart';
 
 import '../mixins/annotations.dart';
 import '../mixins/dartdoc.dart';
-import 'annotation.dart';
 import 'code.dart';
+import 'expression.dart';
 import 'method.dart';
 import 'reference.dart';
 
@@ -26,7 +26,7 @@ abstract class Constructor extends Object
   Constructor._();
 
   @override
-  BuiltList<Annotation> get annotations;
+  BuiltList<Expression> get annotations;
 
   @override
   BuiltList<String> get docs;
@@ -73,7 +73,7 @@ abstract class ConstructorBuilder extends Object
   ConstructorBuilder._();
 
   @override
-  ListBuilder<Annotation> annotations = new ListBuilder<Annotation>();
+  ListBuilder<Expression> annotations = new ListBuilder<Expression>();
 
   @override
   ListBuilder<String> docs = new ListBuilder<String>();

--- a/lib/src/specs/constructor.g.dart
+++ b/lib/src/specs/constructor.g.dart
@@ -16,7 +16,7 @@ part of code_builder.src.specs.constructor;
 
 class _$Constructor extends Constructor {
   @override
-  final BuiltList<Annotation> annotations;
+  final BuiltList<Expression> annotations;
   @override
   final BuiltList<String> docs;
   @override
@@ -144,13 +144,13 @@ class _$ConstructorBuilder extends ConstructorBuilder {
   _$Constructor _$v;
 
   @override
-  ListBuilder<Annotation> get annotations {
+  ListBuilder<Expression> get annotations {
     _$this;
-    return super.annotations ??= new ListBuilder<Annotation>();
+    return super.annotations ??= new ListBuilder<Expression>();
   }
 
   @override
-  set annotations(ListBuilder<Annotation> annotations) {
+  set annotations(ListBuilder<Expression> annotations) {
     _$this;
     super.annotations = annotations;
   }

--- a/lib/src/specs/expression.dart
+++ b/lib/src/specs/expression.dart
@@ -173,7 +173,8 @@ abstract class Expression implements Spec {
   }
 
   /// Returns an annotation as a result of calling this constructor.
-  Annotation annotation([
+  @Deprecated('Use "call" instead. Will be removed in 3.0.0.')
+  Expression annotation([
     List<Expression> positionalArguments,
     Map<String, Expression> namedArguments = const {},
     List<Reference> typeArguments = const [],
@@ -195,12 +196,14 @@ abstract class Expression implements Spec {
   }
 
   /// Returns an annotation as a result of calling a named constructor.
-  Annotation annotationNamed(
+  @Deprecated('Use a combination of "property" and "call". Removing in 3.0.0.')
+  Expression annotationNamed(
     String name,
     List<Expression> positionalArguments, [
     Map<String, Expression> namedArguments = const {},
     List<Reference> typeArguments = const [],
   ]) {
+    // ignore: deprecated_member_use
     return new Annotation((b) => b
       ..code = new InvokeExpression._(
               this, positionalArguments, namedArguments, typeArguments, name)

--- a/lib/src/specs/field.dart
+++ b/lib/src/specs/field.dart
@@ -12,8 +12,8 @@ import '../base.dart';
 import '../mixins/annotations.dart';
 import '../mixins/dartdoc.dart';
 import '../visitors.dart';
-import 'annotation.dart';
 import 'code.dart';
+import 'expression.dart';
 import 'reference.dart';
 
 part 'field.g.dart';
@@ -27,7 +27,7 @@ abstract class Field extends Object
   Field._();
 
   @override
-  BuiltList<Annotation> get annotations;
+  BuiltList<Expression> get annotations;
 
   @override
   BuiltList<String> get docs;
@@ -71,7 +71,7 @@ abstract class FieldBuilder extends Object
   FieldBuilder._();
 
   @override
-  ListBuilder<Annotation> annotations = new ListBuilder<Annotation>();
+  ListBuilder<Expression> annotations = new ListBuilder<Expression>();
 
   @override
   ListBuilder<String> docs = new ListBuilder<String>();

--- a/lib/src/specs/field.g.dart
+++ b/lib/src/specs/field.g.dart
@@ -16,7 +16,7 @@ part of code_builder.src.specs.field;
 
 class _$Field extends Field {
   @override
-  final BuiltList<Annotation> annotations;
+  final BuiltList<Expression> annotations;
   @override
   final BuiltList<String> docs;
   @override
@@ -101,13 +101,13 @@ class _$FieldBuilder extends FieldBuilder {
   _$Field _$v;
 
   @override
-  ListBuilder<Annotation> get annotations {
+  ListBuilder<Expression> get annotations {
     _$this;
-    return super.annotations ??= new ListBuilder<Annotation>();
+    return super.annotations ??= new ListBuilder<Expression>();
   }
 
   @override
-  set annotations(ListBuilder<Annotation> annotations) {
+  set annotations(ListBuilder<Expression> annotations) {
     _$this;
     super.annotations = annotations;
   }

--- a/lib/src/specs/method.dart
+++ b/lib/src/specs/method.dart
@@ -13,7 +13,6 @@ import '../mixins/annotations.dart';
 import '../mixins/dartdoc.dart';
 import '../mixins/generics.dart';
 import '../visitors.dart';
-import 'annotation.dart';
 import 'code.dart';
 import 'expression.dart';
 import 'reference.dart';
@@ -40,7 +39,7 @@ abstract class Method extends Object
   Method._();
 
   @override
-  BuiltList<Annotation> get annotations;
+  BuiltList<Expression> get annotations;
 
   @override
   BuiltList<String> get docs;
@@ -105,7 +104,7 @@ abstract class MethodBuilder extends Object
   MethodBuilder._();
 
   @override
-  ListBuilder<Annotation> annotations = new ListBuilder<Annotation>();
+  ListBuilder<Expression> annotations = new ListBuilder<Expression>();
 
   @override
   ListBuilder<String> docs = new ListBuilder<String>();
@@ -179,7 +178,7 @@ abstract class Parameter extends Object
   bool get toThis;
 
   @override
-  BuiltList<Annotation> get annotations;
+  BuiltList<Expression> get annotations;
 
   @override
   BuiltList<String> get docs;
@@ -214,7 +213,7 @@ abstract class ParameterBuilder extends Object
   bool toThis = false;
 
   @override
-  ListBuilder<Annotation> annotations = new ListBuilder<Annotation>();
+  ListBuilder<Expression> annotations = new ListBuilder<Expression>();
 
   @override
   ListBuilder<String> docs = new ListBuilder<String>();

--- a/lib/src/specs/method.g.dart
+++ b/lib/src/specs/method.g.dart
@@ -16,7 +16,7 @@ part of code_builder.src.specs.method;
 
 class _$Method extends Method {
   @override
-  final BuiltList<Annotation> annotations;
+  final BuiltList<Expression> annotations;
   @override
   final BuiltList<String> docs;
   @override
@@ -152,13 +152,13 @@ class _$MethodBuilder extends MethodBuilder {
   _$Method _$v;
 
   @override
-  ListBuilder<Annotation> get annotations {
+  ListBuilder<Expression> get annotations {
     _$this;
-    return super.annotations ??= new ListBuilder<Annotation>();
+    return super.annotations ??= new ListBuilder<Expression>();
   }
 
   @override
-  set annotations(ListBuilder<Annotation> annotations) {
+  set annotations(ListBuilder<Expression> annotations) {
     _$this;
     super.annotations = annotations;
   }
@@ -372,7 +372,7 @@ class _$Parameter extends Parameter {
   @override
   final bool toThis;
   @override
-  final BuiltList<Annotation> annotations;
+  final BuiltList<Expression> annotations;
   @override
   final BuiltList<String> docs;
   @override
@@ -505,13 +505,13 @@ class _$ParameterBuilder extends ParameterBuilder {
   }
 
   @override
-  ListBuilder<Annotation> get annotations {
+  ListBuilder<Expression> get annotations {
     _$this;
-    return super.annotations ??= new ListBuilder<Annotation>();
+    return super.annotations ??= new ListBuilder<Expression>();
   }
 
   @override
-  set annotations(ListBuilder<Annotation> annotations) {
+  set annotations(ListBuilder<Expression> annotations) {
     _$this;
     super.annotations = annotations;
   }

--- a/lib/src/visitors.dart
+++ b/lib/src/visitors.dart
@@ -5,10 +5,10 @@
 import 'package:meta/meta.dart';
 
 import 'base.dart';
-import 'specs/annotation.dart';
 import 'specs/class.dart';
 import 'specs/constructor.dart';
 import 'specs/directive.dart';
+import 'specs/expression.dart';
 import 'specs/field.dart';
 import 'specs/library.dart';
 import 'specs/method.dart';
@@ -20,7 +20,7 @@ import 'specs/type_reference.dart';
 abstract class SpecVisitor<T> {
   const SpecVisitor._();
 
-  T visitAnnotation(Annotation spec, [T context]);
+  T visitAnnotation(Expression spec, [T context]);
 
   T visitClass(Class spec, [T context]);
 

--- a/test/e2e/injection_test.dart
+++ b/test/e2e/injection_test.dart
@@ -31,8 +31,7 @@ void main() {
         ]).code
         ..lambda = true
         ..returns = $Thing
-        ..annotations
-            .add(new Annotation((b) => b..code = const Code('override')))));
+        ..annotations.add(refer('override'))));
 
     expect(
       clazz.build(),

--- a/test/specs/class_test.dart
+++ b/test/specs/class_test.dart
@@ -50,9 +50,8 @@ void main() {
         (b) => b
           ..name = 'Foo'
           ..annotations.addAll([
-            refer('deprecated').annotation(),
-            refer('Deprecated')
-                .annotation([literalString('This is an old class')])
+            refer('deprecated'),
+            refer('Deprecated').call([literalString('This is an old class')])
           ]),
       ),
       equalsDart(r'''
@@ -176,13 +175,29 @@ void main() {
     );
   });
 
-  test('should create a class with a constructor with an annotation', () {
+  test('should create a class with an annotated constructor [deprecated]', () {
     expect(
       new Class((b) => b
         ..name = 'Foo'
         ..constructors.add(new Constructor((b) => b
           ..annotations.add(
-              new Annotation((b) => b..code = const Code('deprecated')))))),
+            new Annotation((b) => b..code = const Code('deprecated')),
+          )))),
+      equalsDart(r'''
+        class Foo {
+          @deprecated
+          Foo();
+        }
+      '''),
+    );
+  });
+
+  test('should create a class with a annotated constructor', () {
+    expect(
+      new Class((b) => b
+        ..name = 'Foo'
+        ..constructors.add(
+            new Constructor((b) => b..annotations.add(refer('deprecated'))))),
       equalsDart(r'''
         class Foo {
           @deprecated

--- a/test/specs/method_test.dart
+++ b/test/specs/method_test.dart
@@ -192,7 +192,7 @@ void main() {
     );
   });
 
-  test('should create a method with a paremter with an annotation', () {
+  test('should create a method with an annotated parameter [deprecated]', () {
     expect(
       new Method(
         (b) => b
@@ -202,6 +202,23 @@ void main() {
               ..name = 'i'
               ..annotations.add(
                   new Annotation((a) => a..code = const Code('deprecated')))),
+          ),
+      ),
+      equalsDart(r'''
+        fib(@deprecated i);
+      '''),
+    );
+  });
+
+  test('should create a method with an annotated parameter', () {
+    expect(
+      new Method(
+        (b) => b
+          ..name = 'fib'
+          ..requiredParameters.add(
+            new Parameter((b) => b
+              ..name = 'i'
+              ..annotations.add(refer('deprecated'))),
           ),
       ),
       equalsDart(r'''


### PR DESCRIPTION
Largely was just boilerplate over some string-based expression 95%+ of the time.

This change shouldn't be breaking, but will allow us to simply remove `Annotation` in 3.x.