### PR TITLE
Make `FunctionType` implement `TypeReference`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,8 +87,8 @@ void main() {
 * Added `nullSafeProperty` to `Expression` to access properties with `?.`
 * Added `conditional` to `Expression` to use the ternary operator `? : `
 * Methods taking `positionalArguments` accept `Iterable<Expression>`
-* **BUG FIX**: Parameters can take a `FunctionType` as a `type`. `FunctionType`
-  now implements `TypeReference`.
+* **BUG FIX**: Parameters can take a `FunctionType` as a `type`.
+  `Reference.type` now returns a `Reference`.
 
 ## 2.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,8 @@ void main() {
 * Added `nullSafeProperty` to `Expression` to access properties with `?.`
 * Added `conditional` to `Expression` to use the ternary operator `? : `
 * Methods taking `positionalArguments` accept `Iterable<Expression>`
+* **BUG FIX**: Parameters can take a `FunctionType` as a `type`. `FunctionType`
+  now implements `TypeReference`.
 
 ## 2.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,7 +88,8 @@ void main() {
 * Added `conditional` to `Expression` to use the ternary operator `? : `
 * Methods taking `positionalArguments` accept `Iterable<Expression>`
 * **BUG FIX**: Parameters can take a `FunctionType` as a `type`.
-  `Reference.type` now returns a `Reference`.
+  `Reference.type` now returns a `Reference`. Note that this change is
+  technically breaking but should not impacts most clients.
 
 ## 2.2.0
 

--- a/lib/src/emitter.dart
+++ b/lib/src/emitter.dart
@@ -100,18 +100,19 @@ class DartEmitter extends Object
     visitTypeParameters(spec.types.map((r) => r.type), output);
     if (spec.extend != null) {
       output.write(' extends ');
-      visitType(spec.extend.type, output);
+      spec.extend.type.accept(this, output);
     }
     if (spec.mixins.isNotEmpty) {
       output
         ..write(' with ')
-        ..writeAll(spec.mixins.map<StringSink>((m) => visitType(m.type)), ',');
+        ..writeAll(
+            spec.mixins.map<StringSink>((m) => m.type.accept(this)), ',');
     }
     if (spec.implements.isNotEmpty) {
       output
         ..write(' implements ')
         ..writeAll(
-            spec.implements.map<StringSink>((m) => visitType(m.type)), ',');
+            spec.implements.map<StringSink>((m) => m.type.accept(this)), ',');
     }
     output.write(' {');
     spec.constructors.forEach((c) {
@@ -198,7 +199,7 @@ class DartEmitter extends Object
     }
     if (spec.redirect != null) {
       output.write(' = ');
-      visitType(spec.redirect.type, output);
+      spec.redirect.type.accept(this, output);
       output.write(';');
     } else if (spec.body != null) {
       if (_isLambdaConstructor(spec)) {
@@ -484,12 +485,12 @@ class DartEmitter extends Object
   }
 
   @override
-  visitTypeParameters(Iterable<TypeReference> specs, [StringSink output]) {
+  visitTypeParameters(Iterable<Reference> specs, [StringSink output]) {
     output ??= new StringBuffer();
     if (specs.isNotEmpty) {
       output
         ..write('<')
-        ..writeAll(specs.map<StringSink>(visitType), ',')
+        ..writeAll(specs.map<StringSink>((s) => s.accept(this)), ',')
         ..write('>');
     }
     return output;

--- a/lib/src/specs/reference.dart
+++ b/lib/src/specs/reference.dart
@@ -123,7 +123,7 @@ class Reference extends Expression implements Spec {
       .toString();
 
   /// Returns as a [TypeReference], which allows adding generic type parameters.
-  TypeReference get type => new TypeReference((b) => b
+  Reference get type => new TypeReference((b) => b
     ..url = url
     ..symbol = symbol);
 }

--- a/lib/src/specs/type_function.dart
+++ b/lib/src/specs/type_function.dart
@@ -21,7 +21,7 @@ part 'type_function.g.dart';
 @immutable
 abstract class FunctionType extends Expression
     with HasGenerics
-    implements Built<FunctionType, FunctionTypeBuilder>, Reference, Spec {
+    implements Built<FunctionType, FunctionTypeBuilder>, TypeReference, Spec {
   factory FunctionType([
     void updates(FunctionTypeBuilder b),
   ]) = _$FunctionType;
@@ -58,7 +58,10 @@ abstract class FunctionType extends Expression
   String get symbol => null;
 
   @override
-  TypeReference get type => null;
+  Reference get bound => null;
+
+  @override
+  TypeReference get type => this;
 
   @override
   Expression newInstance(

--- a/lib/src/specs/type_function.dart
+++ b/lib/src/specs/type_function.dart
@@ -14,14 +14,13 @@ import '../visitors.dart';
 import 'code.dart';
 import 'expression.dart';
 import 'reference.dart';
-import 'type_reference.dart';
 
 part 'type_function.g.dart';
 
 @immutable
 abstract class FunctionType extends Expression
     with HasGenerics
-    implements Built<FunctionType, FunctionTypeBuilder>, TypeReference, Spec {
+    implements Built<FunctionType, FunctionTypeBuilder>, Reference, Spec {
   factory FunctionType([
     void updates(FunctionTypeBuilder b),
   ]) = _$FunctionType;
@@ -58,10 +57,7 @@ abstract class FunctionType extends Expression
   String get symbol => null;
 
   @override
-  Reference get bound => null;
-
-  @override
-  TypeReference get type => this;
+  Reference get type => this;
 
   @override
   Expression newInstance(

--- a/lib/src/specs/type_function.g.dart
+++ b/lib/src/specs/type_function.g.dart
@@ -164,7 +164,7 @@ class _$FunctionTypeBuilder extends FunctionTypeBuilder {
   }
 
   @override
-  void replace(covariant FunctionType other) {
+  void replace(FunctionType other) {
     if (other == null) throw new ArgumentError.notNull('other');
     _$v = other as _$FunctionType;
   }

--- a/lib/src/specs/type_function.g.dart
+++ b/lib/src/specs/type_function.g.dart
@@ -164,7 +164,7 @@ class _$FunctionTypeBuilder extends FunctionTypeBuilder {
   }
 
   @override
-  void replace(FunctionType other) {
+  void replace(covariant FunctionType other) {
     if (other == null) throw new ArgumentError.notNull('other');
     _$v = other as _$FunctionType;
   }

--- a/lib/src/visitors.dart
+++ b/lib/src/visitors.dart
@@ -45,5 +45,5 @@ abstract class SpecVisitor<T> {
 
   T visitType(TypeReference spec, [T context]);
 
-  T visitTypeParameters(Iterable<TypeReference> specs, [T context]);
+  T visitTypeParameters(Iterable<Reference> specs, [T context]);
 }

--- a/test/specs/method_test.dart
+++ b/test/specs/method_test.dart
@@ -145,6 +145,53 @@ void main() {
     );
   });
 
+  test('should create a method with a nested function type return type', () {
+    expect(
+      new Method((b) => b
+        ..name = 'foo'
+        ..returns = new FunctionType((b) => b
+          ..returnType = new FunctionType((b) => b
+            ..returnType = refer('String')
+            ..requiredParameters.add(refer('String')))
+          ..requiredParameters.addAll([
+            refer('int'),
+          ]))),
+      equalsDart(r'''
+        String Function(String) Function(int) foo();
+      '''),
+    );
+  });
+
+  test('should create a method with a function type argument', () {
+    expect(
+        new Method((b) => b
+          ..name = 'foo'
+          ..requiredParameters.add(new Parameter((b) => b
+            ..type = new FunctionType((b) => b
+              ..returnType = refer('String')
+              ..requiredParameters.add(refer('int')))
+            ..name = 'argument'))),
+        equalsDart(r'''
+          foo(String Function(int) argument);
+        '''));
+  });
+
+  test('should create a method with a nested function type argument', () {
+    expect(
+        new Method((b) => b
+          ..name = 'foo'
+          ..requiredParameters.add(new Parameter((b) => b
+            ..type = new FunctionType((b) => b
+              ..returnType = new FunctionType((b) => b
+                ..returnType = refer('String')
+                ..requiredParameters.add(refer('String')))
+              ..requiredParameters.add(refer('int')))
+            ..name = 'argument'))),
+        equalsDart(r'''
+          foo(String Function(String) Function(int) argument);
+        '''));
+  });
+
   test('should create a method with generic types', () {
     expect(
       new Method((b) => b


### PR DESCRIPTION
Fixes #174

- Add a test which fails before this change and passes after
- Add tests for nested function types since that was untested previously
- Make `FuctionType` implement `TypeReference`, add missing fields
  returning null and rebuild the built_value file.
- Return `this` from the `type` getter.