### PR TITLE
Upgrade to built_value 5.1.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.2
+
+* Upgrade to `built_value` 5.1.0.
+
 ## 3.0.1
 
 * Export the `literalNum` function.

--- a/lib/src/specs/class.g.dart
+++ b/lib/src/specs/class.g.dart
@@ -54,16 +54,20 @@ class _$Class extends Class {
       this.fields,
       this.name})
       : super._() {
-    if (abstract == null) throw new ArgumentError.notNull('abstract');
-    if (annotations == null) throw new ArgumentError.notNull('annotations');
-    if (docs == null) throw new ArgumentError.notNull('docs');
-    if (implements == null) throw new ArgumentError.notNull('implements');
-    if (mixins == null) throw new ArgumentError.notNull('mixins');
-    if (types == null) throw new ArgumentError.notNull('types');
-    if (constructors == null) throw new ArgumentError.notNull('constructors');
-    if (methods == null) throw new ArgumentError.notNull('methods');
-    if (fields == null) throw new ArgumentError.notNull('fields');
-    if (name == null) throw new ArgumentError.notNull('name');
+    if (abstract == null)
+      throw new BuiltValueNullFieldError('Class', 'abstract');
+    if (annotations == null)
+      throw new BuiltValueNullFieldError('Class', 'annotations');
+    if (docs == null) throw new BuiltValueNullFieldError('Class', 'docs');
+    if (implements == null)
+      throw new BuiltValueNullFieldError('Class', 'implements');
+    if (mixins == null) throw new BuiltValueNullFieldError('Class', 'mixins');
+    if (types == null) throw new BuiltValueNullFieldError('Class', 'types');
+    if (constructors == null)
+      throw new BuiltValueNullFieldError('Class', 'constructors');
+    if (methods == null) throw new BuiltValueNullFieldError('Class', 'methods');
+    if (fields == null) throw new BuiltValueNullFieldError('Class', 'fields');
+    if (name == null) throw new BuiltValueNullFieldError('Class', 'name');
   }
 
   @override
@@ -300,19 +304,47 @@ class _$ClassBuilder extends ClassBuilder {
 
   @override
   _$Class build() {
-    final _$result = _$v ??
-        new _$Class._(
-            abstract: abstract,
-            annotations: annotations?.build(),
-            docs: docs?.build(),
-            extend: extend,
-            implements: implements?.build(),
-            mixins: mixins?.build(),
-            types: types?.build(),
-            constructors: constructors?.build(),
-            methods: methods?.build(),
-            fields: fields?.build(),
-            name: name);
+    _$Class _$result;
+    try {
+      _$result = _$v ??
+          new _$Class._(
+              abstract: abstract,
+              annotations: annotations.build(),
+              docs: docs.build(),
+              extend: extend,
+              implements: implements.build(),
+              mixins: mixins.build(),
+              types: types.build(),
+              constructors: constructors.build(),
+              methods: methods.build(),
+              fields: fields.build(),
+              name: name);
+    } catch (_) {
+      String _$failedField;
+      try {
+        _$failedField = 'annotations';
+        annotations.build();
+        _$failedField = 'docs';
+        docs.build();
+
+        _$failedField = 'implements';
+        implements.build();
+        _$failedField = 'mixins';
+        mixins.build();
+        _$failedField = 'types';
+        types.build();
+        _$failedField = 'constructors';
+        constructors.build();
+        _$failedField = 'methods';
+        methods.build();
+        _$failedField = 'fields';
+        fields.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            'Class', _$failedField, e.toString());
+      }
+      rethrow;
+    }
     replace(_$result);
     return _$result;
   }

--- a/lib/src/specs/code.g.dart
+++ b/lib/src/specs/code.g.dart
@@ -22,7 +22,8 @@ class _$Block extends Block {
       (new BlockBuilder()..update(updates)).build() as _$Block;
 
   _$Block._({this.statements}) : super._() {
-    if (statements == null) throw new ArgumentError.notNull('statements');
+    if (statements == null)
+      throw new BuiltValueNullFieldError('Block', 'statements');
   }
 
   @override
@@ -89,7 +90,20 @@ class _$BlockBuilder extends BlockBuilder {
 
   @override
   _$Block build() {
-    final _$result = _$v ?? new _$Block._(statements: statements?.build());
+    _$Block _$result;
+    try {
+      _$result = _$v ?? new _$Block._(statements: statements.build());
+    } catch (_) {
+      String _$failedField;
+      try {
+        _$failedField = 'statements';
+        statements.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            'Block', _$failedField, e.toString());
+      }
+      rethrow;
+    }
     replace(_$result);
     return _$result;
   }

--- a/lib/src/specs/constructor.g.dart
+++ b/lib/src/specs/constructor.g.dart
@@ -57,16 +57,21 @@ class _$Constructor extends Constructor {
       this.name,
       this.redirect})
       : super._() {
-    if (annotations == null) throw new ArgumentError.notNull('annotations');
-    if (docs == null) throw new ArgumentError.notNull('docs');
+    if (annotations == null)
+      throw new BuiltValueNullFieldError('Constructor', 'annotations');
+    if (docs == null) throw new BuiltValueNullFieldError('Constructor', 'docs');
     if (optionalParameters == null)
-      throw new ArgumentError.notNull('optionalParameters');
+      throw new BuiltValueNullFieldError('Constructor', 'optionalParameters');
     if (requiredParameters == null)
-      throw new ArgumentError.notNull('requiredParameters');
-    if (initializers == null) throw new ArgumentError.notNull('initializers');
-    if (external == null) throw new ArgumentError.notNull('external');
-    if (constant == null) throw new ArgumentError.notNull('constant');
-    if (factory == null) throw new ArgumentError.notNull('factory');
+      throw new BuiltValueNullFieldError('Constructor', 'requiredParameters');
+    if (initializers == null)
+      throw new BuiltValueNullFieldError('Constructor', 'initializers');
+    if (external == null)
+      throw new BuiltValueNullFieldError('Constructor', 'external');
+    if (constant == null)
+      throw new BuiltValueNullFieldError('Constructor', 'constant');
+    if (factory == null)
+      throw new BuiltValueNullFieldError('Constructor', 'factory');
   }
 
   @override
@@ -320,20 +325,41 @@ class _$ConstructorBuilder extends ConstructorBuilder {
 
   @override
   _$Constructor build() {
-    final _$result = _$v ??
-        new _$Constructor._(
-            annotations: annotations?.build(),
-            docs: docs?.build(),
-            optionalParameters: optionalParameters?.build(),
-            requiredParameters: requiredParameters?.build(),
-            initializers: initializers?.build(),
-            body: body,
-            external: external,
-            constant: constant,
-            factory: factory,
-            lambda: lambda,
-            name: name,
-            redirect: redirect);
+    _$Constructor _$result;
+    try {
+      _$result = _$v ??
+          new _$Constructor._(
+              annotations: annotations.build(),
+              docs: docs.build(),
+              optionalParameters: optionalParameters.build(),
+              requiredParameters: requiredParameters.build(),
+              initializers: initializers.build(),
+              body: body,
+              external: external,
+              constant: constant,
+              factory: factory,
+              lambda: lambda,
+              name: name,
+              redirect: redirect);
+    } catch (_) {
+      String _$failedField;
+      try {
+        _$failedField = 'annotations';
+        annotations.build();
+        _$failedField = 'docs';
+        docs.build();
+        _$failedField = 'optionalParameters';
+        optionalParameters.build();
+        _$failedField = 'requiredParameters';
+        requiredParameters.build();
+        _$failedField = 'initializers';
+        initializers.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            'Constructor', _$failedField, e.toString());
+      }
+      rethrow;
+    }
     replace(_$result);
     return _$result;
   }

--- a/lib/src/specs/directive.g.dart
+++ b/lib/src/specs/directive.g.dart
@@ -34,11 +34,12 @@ class _$Directive extends Directive {
   _$Directive._(
       {this.as, this.url, this.type, this.show, this.hide, this.deferred})
       : super._() {
-    if (url == null) throw new ArgumentError.notNull('url');
-    if (type == null) throw new ArgumentError.notNull('type');
-    if (show == null) throw new ArgumentError.notNull('show');
-    if (hide == null) throw new ArgumentError.notNull('hide');
-    if (deferred == null) throw new ArgumentError.notNull('deferred');
+    if (url == null) throw new BuiltValueNullFieldError('Directive', 'url');
+    if (type == null) throw new BuiltValueNullFieldError('Directive', 'type');
+    if (show == null) throw new BuiltValueNullFieldError('Directive', 'show');
+    if (hide == null) throw new BuiltValueNullFieldError('Directive', 'hide');
+    if (deferred == null)
+      throw new BuiltValueNullFieldError('Directive', 'deferred');
   }
 
   @override

--- a/lib/src/specs/field.g.dart
+++ b/lib/src/specs/field.g.dart
@@ -42,11 +42,13 @@ class _$Field extends Field {
       this.type,
       this.modifier})
       : super._() {
-    if (annotations == null) throw new ArgumentError.notNull('annotations');
-    if (docs == null) throw new ArgumentError.notNull('docs');
-    if (static == null) throw new ArgumentError.notNull('static');
-    if (name == null) throw new ArgumentError.notNull('name');
-    if (modifier == null) throw new ArgumentError.notNull('modifier');
+    if (annotations == null)
+      throw new BuiltValueNullFieldError('Field', 'annotations');
+    if (docs == null) throw new BuiltValueNullFieldError('Field', 'docs');
+    if (static == null) throw new BuiltValueNullFieldError('Field', 'static');
+    if (name == null) throw new BuiltValueNullFieldError('Field', 'name');
+    if (modifier == null)
+      throw new BuiltValueNullFieldError('Field', 'modifier');
   }
 
   @override
@@ -213,15 +215,30 @@ class _$FieldBuilder extends FieldBuilder {
 
   @override
   _$Field build() {
-    final _$result = _$v ??
-        new _$Field._(
-            annotations: annotations?.build(),
-            docs: docs?.build(),
-            assignment: assignment,
-            static: static,
-            name: name,
-            type: type,
-            modifier: modifier);
+    _$Field _$result;
+    try {
+      _$result = _$v ??
+          new _$Field._(
+              annotations: annotations.build(),
+              docs: docs.build(),
+              assignment: assignment,
+              static: static,
+              name: name,
+              type: type,
+              modifier: modifier);
+    } catch (_) {
+      String _$failedField;
+      try {
+        _$failedField = 'annotations';
+        annotations.build();
+        _$failedField = 'docs';
+        docs.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            'Field', _$failedField, e.toString());
+      }
+      rethrow;
+    }
     replace(_$result);
     return _$result;
   }

--- a/lib/src/specs/library.g.dart
+++ b/lib/src/specs/library.g.dart
@@ -24,8 +24,9 @@ class _$Library extends Library {
       (new LibraryBuilder()..update(updates)).build() as _$Library;
 
   _$Library._({this.directives, this.body}) : super._() {
-    if (directives == null) throw new ArgumentError.notNull('directives');
-    if (body == null) throw new ArgumentError.notNull('body');
+    if (directives == null)
+      throw new BuiltValueNullFieldError('Library', 'directives');
+    if (body == null) throw new BuiltValueNullFieldError('Library', 'body');
   }
 
   @override
@@ -107,8 +108,23 @@ class _$LibraryBuilder extends LibraryBuilder {
 
   @override
   _$Library build() {
-    final _$result = _$v ??
-        new _$Library._(directives: directives?.build(), body: body?.build());
+    _$Library _$result;
+    try {
+      _$result = _$v ??
+          new _$Library._(directives: directives.build(), body: body.build());
+    } catch (_) {
+      String _$failedField;
+      try {
+        _$failedField = 'directives';
+        directives.build();
+        _$failedField = 'body';
+        body.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            'Library', _$failedField, e.toString());
+      }
+      rethrow;
+    }
     replace(_$result);
     return _$result;
   }

--- a/lib/src/specs/method.g.dart
+++ b/lib/src/specs/method.g.dart
@@ -60,15 +60,17 @@ class _$Method extends Method {
       this.modifier,
       this.returns})
       : super._() {
-    if (annotations == null) throw new ArgumentError.notNull('annotations');
-    if (docs == null) throw new ArgumentError.notNull('docs');
-    if (types == null) throw new ArgumentError.notNull('types');
+    if (annotations == null)
+      throw new BuiltValueNullFieldError('Method', 'annotations');
+    if (docs == null) throw new BuiltValueNullFieldError('Method', 'docs');
+    if (types == null) throw new BuiltValueNullFieldError('Method', 'types');
     if (optionalParameters == null)
-      throw new ArgumentError.notNull('optionalParameters');
+      throw new BuiltValueNullFieldError('Method', 'optionalParameters');
     if (requiredParameters == null)
-      throw new ArgumentError.notNull('requiredParameters');
-    if (external == null) throw new ArgumentError.notNull('external');
-    if (static == null) throw new ArgumentError.notNull('static');
+      throw new BuiltValueNullFieldError('Method', 'requiredParameters');
+    if (external == null)
+      throw new BuiltValueNullFieldError('Method', 'external');
+    if (static == null) throw new BuiltValueNullFieldError('Method', 'static');
   }
 
   @override
@@ -341,21 +343,42 @@ class _$MethodBuilder extends MethodBuilder {
 
   @override
   _$Method build() {
-    final _$result = _$v ??
-        new _$Method._(
-            annotations: annotations?.build(),
-            docs: docs?.build(),
-            types: types?.build(),
-            optionalParameters: optionalParameters?.build(),
-            requiredParameters: requiredParameters?.build(),
-            body: body,
-            external: external,
-            lambda: lambda,
-            static: static,
-            name: name,
-            type: type,
-            modifier: modifier,
-            returns: returns);
+    _$Method _$result;
+    try {
+      _$result = _$v ??
+          new _$Method._(
+              annotations: annotations.build(),
+              docs: docs.build(),
+              types: types.build(),
+              optionalParameters: optionalParameters.build(),
+              requiredParameters: requiredParameters.build(),
+              body: body,
+              external: external,
+              lambda: lambda,
+              static: static,
+              name: name,
+              type: type,
+              modifier: modifier,
+              returns: returns);
+    } catch (_) {
+      String _$failedField;
+      try {
+        _$failedField = 'annotations';
+        annotations.build();
+        _$failedField = 'docs';
+        docs.build();
+        _$failedField = 'types';
+        types.build();
+        _$failedField = 'optionalParameters';
+        optionalParameters.build();
+        _$failedField = 'requiredParameters';
+        requiredParameters.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            'Method', _$failedField, e.toString());
+      }
+      rethrow;
+    }
     replace(_$result);
     return _$result;
   }
@@ -392,12 +415,14 @@ class _$Parameter extends Parameter {
       this.types,
       this.type})
       : super._() {
-    if (name == null) throw new ArgumentError.notNull('name');
-    if (named == null) throw new ArgumentError.notNull('named');
-    if (toThis == null) throw new ArgumentError.notNull('toThis');
-    if (annotations == null) throw new ArgumentError.notNull('annotations');
-    if (docs == null) throw new ArgumentError.notNull('docs');
-    if (types == null) throw new ArgumentError.notNull('types');
+    if (name == null) throw new BuiltValueNullFieldError('Parameter', 'name');
+    if (named == null) throw new BuiltValueNullFieldError('Parameter', 'named');
+    if (toThis == null)
+      throw new BuiltValueNullFieldError('Parameter', 'toThis');
+    if (annotations == null)
+      throw new BuiltValueNullFieldError('Parameter', 'annotations');
+    if (docs == null) throw new BuiltValueNullFieldError('Parameter', 'docs');
+    if (types == null) throw new BuiltValueNullFieldError('Parameter', 'types');
   }
 
   @override
@@ -581,16 +606,33 @@ class _$ParameterBuilder extends ParameterBuilder {
 
   @override
   _$Parameter build() {
-    final _$result = _$v ??
-        new _$Parameter._(
-            defaultTo: defaultTo,
-            name: name,
-            named: named,
-            toThis: toThis,
-            annotations: annotations?.build(),
-            docs: docs?.build(),
-            types: types?.build(),
-            type: type);
+    _$Parameter _$result;
+    try {
+      _$result = _$v ??
+          new _$Parameter._(
+              defaultTo: defaultTo,
+              name: name,
+              named: named,
+              toThis: toThis,
+              annotations: annotations.build(),
+              docs: docs.build(),
+              types: types.build(),
+              type: type);
+    } catch (_) {
+      String _$failedField;
+      try {
+        _$failedField = 'annotations';
+        annotations.build();
+        _$failedField = 'docs';
+        docs.build();
+        _$failedField = 'types';
+        types.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            'Parameter', _$failedField, e.toString());
+      }
+      rethrow;
+    }
     replace(_$result);
     return _$result;
   }

--- a/lib/src/specs/type_function.g.dart
+++ b/lib/src/specs/type_function.g.dart
@@ -36,13 +36,14 @@ class _$FunctionType extends FunctionType {
       this.optionalParameters,
       this.namedParameters})
       : super._() {
-    if (types == null) throw new ArgumentError.notNull('types');
+    if (types == null)
+      throw new BuiltValueNullFieldError('FunctionType', 'types');
     if (requiredParameters == null)
-      throw new ArgumentError.notNull('requiredParameters');
+      throw new BuiltValueNullFieldError('FunctionType', 'requiredParameters');
     if (optionalParameters == null)
-      throw new ArgumentError.notNull('optionalParameters');
+      throw new BuiltValueNullFieldError('FunctionType', 'optionalParameters');
     if (namedParameters == null)
-      throw new ArgumentError.notNull('namedParameters');
+      throw new BuiltValueNullFieldError('FunctionType', 'namedParameters');
   }
 
   @override
@@ -176,13 +177,32 @@ class _$FunctionTypeBuilder extends FunctionTypeBuilder {
 
   @override
   _$FunctionType build() {
-    final _$result = _$v ??
-        new _$FunctionType._(
-            returnType: returnType,
-            types: types?.build(),
-            requiredParameters: requiredParameters?.build(),
-            optionalParameters: optionalParameters?.build(),
-            namedParameters: namedParameters?.build());
+    _$FunctionType _$result;
+    try {
+      _$result = _$v ??
+          new _$FunctionType._(
+              returnType: returnType,
+              types: types.build(),
+              requiredParameters: requiredParameters.build(),
+              optionalParameters: optionalParameters.build(),
+              namedParameters: namedParameters.build());
+    } catch (_) {
+      String _$failedField;
+      try {
+        _$failedField = 'types';
+        types.build();
+        _$failedField = 'requiredParameters';
+        requiredParameters.build();
+        _$failedField = 'optionalParameters';
+        optionalParameters.build();
+        _$failedField = 'namedParameters';
+        namedParameters.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            'FunctionType', _$failedField, e.toString());
+      }
+      rethrow;
+    }
     replace(_$result);
     return _$result;
   }

--- a/lib/src/specs/type_reference.g.dart
+++ b/lib/src/specs/type_reference.g.dart
@@ -29,8 +29,10 @@ class _$TypeReference extends TypeReference {
 
   _$TypeReference._({this.symbol, this.url, this.bound, this.types})
       : super._() {
-    if (symbol == null) throw new ArgumentError.notNull('symbol');
-    if (types == null) throw new ArgumentError.notNull('types');
+    if (symbol == null)
+      throw new BuiltValueNullFieldError('TypeReference', 'symbol');
+    if (types == null)
+      throw new BuiltValueNullFieldError('TypeReference', 'types');
   }
 
   @override
@@ -146,9 +148,22 @@ class _$TypeReferenceBuilder extends TypeReferenceBuilder {
 
   @override
   _$TypeReference build() {
-    final _$result = _$v ??
-        new _$TypeReference._(
-            symbol: symbol, url: url, bound: bound, types: types?.build());
+    _$TypeReference _$result;
+    try {
+      _$result = _$v ??
+          new _$TypeReference._(
+              symbol: symbol, url: url, bound: bound, types: types.build());
+    } catch (_) {
+      String _$failedField;
+      try {
+        _$failedField = 'types';
+        types.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            'TypeReference', _$failedField, e.toString());
+      }
+      rethrow;
+    }
     replace(_$result);
     return _$result;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: code_builder
-version: 3.0.1
+version: 3.0.2
 description: A fluent API for generating Dart code
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/code_builder
@@ -13,13 +13,13 @@ web:
 
 dependencies:
   built_collection: '>=1.0.0 <4.0.0'
-  built_value: '>=2.0.0 <5.0.0'
+  built_value: ^5.1.0
   matcher: ^0.12.0
   meta: ^1.0.5
 
 dev_dependencies:
   build_runner: '>=0.4.0 <0.7.0'
-  built_value_generator: '>=2.0.0 <5.0.0'
+  built_value_generator: ^5.1.0
   dart_style: ^1.0.0
   source_gen: '^0.7.0'
   test: ^0.12.0


### PR DESCRIPTION
Update `built_value` and regenerate. This is needed to allow `built_value` to upgrade to the latest `builder_runner`.

The newly generated code provides much better error messages on failure to construct an instance, particularly with nested classes.