### PR TITLE
Remove visibleForTesting annotation for 4 functions

### DIFF
--- a/lib/src/emitter.dart
+++ b/lib/src/emitter.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:meta/meta.dart';
-
 import 'allocator.dart';
 import 'base.dart';
 import 'specs/class.dart';
@@ -24,7 +22,6 @@ import 'visitors.dart';
 /// For every `Spec` in [elements], executing [visit].
 ///
 /// If [elements] is at least 2 elements, inserts [separator] delimiting them.
-@visibleForTesting
 StringSink visitAll<T>(
   Iterable<T> elements,
   StringSink output,

--- a/lib/src/specs/expression/closure.dart
+++ b/lib/src/specs/expression/closure.dart
@@ -4,7 +4,6 @@
 
 part of code_builder.src.specs.expression;
 
-@visibleForTesting
 Expression toClosure(Method method) {
   final withoutTypes = method.rebuild((b) {
     b.returns = null;

--- a/lib/src/specs/expression/invoke.dart
+++ b/lib/src/specs/expression/invoke.dart
@@ -25,7 +25,6 @@ class InvokeExpression extends Expression {
     this.name,
   ]) : type = null;
 
-  @visibleForTesting
   const InvokeExpression.newOf(
     this.target,
     this.positionalArguments, [
@@ -34,7 +33,6 @@ class InvokeExpression extends Expression {
     this.name,
   ]) : type = InvokeExpressionType.newInstance;
 
-  @visibleForTesting
   const InvokeExpression.constOf(
     this.target,
     this.positionalArguments, [


### PR DESCRIPTION
These four functions are called from libraries _not_ in `test/` or `testing/` directories:

* `toClosure` - called from lib/src/specs/method.dart
* `InvokeExpression.constOf` - called from lib/src/specs/reference.dart
* `InvokeExpression.newOf` - called from lib/src/specs/reference.dart
* `visitAll` - called from lib/src/specs/expression.dart