### PR TITLE
Run dartfmt --fix to drop optional new

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ import 'package:code_builder/code_builder.dart';
 import 'package:dart_style/dart_style.dart';
 
 void main() {
-  final animal = new Class((b) => b
+  final animal = Class((b) => b
     ..name = 'Animal'
     ..extend = refer('Organism')
-    ..methods.add(new Method.returnsVoid((b) => b
+    ..methods.add(Method.returnsVoid((b) => b
       ..name = 'eat'
       ..body = const Code('print(\'Yum\')'))));
-  final emitter = new DartEmitter();
-  print(new DartFormatter().format('${animal.accept(emitter)}'));
+  final emitter = DartEmitter();
+  print(DartFormatter().format('${animal.accept(emitter)}'));
 }
 ```
 
@@ -47,18 +47,18 @@ import 'package:code_builder/code_builder.dart';
 import 'package:dart_style/dart_style.dart';
 
 void main() {
-  final library = new Library((b) => b.body.addAll([
-        new Method((b) => b
+  final library = Library((b) => b.body.addAll([
+        Method((b) => b
           ..body = const Code('')
           ..name = 'doThing'
           ..returns = refer('Thing', 'package:a/a.dart')),
-        new Method((b) => b
+        Method((b) => b
           ..body = const Code('')
           ..name = 'doOther'
           ..returns = refer('Other', 'package:b/b.dart')),
       ]));
-  final emitter = new DartEmitter(new Allocator.simplePrefixing());
-  print(new DartFormatter().format('${library.accept(emitter)}'));
+  final emitter = DartEmitter(Allocator.simplePrefixing());
+  print(DartFormatter().format('${library.accept(emitter)}'));
 }
 ```
 

--- a/example/example.dart
+++ b/example/example.dart
@@ -5,7 +5,7 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:dart_style/dart_style.dart';
 
-final _dartfmt = new DartFormatter();
+final _dartfmt = DartFormatter();
 
 void main() {
   print('animalClass():\n${'=' * 40}\n${animalClass()}');
@@ -20,13 +20,13 @@ void main() {
 /// }
 /// ```
 String animalClass() {
-  final animal = new Class((b) => b
+  final animal = Class((b) => b
     ..name = 'Animal'
     ..extend = refer('Organism')
-    ..methods.add(new Method.returnsVoid((b) => b
+    ..methods.add(Method.returnsVoid((b) => b
       ..name = 'eat'
       ..body = refer('print').call([literalString('Yum!')]).code)));
-  return _dartfmt.format('${animal.accept(new DartEmitter())}');
+  return _dartfmt.format('${animal.accept(DartEmitter())}');
 }
 
 /// Outputs:
@@ -40,15 +40,15 @@ String animalClass() {
 /// ```
 String scopedLibrary() {
   final methods = [
-    new Method((b) => b
+    Method((b) => b
       ..body = const Code('')
       ..name = 'doThing'
       ..returns = refer('Thing', 'package:a/a.dart')),
-    new Method((b) => b
+    Method((b) => b
       ..body = const Code('')
       ..name = 'doOther'
       ..returns = refer('Other', 'package:b/b.dart')),
   ];
-  final library = new Library((b) => b.body.addAll(methods));
-  return _dartfmt.format('${library.accept(new DartEmitter.scoped())}');
+  final library = Library((b) => b.body.addAll(methods));
+  return _dartfmt.format('${library.accept(DartEmitter.scoped())}');
 }

--- a/lib/src/allocator.dart
+++ b/lib/src/allocator.dart
@@ -12,7 +12,7 @@ import 'specs/reference.dart';
 /// to resolve all symbols in your generated code.
 abstract class Allocator {
   /// An allocator that does not prefix symbols nor collects imports.
-  static const Allocator none = const _NullAllocator();
+  static const Allocator none = _NullAllocator();
 
   /// Creates a new default allocator that applies no prefixing.
   factory Allocator() = _Allocator;
@@ -46,7 +46,7 @@ abstract class Allocator {
 }
 
 class _Allocator implements Allocator {
-  final _imports = new Set<String>();
+  final _imports = Set<String>();
 
   @override
   String allocate(Reference reference) {
@@ -58,7 +58,7 @@ class _Allocator implements Allocator {
 
   @override
   Iterable<Directive> get imports {
-    return _imports.map((u) => new Directive.import(u));
+    return _imports.map((u) => Directive.import(u));
   }
 }
 
@@ -73,7 +73,7 @@ class _NullAllocator implements Allocator {
 }
 
 class _PrefixedAllocator implements Allocator {
-  static const _doNotPrefix = const ['dart:core'];
+  static const _doNotPrefix = ['dart:core'];
 
   final _imports = <String, int>{};
   var _keys = 1;
@@ -92,7 +92,7 @@ class _PrefixedAllocator implements Allocator {
   @override
   Iterable<Directive> get imports {
     return _imports.keys.map(
-      (u) => new Directive.import(u, as: '_i${_imports[u]}'),
+      (u) => Directive.import(u, as: '_i${_imports[u]}'),
     );
   }
 }

--- a/lib/src/base.dart
+++ b/lib/src/base.dart
@@ -9,7 +9,7 @@ abstract class Spec {
 }
 
 /// Returns a generic [Spec] that is lazily generated when visited.
-Spec lazySpec(Spec Function() generate) => new _LazySpec(generate);
+Spec lazySpec(Spec Function() generate) => _LazySpec(generate);
 
 class _LazySpec implements Spec {
   final Spec Function() generate;

--- a/lib/src/emitter.dart
+++ b/lib/src/emitter.dart
@@ -57,7 +57,7 @@ class DartEmitter extends Object
 
   /// Creates a new instance of [DartEmitter] with simple automatic imports.
   factory DartEmitter.scoped() {
-    return new DartEmitter(new Allocator.simplePrefixing());
+    return DartEmitter(Allocator.simplePrefixing());
   }
 
   static bool _isLambdaBody(Code code) =>
@@ -74,7 +74,7 @@ class DartEmitter extends Object
 
   @override
   visitAnnotation(Expression spec, [StringSink output]) {
-    (output ??= new StringBuffer()).write('@');
+    (output ??= StringBuffer()).write('@');
     spec.accept(this, output);
     output.write(' ');
     return output;
@@ -82,7 +82,7 @@ class DartEmitter extends Object
 
   @override
   visitClass(Class spec, [StringSink output]) {
-    output ??= new StringBuffer();
+    output ??= StringBuffer();
     spec.docs.forEach(output.writeln);
     spec.annotations.forEach((a) => visitAnnotation(a, output));
     if (spec.abstract) {
@@ -128,7 +128,7 @@ class DartEmitter extends Object
 
   @override
   visitConstructor(Constructor spec, String clazz, [StringSink output]) {
-    output ??= new StringBuffer();
+    output ??= StringBuffer();
     spec.docs.forEach(output.writeln);
     spec.annotations.forEach((a) => visitAnnotation(a, output));
     if (spec.external) {
@@ -212,7 +212,7 @@ class DartEmitter extends Object
 
   @override
   visitDirective(Directive spec, [StringSink output]) {
-    output ??= new StringBuffer();
+    output ??= StringBuffer();
     if (spec.type == DirectiveType.import) {
       output.write('import ');
     } else {
@@ -240,7 +240,7 @@ class DartEmitter extends Object
 
   @override
   visitField(Field spec, [StringSink output]) {
-    output ??= new StringBuffer();
+    output ??= StringBuffer();
     spec.docs.forEach(output.writeln);
     spec.annotations.forEach((a) => visitAnnotation(a, output));
     if (spec.static) {
@@ -274,9 +274,9 @@ class DartEmitter extends Object
 
   @override
   visitLibrary(Library spec, [StringSink output]) {
-    output ??= new StringBuffer();
+    output ??= StringBuffer();
     // Process the body first in order to prime the allocators.
-    final body = new StringBuffer();
+    final body = StringBuffer();
     for (final spec in spec.body) {
       spec.accept(this, body);
       if (spec is Method && _isLambdaMethod(spec)) {
@@ -296,7 +296,7 @@ class DartEmitter extends Object
 
   @override
   visitFunctionType(FunctionType spec, [StringSink output]) {
-    output ??= new StringBuffer();
+    output ??= StringBuffer();
     if (spec.returnType != null) {
       spec.returnType.accept(this, output);
       output.write(' ');
@@ -336,7 +336,7 @@ class DartEmitter extends Object
 
   @override
   visitMethod(Method spec, [StringSink output]) {
-    output ??= new StringBuffer();
+    output ??= StringBuffer();
     spec.docs.forEach(output.writeln);
     spec.annotations.forEach((a) => visitAnnotation(a, output));
     if (spec.external) {
@@ -452,7 +452,7 @@ class DartEmitter extends Object
 
   @override
   visitReference(Reference spec, [StringSink output]) {
-    return (output ??= new StringBuffer())..write(allocator.allocate(spec));
+    return (output ??= StringBuffer())..write(allocator.allocate(spec));
   }
 
   @override
@@ -460,7 +460,7 @@ class DartEmitter extends Object
 
   @override
   visitType(TypeReference spec, [StringSink output]) {
-    output ??= new StringBuffer();
+    output ??= StringBuffer();
     // Intentionally not .accept to avoid stack overflow.
     visitReference(spec, output);
     if (spec.bound != null) {
@@ -473,7 +473,7 @@ class DartEmitter extends Object
 
   @override
   visitTypeParameters(Iterable<Reference> specs, [StringSink output]) {
-    output ??= new StringBuffer();
+    output ??= StringBuffer();
     if (specs.isNotEmpty) {
       output
         ..write('<')

--- a/lib/src/matchers.dart
+++ b/lib/src/matchers.dart
@@ -16,7 +16,7 @@ Matcher equalsDart(
   String source, [
   DartEmitter emitter,
 ]) =>
-    new EqualsDart._(EqualsDart._format(source), emitter ?? new DartEmitter());
+    EqualsDart._(EqualsDart._format(source), emitter ?? DartEmitter());
 
 /// Implementation detail of using the [equalsDart] matcher.
 ///

--- a/lib/src/specs/class.dart
+++ b/lib/src/specs/class.dart
@@ -72,22 +72,22 @@ abstract class ClassBuilder extends Object
   bool abstract = false;
 
   @override
-  ListBuilder<Expression> annotations = new ListBuilder<Expression>();
+  ListBuilder<Expression> annotations = ListBuilder<Expression>();
 
   @override
-  ListBuilder<String> docs = new ListBuilder<String>();
+  ListBuilder<String> docs = ListBuilder<String>();
 
   Reference extend;
 
-  ListBuilder<Reference> implements = new ListBuilder<Reference>();
-  ListBuilder<Reference> mixins = new ListBuilder<Reference>();
+  ListBuilder<Reference> implements = ListBuilder<Reference>();
+  ListBuilder<Reference> mixins = ListBuilder<Reference>();
 
   @override
-  ListBuilder<Reference> types = new ListBuilder<Reference>();
+  ListBuilder<Reference> types = ListBuilder<Reference>();
 
-  ListBuilder<Constructor> constructors = new ListBuilder<Constructor>();
-  ListBuilder<Method> methods = new ListBuilder<Method>();
-  ListBuilder<Field> fields = new ListBuilder<Field>();
+  ListBuilder<Constructor> constructors = ListBuilder<Constructor>();
+  ListBuilder<Method> methods = ListBuilder<Method>();
+  ListBuilder<Field> fields = ListBuilder<Field>();
 
   /// Name of the class.
   String name;

--- a/lib/src/specs/code.dart
+++ b/lib/src/specs/code.dart
@@ -50,7 +50,7 @@ abstract class Block implements Built<Block, BlockBuilder>, Code, Spec {
   factory Block([void updates(BlockBuilder b)]) = _$Block;
 
   factory Block.of(Iterable<Code> statements) {
-    return new Block((b) => b..statements.addAll(statements));
+    return Block((b) => b..statements.addAll(statements));
   }
 
   Block._();
@@ -75,7 +75,7 @@ abstract class BlockBuilder implements Builder<Block, BlockBuilder> {
     statements.add(expression.statement);
   }
 
-  ListBuilder<Code> statements = new ListBuilder<Code>();
+  ListBuilder<Code> statements = ListBuilder<Code>();
 }
 
 /// Knowledge of different types of blocks of code in Dart.
@@ -94,7 +94,7 @@ abstract class CodeEmitter implements CodeVisitor<StringSink> {
 
   @override
   visitBlock(Block block, [StringSink output]) {
-    output ??= new StringBuffer();
+    output ??= StringBuffer();
     return visitAll<Code>(block.statements, output, (statement) {
       statement.accept(this, output);
     }, '\n');
@@ -102,13 +102,13 @@ abstract class CodeEmitter implements CodeVisitor<StringSink> {
 
   @override
   visitStaticCode(StaticCode code, [StringSink output]) {
-    output ??= new StringBuffer();
+    output ??= StringBuffer();
     return output..write(code.code);
   }
 
   @override
   visitScopedCode(ScopedCode code, [StringSink output]) {
-    output ??= new StringBuffer();
+    output ??= StringBuffer();
     return output..write(code.code(allocator.allocate));
   }
 }
@@ -126,7 +126,7 @@ class LazyCode implements Code {
 }
 
 /// Returns a generic [Code] that is lazily generated when visited.
-Code lazyCode(Code Function() generate) => new _LazyCode(generate);
+Code lazyCode(Code Function() generate) => _LazyCode(generate);
 
 class _LazyCode implements Code {
   final Code Function() generate;

--- a/lib/src/specs/constructor.dart
+++ b/lib/src/specs/constructor.dart
@@ -72,19 +72,19 @@ abstract class ConstructorBuilder extends Object
   ConstructorBuilder._();
 
   @override
-  ListBuilder<Expression> annotations = new ListBuilder<Expression>();
+  ListBuilder<Expression> annotations = ListBuilder<Expression>();
 
   @override
-  ListBuilder<String> docs = new ListBuilder<String>();
+  ListBuilder<String> docs = ListBuilder<String>();
 
   /// Optional parameters.
-  ListBuilder<Parameter> optionalParameters = new ListBuilder<Parameter>();
+  ListBuilder<Parameter> optionalParameters = ListBuilder<Parameter>();
 
   /// Required parameters.
-  ListBuilder<Parameter> requiredParameters = new ListBuilder<Parameter>();
+  ListBuilder<Parameter> requiredParameters = ListBuilder<Parameter>();
 
   /// Constructor initializer statements.
-  ListBuilder<Code> initializers = new ListBuilder<Code>();
+  ListBuilder<Code> initializers = ListBuilder<Code>();
 
   /// Body of the constructor.
   Code body;

--- a/lib/src/specs/directive.dart
+++ b/lib/src/specs/directive.dart
@@ -20,7 +20,7 @@ abstract class Directive implements Built<Directive, DirectiveBuilder>, Spec {
     List<String> show = const [],
     List<String> hide = const [],
   }) =>
-      new Directive((builder) => builder
+      Directive((builder) => builder
         ..as = as
         ..type = DirectiveType.import
         ..url = url
@@ -33,7 +33,7 @@ abstract class Directive implements Built<Directive, DirectiveBuilder>, Spec {
     List<String> show = const [],
     List<String> hide = const [],
   }) =>
-      new Directive((builder) => builder
+      Directive((builder) => builder
         ..as = as
         ..type = DirectiveType.import
         ..url = url
@@ -46,7 +46,7 @@ abstract class Directive implements Built<Directive, DirectiveBuilder>, Spec {
     List<String> show = const [],
     List<String> hide = const [],
   }) =>
-      new Directive((builder) => builder
+      Directive((builder) => builder
         ..type = DirectiveType.export
         ..url = url
         ..show.addAll(show)

--- a/lib/src/specs/expression.dart
+++ b/lib/src/specs/expression.dart
@@ -34,21 +34,21 @@ abstract class Expression implements Spec {
   /// The expression as a valid [Code] block.
   ///
   /// Also see [statement].
-  Code get code => new ToCodeExpression(this, false);
+  Code get code => ToCodeExpression(this, false);
 
   /// The expression as a valid [Code] block with a trailing `;`.
-  Code get statement => new ToCodeExpression(this, true);
+  Code get statement => ToCodeExpression(this, true);
 
   /// Returns the result of `this` `&&` [other].
   Expression and(Expression other) {
-    return new BinaryExpression._(expression, other, '&&');
+    return BinaryExpression._(expression, other, '&&');
   }
 
   /// Returns the result of `this` `as` [other].
   Expression asA(Expression other) {
-    return new CodeExpression(new Block.of([
+    return CodeExpression(Block.of([
       const Code('('),
-      new BinaryExpression._(
+      BinaryExpression._(
         expression,
         other,
         'as',
@@ -59,9 +59,9 @@ abstract class Expression implements Spec {
 
   /// Returns accessing the index operator (`[]`) on `this`.
   Expression index(Expression index) {
-    return new BinaryExpression._(
+    return BinaryExpression._(
       expression,
-      new CodeExpression(new Block.of([
+      CodeExpression(Block.of([
         const Code('['),
         index.code,
         const Code(']'),
@@ -72,7 +72,7 @@ abstract class Expression implements Spec {
 
   /// Returns the result of `this` `is` [other].
   Expression isA(Expression other) {
-    return new BinaryExpression._(
+    return BinaryExpression._(
       expression,
       other,
       'is',
@@ -81,7 +81,7 @@ abstract class Expression implements Spec {
 
   /// Returns the result of `this` `is!` [other].
   Expression isNotA(Expression other) {
-    return new BinaryExpression._(
+    return BinaryExpression._(
       expression,
       other,
       'is!',
@@ -90,7 +90,7 @@ abstract class Expression implements Spec {
 
   /// Returns the result of `this` `==` [other].
   Expression equalTo(Expression other) {
-    return new BinaryExpression._(
+    return BinaryExpression._(
       expression,
       other,
       '==',
@@ -99,7 +99,7 @@ abstract class Expression implements Spec {
 
   /// Returns the result of `this` `!=` [other].
   Expression notEqualTo(Expression other) {
-    return new BinaryExpression._(
+    return BinaryExpression._(
       expression,
       other,
       '!=',
@@ -108,7 +108,7 @@ abstract class Expression implements Spec {
 
   /// Returns the result of `this` `>` [other].
   Expression greaterThan(Expression other) {
-    return new BinaryExpression._(
+    return BinaryExpression._(
       expression,
       other,
       '>',
@@ -117,7 +117,7 @@ abstract class Expression implements Spec {
 
   /// Returns the result of `this` `<` [other].
   Expression lessThan(Expression other) {
-    return new BinaryExpression._(
+    return BinaryExpression._(
       expression,
       other,
       '<',
@@ -126,7 +126,7 @@ abstract class Expression implements Spec {
 
   /// Returns the result of `this` `>=` [other].
   Expression greaterOrEqualTo(Expression other) {
-    return new BinaryExpression._(
+    return BinaryExpression._(
       expression,
       other,
       '>=',
@@ -135,7 +135,7 @@ abstract class Expression implements Spec {
 
   /// Returns the result of `this` `<=` [other].
   Expression lessOrEqualTo(Expression other) {
-    return new BinaryExpression._(
+    return BinaryExpression._(
       expression,
       other,
       '<=',
@@ -144,7 +144,7 @@ abstract class Expression implements Spec {
 
   /// Returns the result of `this` `+` [other].
   Expression operatorAdd(Expression other) {
-    return new BinaryExpression._(
+    return BinaryExpression._(
       expression,
       other,
       '+',
@@ -153,7 +153,7 @@ abstract class Expression implements Spec {
 
   /// Returns the result of `this` `-` [other].
   Expression operatorSubstract(Expression other) {
-    return new BinaryExpression._(
+    return BinaryExpression._(
       expression,
       other,
       '-',
@@ -162,7 +162,7 @@ abstract class Expression implements Spec {
 
   /// Returns the result of `this` `/` [other].
   Expression operatorDivide(Expression other) {
-    return new BinaryExpression._(
+    return BinaryExpression._(
       expression,
       other,
       '/',
@@ -171,7 +171,7 @@ abstract class Expression implements Spec {
 
   /// Returns the result of `this` `*` [other].
   Expression operatorMultiply(Expression other) {
-    return new BinaryExpression._(
+    return BinaryExpression._(
       expression,
       other,
       '*',
@@ -180,7 +180,7 @@ abstract class Expression implements Spec {
 
   /// Returns the result of `this` `%` [other].
   Expression operatorEuclideanModulo(Expression other) {
-    return new BinaryExpression._(
+    return BinaryExpression._(
       expression,
       other,
       '%',
@@ -188,16 +188,16 @@ abstract class Expression implements Spec {
   }
 
   Expression conditional(Expression whenTrue, Expression whenFalse) {
-    return new BinaryExpression._(
+    return BinaryExpression._(
       expression,
-      new BinaryExpression._(whenTrue, whenFalse, ':'),
+      BinaryExpression._(whenTrue, whenFalse, ':'),
       '?',
     );
   }
 
   /// This expression preceded by `await`.
   Expression get awaited {
-    return new BinaryExpression._(
+    return BinaryExpression._(
       const LiteralExpression._('await'),
       this,
       '',
@@ -206,7 +206,7 @@ abstract class Expression implements Spec {
 
   /// Return `{other} = {this}`.
   Expression assign(Expression other) {
-    return new BinaryExpression._(
+    return BinaryExpression._(
       this,
       other,
       '=',
@@ -215,7 +215,7 @@ abstract class Expression implements Spec {
 
   /// Return `{other} ??= {this}`.
   Expression assignNullAware(Expression other) {
-    return new BinaryExpression._(
+    return BinaryExpression._(
       this,
       other,
       '??=',
@@ -224,12 +224,12 @@ abstract class Expression implements Spec {
 
   /// Return `var {name} = {this}`.
   Expression assignVar(String name, [Reference type]) {
-    return new BinaryExpression._(
+    return BinaryExpression._(
       type == null
-          ? new LiteralExpression._('var $name')
-          : new BinaryExpression._(
+          ? LiteralExpression._('var $name')
+          : BinaryExpression._(
               type.expression,
-              new LiteralExpression._(name),
+              LiteralExpression._(name),
               '',
             ),
       this,
@@ -239,10 +239,10 @@ abstract class Expression implements Spec {
 
   /// Return `final {name} = {this}`.
   Expression assignFinal(String name, [Reference type]) {
-    return new BinaryExpression._(
+    return BinaryExpression._(
       type == null
           ? const LiteralExpression._('final')
-          : new BinaryExpression._(
+          : BinaryExpression._(
               const LiteralExpression._('final'),
               type.expression,
               '',
@@ -254,10 +254,10 @@ abstract class Expression implements Spec {
 
   /// Return `const {name} = {this}`.
   Expression assignConst(String name, [Reference type]) {
-    return new BinaryExpression._(
+    return BinaryExpression._(
       type == null
           ? const LiteralExpression._('const')
-          : new BinaryExpression._(
+          : BinaryExpression._(
               const LiteralExpression._('const'),
               type.expression,
               '',
@@ -273,7 +273,7 @@ abstract class Expression implements Spec {
     Map<String, Expression> namedArguments = const {},
     List<Reference> typeArguments = const [],
   ]) {
-    return new InvokeExpression._(
+    return InvokeExpression._(
       this,
       positionalArguments.toList(),
       namedArguments,
@@ -283,9 +283,9 @@ abstract class Expression implements Spec {
 
   /// Returns an expression accessing `.<name>` on this expression.
   Expression property(String name) {
-    return new BinaryExpression._(
+    return BinaryExpression._(
       this,
-      new LiteralExpression._(name),
+      LiteralExpression._(name),
       '.',
       false,
     );
@@ -293,9 +293,9 @@ abstract class Expression implements Spec {
 
   /// Returns an expression accessing `?.<name>` on this expression.
   Expression nullSafeProperty(String name) {
-    return new BinaryExpression._(
+    return BinaryExpression._(
       this,
-      new LiteralExpression._(name),
+      LiteralExpression._(name),
       '?.',
       false,
     );
@@ -303,7 +303,7 @@ abstract class Expression implements Spec {
 
   /// This expression preceded by `return`.
   Expression get returned {
-    return new BinaryExpression._(
+    return BinaryExpression._(
       const LiteralExpression._('return'),
       this,
       '',
@@ -316,8 +316,8 @@ abstract class Expression implements Spec {
 }
 
 /// Creates `typedef {name} =`.
-Code createTypeDef(String name, FunctionType type) => new BinaryExpression._(
-        new LiteralExpression._('typedef $name'), type.expression, '=')
+Code createTypeDef(String name, FunctionType type) => BinaryExpression._(
+        LiteralExpression._('typedef $name'), type.expression, '=')
     .statement;
 
 class ToCodeExpression implements Code {
@@ -359,7 +359,7 @@ abstract class ExpressionVisitor<T> implements SpecVisitor<T> {
 abstract class ExpressionEmitter implements ExpressionVisitor<StringSink> {
   @override
   visitToCodeExpression(ToCodeExpression expression, [StringSink output]) {
-    output ??= new StringBuffer();
+    output ??= StringBuffer();
     expression.code.accept(this, output);
     if (expression.isStatement) {
       output.write(';');
@@ -369,7 +369,7 @@ abstract class ExpressionEmitter implements ExpressionVisitor<StringSink> {
 
   @override
   visitBinaryExpression(BinaryExpression expression, [StringSink output]) {
-    output ??= new StringBuffer();
+    output ??= StringBuffer();
     expression.left.accept(this, output);
     if (expression.addSpace) {
       output.write(' ');
@@ -384,20 +384,20 @@ abstract class ExpressionEmitter implements ExpressionVisitor<StringSink> {
 
   @override
   visitClosureExpression(ClosureExpression expression, [StringSink output]) {
-    output ??= new StringBuffer();
+    output ??= StringBuffer();
     return expression.method.accept(this, output);
   }
 
   @override
   visitCodeExpression(CodeExpression expression, [StringSink output]) {
-    output ??= new StringBuffer();
+    output ??= StringBuffer();
     final visitor = this as CodeVisitor<StringSink>;
     return expression.code.accept(visitor, output);
   }
 
   @override
   visitInvokeExpression(InvokeExpression expression, [StringSink output]) {
-    output ??= new StringBuffer();
+    output ??= StringBuffer();
     switch (expression.type) {
       case InvokeExpressionType.newInstance:
         output.write('new ');
@@ -434,7 +434,7 @@ abstract class ExpressionEmitter implements ExpressionVisitor<StringSink> {
 
   @override
   visitLiteralExpression(LiteralExpression expression, [StringSink output]) {
-    output ??= new StringBuffer();
+    output ??= StringBuffer();
     return output..write(expression.literal);
   }
 
@@ -451,7 +451,7 @@ abstract class ExpressionEmitter implements ExpressionVisitor<StringSink> {
     LiteralListExpression expression, [
     StringSink output,
   ]) {
-    output ??= new StringBuffer();
+    output ??= StringBuffer();
     if (expression.isConst) {
       output.write('const ');
     }
@@ -472,7 +472,7 @@ abstract class ExpressionEmitter implements ExpressionVisitor<StringSink> {
     LiteralMapExpression expression, [
     StringSink output,
   ]) {
-    output ??= new StringBuffer();
+    output ??= StringBuffer();
     if (expression.isConst) {
       output.write('const ');
     }

--- a/lib/src/specs/expression/closure.dart
+++ b/lib/src/specs/expression/closure.dart
@@ -9,7 +9,7 @@ Expression toClosure(Method method) {
     b.returns = null;
     b.types.clear();
   });
-  return new ClosureExpression._(withoutTypes);
+  return ClosureExpression._(withoutTypes);
 }
 
 class ClosureExpression extends Expression {

--- a/lib/src/specs/expression/literal.dart
+++ b/lib/src/specs/expression/literal.dart
@@ -29,23 +29,23 @@ Expression literal(Object literal, {Expression onError(Object value)}) {
   if (onError != null) {
     return onError(literal);
   }
-  throw new UnsupportedError('Not a supported literal type: $literal.');
+  throw UnsupportedError('Not a supported literal type: $literal.');
 }
 
 /// Represents the literal value `true`.
-const Expression literalTrue = const LiteralExpression._('true');
+const Expression literalTrue = LiteralExpression._('true');
 
 /// Represents the literal value `false`.
-const Expression literalFalse = const LiteralExpression._('false');
+const Expression literalFalse = LiteralExpression._('false');
 
 /// Create a literal expression from a boolean [value].
 Expression literalBool(bool value) => value ? literalTrue : literalFalse;
 
 /// Represents the literal value `null`.
-const Expression literalNull = const LiteralExpression._('null');
+const Expression literalNull = LiteralExpression._('null');
 
 /// Create a literal expression from a number [value].
-Expression literalNum(num value) => new LiteralExpression._('$value');
+Expression literalNum(num value) => LiteralExpression._('$value');
 
 /// Create a literal expression from a string [value].
 ///
@@ -56,20 +56,20 @@ Expression literalNum(num value) => new LiteralExpression._('$value');
 /// If [raw] is `false` escapes single quotes in the value.
 Expression literalString(String value, {bool raw = false}) {
   if (raw && value.contains('\'')) {
-    throw new ArgumentError('Cannot include a single quote in a raw string');
+    throw ArgumentError('Cannot include a single quote in a raw string');
   }
   final escaped = value.replaceAll('\'', '\\\'');
-  return new LiteralExpression._("${raw ? 'r' : ''}'$escaped'");
+  return LiteralExpression._("${raw ? 'r' : ''}'$escaped'");
 }
 
 /// Creates a literal list expression from [values].
 LiteralListExpression literalList(Iterable<Object> values, [Reference type]) {
-  return new LiteralListExpression._(false, values.toList(), type);
+  return LiteralListExpression._(false, values.toList(), type);
 }
 
 /// Creates a literal `const` list expression from [values].
 LiteralListExpression literalConstList(List<Object> values, [Reference type]) {
-  return new LiteralListExpression._(true, values, type);
+  return LiteralListExpression._(true, values, type);
 }
 
 /// Create a literal map expression from [values].
@@ -78,7 +78,7 @@ LiteralMapExpression literalMap(
   Reference keyType,
   Reference valueType,
 ]) {
-  return new LiteralMapExpression._(false, values, keyType, valueType);
+  return LiteralMapExpression._(false, values, keyType, valueType);
 }
 
 /// Create a literal `const` map expression from [values].
@@ -87,7 +87,7 @@ LiteralMapExpression literalConstMap(
   Reference keyType,
   Reference valueType,
 ]) {
-  return new LiteralMapExpression._(true, values, keyType, valueType);
+  return LiteralMapExpression._(true, values, keyType, valueType);
 }
 
 /// Represents a literal value in Dart source code.

--- a/lib/src/specs/field.dart
+++ b/lib/src/specs/field.dart
@@ -69,10 +69,10 @@ abstract class FieldBuilder extends Object
   FieldBuilder._();
 
   @override
-  ListBuilder<Expression> annotations = new ListBuilder<Expression>();
+  ListBuilder<Expression> annotations = ListBuilder<Expression>();
 
   @override
-  ListBuilder<String> docs = new ListBuilder<String>();
+  ListBuilder<String> docs = ListBuilder<String>();
 
   /// Field assignment, if any.
   Code assignment;

--- a/lib/src/specs/library.dart
+++ b/lib/src/specs/library.dart
@@ -32,6 +32,6 @@ abstract class LibraryBuilder implements Builder<Library, LibraryBuilder> {
   factory LibraryBuilder() = _$LibraryBuilder;
   LibraryBuilder._();
 
-  ListBuilder<Spec> body = new ListBuilder<Spec>();
-  ListBuilder<Directive> directives = new ListBuilder<Directive>();
+  ListBuilder<Spec> body = ListBuilder<Spec>();
+  ListBuilder<Directive> directives = ListBuilder<Directive>();
 }

--- a/lib/src/specs/method.dart
+++ b/lib/src/specs/method.dart
@@ -26,7 +26,7 @@ abstract class Method extends Object
   factory Method([void updates(MethodBuilder b)]) = _$Method;
 
   factory Method.returnsVoid([void updates(MethodBuilder b)]) {
-    return new Method((b) {
+    return Method((b) {
       if (updates != null) {
         updates(b);
       }
@@ -105,19 +105,19 @@ abstract class MethodBuilder extends Object
   MethodBuilder._();
 
   @override
-  ListBuilder<Expression> annotations = new ListBuilder<Expression>();
+  ListBuilder<Expression> annotations = ListBuilder<Expression>();
 
   @override
-  ListBuilder<String> docs = new ListBuilder<String>();
+  ListBuilder<String> docs = ListBuilder<String>();
 
   @override
-  ListBuilder<Reference> types = new ListBuilder<Reference>();
+  ListBuilder<Reference> types = ListBuilder<Reference>();
 
   /// Optional parameters.
-  ListBuilder<Parameter> optionalParameters = new ListBuilder<Parameter>();
+  ListBuilder<Parameter> optionalParameters = ListBuilder<Parameter>();
 
   /// Required parameters.
-  ListBuilder<Parameter> requiredParameters = new ListBuilder<Parameter>();
+  ListBuilder<Parameter> requiredParameters = ListBuilder<Parameter>();
 
   /// Body of the method.
   Code body;
@@ -216,13 +216,13 @@ abstract class ParameterBuilder extends Object
   bool toThis = false;
 
   @override
-  ListBuilder<Expression> annotations = new ListBuilder<Expression>();
+  ListBuilder<Expression> annotations = ListBuilder<Expression>();
 
   @override
-  ListBuilder<String> docs = new ListBuilder<String>();
+  ListBuilder<String> docs = ListBuilder<String>();
 
   @override
-  ListBuilder<Reference> types = new ListBuilder<Reference>();
+  ListBuilder<Reference> types = ListBuilder<Reference>();
 
   /// Type of the parameter;
   Reference type;

--- a/lib/src/specs/reference.dart
+++ b/lib/src/specs/reference.dart
@@ -15,7 +15,7 @@ import 'type_reference.dart';
 
 /// Short-hand for `new Reference(symbol, url)`.
 Reference refer(String symbol, [String url]) {
-  return new Reference(symbol, url);
+  return Reference(symbol, url);
 }
 
 /// A reference to [symbol], such as a class, or top-level method or field.
@@ -55,7 +55,7 @@ class Reference extends Expression implements Spec {
     Map<String, Expression> namedArguments = const {},
     List<Reference> typeArguments = const [],
   ]) {
-    return new InvokeExpression.newOf(
+    return InvokeExpression.newOf(
       this,
       positionalArguments.toList(),
       namedArguments,
@@ -71,7 +71,7 @@ class Reference extends Expression implements Spec {
     Map<String, Expression> namedArguments = const {},
     List<Reference> typeArguments = const [],
   ]) {
-    return new InvokeExpression.newOf(
+    return InvokeExpression.newOf(
       this,
       positionalArguments.toList(),
       namedArguments,
@@ -86,7 +86,7 @@ class Reference extends Expression implements Spec {
     Map<String, Expression> namedArguments = const {},
     List<Reference> typeArguments = const [],
   ]) {
-    return new InvokeExpression.constOf(
+    return InvokeExpression.constOf(
       this,
       positionalArguments.toList(),
       namedArguments,
@@ -102,7 +102,7 @@ class Reference extends Expression implements Spec {
     Map<String, Expression> namedArguments = const {},
     List<Reference> typeArguments = const [],
   ]) {
-    return new InvokeExpression.constOf(
+    return InvokeExpression.constOf(
       this,
       positionalArguments.toList(),
       namedArguments,
@@ -113,7 +113,7 @@ class Reference extends Expression implements Spec {
 
   @override
   Expression get expression {
-    return new CodeExpression(new Code.scope((a) => a(this)));
+    return CodeExpression(Code.scope((a) => a(this)));
   }
 
   @override
@@ -123,7 +123,7 @@ class Reference extends Expression implements Spec {
       .toString();
 
   /// Returns as a [TypeReference], which allows adding generic type parameters.
-  Reference get type => new TypeReference((b) => b
+  Reference get type => TypeReference((b) => b
     ..url = url
     ..symbol = symbol);
 }

--- a/lib/src/specs/type_function.dart
+++ b/lib/src/specs/type_function.dart
@@ -63,7 +63,7 @@ abstract class FunctionType extends Expression
     Map<String, Expression> namedArguments = const {},
     List<Reference> typeArguments = const [],
   ]) =>
-      throw new UnsupportedError('Cannot "new" a function type.');
+      throw UnsupportedError('Cannot "new" a function type.');
 
   @override
   Expression newInstanceNamed(
@@ -72,7 +72,7 @@ abstract class FunctionType extends Expression
     Map<String, Expression> namedArguments = const {},
     List<Reference> typeArguments = const [],
   ]) =>
-      throw new UnsupportedError('Cannot "new" a function type.');
+      throw UnsupportedError('Cannot "new" a function type.');
 
   @override
   Expression constInstance(
@@ -80,7 +80,7 @@ abstract class FunctionType extends Expression
     Map<String, Expression> namedArguments = const {},
     List<Reference> typeArguments = const [],
   ]) =>
-      throw new UnsupportedError('Cannot "const" a function type.');
+      throw UnsupportedError('Cannot "const" a function type.');
 
   @override
   Expression constInstanceNamed(
@@ -89,7 +89,7 @@ abstract class FunctionType extends Expression
     Map<String, Expression> namedArguments = const {},
     List<Reference> typeArguments = const [],
   ]) =>
-      throw new UnsupportedError('Cannot "const" a function type.');
+      throw UnsupportedError('Cannot "const" a function type.');
 
   /// A typedef assignment to this type.
   Code toTypeDef(String name) => createTypeDef(name, this);
@@ -105,12 +105,12 @@ abstract class FunctionTypeBuilder extends Object
   Reference returnType;
 
   @override
-  ListBuilder<Reference> types = new ListBuilder<Reference>();
+  ListBuilder<Reference> types = ListBuilder<Reference>();
 
-  ListBuilder<Reference> requiredParameters = new ListBuilder<Reference>();
+  ListBuilder<Reference> requiredParameters = ListBuilder<Reference>();
 
-  ListBuilder<Reference> optionalParameters = new ListBuilder<Reference>();
+  ListBuilder<Reference> optionalParameters = ListBuilder<Reference>();
 
   MapBuilder<String, Reference> namedParameters =
-      new MapBuilder<String, Reference>();
+      MapBuilder<String, Reference>();
 }

--- a/lib/src/specs/type_reference.dart
+++ b/lib/src/specs/type_reference.dart
@@ -48,7 +48,7 @@ abstract class TypeReference extends Expression
 
   @override
   Expression get expression {
-    return new CodeExpression(new Code.scope((a) => a(this)));
+    return CodeExpression(Code.scope((a) => a(this)));
   }
 
   @override
@@ -60,7 +60,7 @@ abstract class TypeReference extends Expression
     Map<String, Expression> namedArguments = const {},
     List<Reference> typeArguments = const [],
   ]) {
-    return new InvokeExpression.newOf(
+    return InvokeExpression.newOf(
       this,
       positionalArguments.toList(),
       namedArguments,
@@ -76,7 +76,7 @@ abstract class TypeReference extends Expression
     Map<String, Expression> namedArguments = const {},
     List<Reference> typeArguments = const [],
   ]) {
-    return new InvokeExpression.newOf(
+    return InvokeExpression.newOf(
       this,
       positionalArguments.toList(),
       namedArguments,
@@ -91,7 +91,7 @@ abstract class TypeReference extends Expression
     Map<String, Expression> namedArguments = const {},
     List<Reference> typeArguments = const [],
   ]) {
-    return new InvokeExpression.constOf(
+    return InvokeExpression.constOf(
       this,
       positionalArguments.toList(),
       namedArguments,
@@ -107,7 +107,7 @@ abstract class TypeReference extends Expression
     Map<String, Expression> namedArguments = const {},
     List<Reference> typeArguments = const [],
   ]) {
-    return new InvokeExpression.constOf(
+    return InvokeExpression.constOf(
       this,
       positionalArguments.toList(),
       namedArguments,
@@ -132,5 +132,5 @@ abstract class TypeReferenceBuilder extends Object
   Reference bound;
 
   @override
-  ListBuilder<Reference> types = new ListBuilder<Reference>();
+  ListBuilder<Reference> types = ListBuilder<Reference>();
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: code_builder
-version: 3.1.2
+version: 3.1.3-dev
 
 description: A fluent API for generating Dart code
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/code_builder
 
 environment:
-  sdk: '>=2.0.0-dev <3.0.0'
+  sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
   built_collection: '>=1.0.0 <4.0.0'

--- a/test/allocator_test.dart
+++ b/test/allocator_test.dart
@@ -14,12 +14,12 @@ void main() {
     Allocator allocator;
 
     test('should return the exact (non-prefixed) symbol', () {
-      allocator = new Allocator();
+      allocator = Allocator();
       expect(allocator.allocate(refer('Foo', 'package:foo')), 'Foo');
     });
 
     test('should collect import URLs', () {
-      allocator = new Allocator()
+      allocator = Allocator()
         ..allocate(refer('List', 'dart:core'))
         ..allocate(refer('LinkedHashMap', 'dart:collection'))
         ..allocate(refer('someSymbol'));
@@ -36,7 +36,7 @@ void main() {
     });
 
     test('.simplePrefixing should add import prefixes', () {
-      allocator = new Allocator.simplePrefixing();
+      allocator = Allocator.simplePrefixing();
       expect(
         allocator.allocate(refer('List', 'dart:core')),
         'List',

--- a/test/common.dart
+++ b/test/common.dart
@@ -5,7 +5,7 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:dart_style/dart_style.dart';
 
-final DartFormatter _dartfmt = new DartFormatter();
+final DartFormatter _dartfmt = DartFormatter();
 String _format(String source) {
   try {
     return _dartfmt.format(source);

--- a/test/e2e/injection_test.dart
+++ b/test/e2e/injection_test.dart
@@ -16,18 +16,18 @@ void main() {
     final $Module = refer('Module', 'package:app/module.dart');
     final $Thing = refer('Thing', 'package:app/thing.dart');
 
-    final clazz = new ClassBuilder()
+    final clazz = ClassBuilder()
       ..name = 'Injector'
       ..implements.add($App)
-      ..fields.add(new Field((b) => b
+      ..fields.add(Field((b) => b
         ..modifier = FieldModifier.final$
         ..name = '_module'
         ..type = $Module.type))
-      ..constructors.add(new Constructor((b) => b
-        ..requiredParameters.add(new Parameter((b) => b
+      ..constructors.add(Constructor((b) => b
+        ..requiredParameters.add(Parameter((b) => b
           ..name = '_module'
           ..toThis = true))))
-      ..methods.add(new Method((b) => b
+      ..methods.add(Method((b) => b
         ..name = 'getThing'
         ..body = $Thing.newInstance([
           refer('_module').property('get1').call([]),
@@ -61,7 +61,7 @@ void main() {
           @override
           _i3.Thing getThing() => new _i3.Thing(_module.get1(), _module.get2());
         }
-      ''', new DartEmitter(new Allocator.simplePrefixing())),
+      ''', DartEmitter(Allocator.simplePrefixing())),
     );
   });
 }

--- a/test/specs/class_test.dart
+++ b/test/specs/class_test.dart
@@ -12,7 +12,7 @@ void main() {
 
   test('should create a class', () {
     expect(
-      new Class((b) => b..name = 'Foo'),
+      Class((b) => b..name = 'Foo'),
       equalsDart(r'''
         class Foo {}
       '''),
@@ -21,7 +21,7 @@ void main() {
 
   test('should create an abstract class', () {
     expect(
-      new Class((b) => b
+      Class((b) => b
         ..name = 'Foo'
         ..abstract = true),
       equalsDart(r'''
@@ -32,7 +32,7 @@ void main() {
 
   test('should create a class with documentations', () {
     expect(
-      new Class(
+      Class(
         (b) => b
           ..name = 'Foo'
           ..docs.addAll(
@@ -50,7 +50,7 @@ void main() {
 
   test('should create a class with annotations', () {
     expect(
-      new Class(
+      Class(
         (b) => b
           ..name = 'Foo'
           ..annotations.addAll([
@@ -68,7 +68,7 @@ void main() {
 
   test('should create a class with a generic type', () {
     expect(
-      new Class((b) => b
+      Class((b) => b
         ..name = 'List'
         ..types.add(refer('T'))),
       equalsDart(r'''
@@ -79,7 +79,7 @@ void main() {
 
   test('should create a class with multiple generic types', () {
     expect(
-      new Class(
+      Class(
         (b) => b
           ..name = 'Map'
           ..types.addAll([
@@ -95,11 +95,11 @@ void main() {
 
   test('should create a class with a bound generic type', () {
     expect(
-      new Class((b) => b
+      Class((b) => b
         ..name = 'Comparable'
-        ..types.add(new TypeReference((b) => b
+        ..types.add(TypeReference((b) => b
           ..symbol = 'T'
-          ..bound = new TypeReference((b) => b
+          ..bound = TypeReference((b) => b
             ..symbol = 'Comparable'
             ..types.add(refer('T').type))))),
       equalsDart(r'''
@@ -110,9 +110,9 @@ void main() {
 
   test('should create a class extending another class', () {
     expect(
-      new Class((b) => b
+      Class((b) => b
         ..name = 'Foo'
-        ..extend = new TypeReference((b) => b.symbol = 'Bar')),
+        ..extend = TypeReference((b) => b.symbol = 'Bar')),
       equalsDart(r'''
         class Foo extends Bar {}
       '''),
@@ -121,10 +121,10 @@ void main() {
 
   test('should create a class mixing in another class', () {
     expect(
-      new Class((b) => b
+      Class((b) => b
         ..name = 'Foo'
-        ..extend = new TypeReference((b) => b.symbol = 'Bar')
-        ..mixins.add(new TypeReference((b) => b.symbol = 'Foo'))),
+        ..extend = TypeReference((b) => b.symbol = 'Bar')
+        ..mixins.add(TypeReference((b) => b.symbol = 'Foo'))),
       equalsDart(r'''
         class Foo extends Bar with Foo {}
       '''),
@@ -133,10 +133,10 @@ void main() {
 
   test('should create a class implementing another class', () {
     expect(
-      new Class((b) => b
+      Class((b) => b
         ..name = 'Foo'
-        ..extend = new TypeReference((b) => b.symbol = 'Bar')
-        ..implements.add(new TypeReference((b) => b.symbol = 'Foo'))),
+        ..extend = TypeReference((b) => b.symbol = 'Bar')
+        ..implements.add(TypeReference((b) => b.symbol = 'Foo'))),
       equalsDart(r'''
         class Foo extends Bar implements Foo {}
       '''),
@@ -145,9 +145,9 @@ void main() {
 
   test('should create a class with a constructor', () {
     expect(
-      new Class((b) => b
+      Class((b) => b
         ..name = 'Foo'
-        ..constructors.add(new Constructor())),
+        ..constructors.add(Constructor())),
       equalsDart(r'''
         class Foo {
           Foo();
@@ -158,11 +158,11 @@ void main() {
 
   test('should create a class with a constructor with initializers', () {
     expect(
-      new Class(
+      Class(
         (b) => b
           ..name = 'Foo'
           ..constructors.add(
-            new Constructor(
+            Constructor(
               (b) => b
                 ..initializers.addAll([
                   const Code('a = 5'),
@@ -181,10 +181,10 @@ void main() {
 
   test('should create a class with a annotated constructor', () {
     expect(
-      new Class((b) => b
+      Class((b) => b
         ..name = 'Foo'
-        ..constructors.add(
-            new Constructor((b) => b..annotations.add(refer('deprecated'))))),
+        ..constructors
+            .add(Constructor((b) => b..annotations.add(refer('deprecated'))))),
       equalsDart(r'''
         class Foo {
           @deprecated
@@ -196,9 +196,9 @@ void main() {
 
   test('should create a class with a named constructor', () {
     expect(
-      new Class((b) => b
+      Class((b) => b
         ..name = 'Foo'
-        ..constructors.add(new Constructor((b) => b..name = 'named'))),
+        ..constructors.add(Constructor((b) => b..name = 'named'))),
       equalsDart(r'''
         class Foo {
           Foo.named();
@@ -209,9 +209,9 @@ void main() {
 
   test('should create a class with a const constructor', () {
     expect(
-      new Class((b) => b
+      Class((b) => b
         ..name = 'Foo'
-        ..constructors.add(new Constructor((b) => b..constant = true))),
+        ..constructors.add(Constructor((b) => b..constant = true))),
       equalsDart(r'''
         class Foo {
           const Foo();
@@ -222,9 +222,9 @@ void main() {
 
   test('should create a class with an external constructor', () {
     expect(
-      new Class((b) => b
+      Class((b) => b
         ..name = 'Foo'
-        ..constructors.add(new Constructor((b) => b..external = true))),
+        ..constructors.add(Constructor((b) => b..external = true))),
       equalsDart(r'''
         class Foo {
           external Foo();
@@ -235,9 +235,9 @@ void main() {
 
   test('should create a class with a factory constructor', () {
     expect(
-      new Class((b) => b
+      Class((b) => b
         ..name = 'Foo'
-        ..constructors.add(new Constructor((b) => b
+        ..constructors.add(Constructor((b) => b
           ..factory = true
           ..redirect = refer('_Foo')))),
       equalsDart(r'''
@@ -250,9 +250,9 @@ void main() {
 
   test('should create a class with a factory lambda constructor', () {
     expect(
-      new Class((b) => b
+      Class((b) => b
         ..name = 'Foo'
-        ..constructors.add(new Constructor((b) => b
+        ..constructors.add(Constructor((b) => b
           ..factory = true
           ..lambda = true
           ..body = const Code('new _Foo()')))),
@@ -266,9 +266,9 @@ void main() {
 
   test('should create a class with an implicit factory lambda constructor', () {
     expect(
-      new Class((b) => b
+      Class((b) => b
         ..name = 'Foo'
-        ..constructors.add(new Constructor((b) => b
+        ..constructors.add(Constructor((b) => b
           ..factory = true
           ..body = refer('_Foo').newInstance([]).code))),
       equalsDart(r'''
@@ -281,9 +281,9 @@ void main() {
 
   test('should create a class with a constructor with a body', () {
     expect(
-      new Class((b) => b
+      Class((b) => b
         ..name = 'Foo'
-        ..constructors.add(new Constructor((b) => b
+        ..constructors.add(Constructor((b) => b
           ..factory = true
           ..body = const Code('return new _Foo();')))),
       equalsDart(r'''
@@ -298,15 +298,15 @@ void main() {
 
   test('should create a class with method parameters', () {
     expect(
-      new Class((b) => b
+      Class((b) => b
         ..name = 'Foo'
-        ..constructors.add(new Constructor((b) => b
+        ..constructors.add(Constructor((b) => b
           ..requiredParameters.addAll([
-            new Parameter((b) => b..name = 'a'),
-            new Parameter((b) => b..name = 'b'),
+            Parameter((b) => b..name = 'a'),
+            Parameter((b) => b..name = 'b'),
           ])
           ..optionalParameters.addAll([
-            new Parameter((b) => b
+            Parameter((b) => b
               ..name = 'c'
               ..named = true),
           ])))),
@@ -320,19 +320,19 @@ void main() {
 
   test('should create a class with a constructor+field-formal parameters', () {
     expect(
-      new Class((b) => b
+      Class((b) => b
         ..name = 'Foo'
-        ..constructors.add(new Constructor((b) => b
+        ..constructors.add(Constructor((b) => b
           ..requiredParameters.addAll([
-            new Parameter((b) => b
+            Parameter((b) => b
               ..name = 'a'
               ..toThis = true),
-            new Parameter((b) => b
+            Parameter((b) => b
               ..name = 'b'
               ..toThis = true),
           ])
           ..optionalParameters.addAll([
-            new Parameter((b) => b
+            Parameter((b) => b
               ..name = 'c'
               ..named = true
               ..toThis = true),

--- a/test/specs/code/expression_test.dart
+++ b/test/specs/code/expression_test.dart
@@ -87,7 +87,7 @@ void main() {
   test('should emit a scoped type as an expression', () {
     expect(
       refer('Foo', 'package:foo/foo.dart'),
-      equalsDart('_i1.Foo', new DartEmitter(new Allocator.simplePrefixing())),
+      equalsDart('_i1.Foo', DartEmitter(Allocator.simplePrefixing())),
     );
   });
 
@@ -200,21 +200,21 @@ void main() {
 
   test('should emit a function type', () {
     expect(
-      new FunctionType((b) => b.returnType = refer('void')),
+      FunctionType((b) => b.returnType = refer('void')),
       equalsDart('void Function()'),
     );
   });
 
   test('should emit a typedef statement', () {
     expect(
-      new FunctionType((b) => b.returnType = refer('void')).toTypeDef('Void0'),
+      FunctionType((b) => b.returnType = refer('void')).toTypeDef('Void0'),
       equalsDart('typedef Void0 = void Function();'),
     );
   });
 
   test('should emit a function type with type parameters', () {
     expect(
-      new FunctionType((b) => b
+      FunctionType((b) => b
         ..returnType = refer('T')
         ..types.add(refer('T'))),
       equalsDart('T Function<T>()'),
@@ -223,14 +223,14 @@ void main() {
 
   test('should emit a function type a single parameter', () {
     expect(
-      new FunctionType((b) => b..requiredParameters.add(refer('String'))),
+      FunctionType((b) => b..requiredParameters.add(refer('String'))),
       equalsDart('Function(String)'),
     );
   });
 
   test('should emit a function type with parameters', () {
     expect(
-      new FunctionType((b) => b
+      FunctionType((b) => b
         ..requiredParameters.add(refer('String'))
         ..optionalParameters.add(refer('int'))),
       equalsDart('Function(String, [int])'),
@@ -239,7 +239,7 @@ void main() {
 
   test('should emit a function type with named parameters', () {
     expect(
-      new FunctionType((b) => b
+      FunctionType((b) => b
         ..namedParameters.addAll({
           'x': refer('int'),
           'y': refer('int'),
@@ -252,7 +252,7 @@ void main() {
     expect(
       refer('map').property('putIfAbsent').call([
         literalString('foo'),
-        new Method((b) => b..body = literalTrue.code).closure,
+        Method((b) => b..body = literalTrue.code).closure,
       ]),
       equalsDart("map.putIfAbsent('foo', () => true)"),
     );

--- a/test/specs/code/statement_test.dart
+++ b/test/specs/code/statement_test.dart
@@ -12,7 +12,7 @@ void main() {
 
   test('should emit a block of code', () {
     expect(
-      new Block.of([
+      Block.of([
         const Code('if (foo) {'),
         const Code('  print(true);'),
         const Code('}'),
@@ -27,7 +27,7 @@ void main() {
 
   test('should emit a block of code including expressions', () {
     expect(
-      new Block.of([
+      Block.of([
         const Code('if (foo) {'),
         refer('print')([literalTrue]).statement,
         const Code('}'),
@@ -42,9 +42,9 @@ void main() {
 
   test('should emit a block of code with lazyily invoked generators', () {
     expect(
-      new Method((b) => b
+      Method((b) => b
         ..name = 'main'
-        ..body = new Block.of([
+        ..body = Block.of([
           const Code('if ('),
           lazyCode(() => refer('foo').code),
           const Code(') {'),

--- a/test/specs/field_test.dart
+++ b/test/specs/field_test.dart
@@ -12,7 +12,7 @@ void main() {
 
   test('should create a field', () {
     expect(
-      new Field((b) => b..name = 'foo'),
+      Field((b) => b..name = 'foo'),
       equalsDart(r'''
         var foo;
       '''),
@@ -21,7 +21,7 @@ void main() {
 
   test('should create a typed field', () {
     expect(
-      new Field((b) => b
+      Field((b) => b
         ..name = 'foo'
         ..type = refer('String')),
       equalsDart(r'''
@@ -32,7 +32,7 @@ void main() {
 
   test('should create a final field', () {
     expect(
-      new Field((b) => b
+      Field((b) => b
         ..name = 'foo'
         ..modifier = FieldModifier.final$),
       equalsDart(r'''
@@ -43,7 +43,7 @@ void main() {
 
   test('should create a constant field', () {
     expect(
-      new Field((b) => b
+      Field((b) => b
         ..name = 'foo'
         ..modifier = FieldModifier.constant),
       equalsDart(r'''
@@ -54,7 +54,7 @@ void main() {
 
   test('should create a field with an assignment', () {
     expect(
-      new Field((b) => b
+      Field((b) => b
         ..name = 'foo'
         ..assignment = const Code('1')),
       equalsDart(r'''

--- a/test/specs/library_test.dart
+++ b/test/specs/library_test.dart
@@ -15,9 +15,9 @@ void main() {
 
     test('should emit a source file with manual imports', () {
       expect(
-        new Library((b) => b
-          ..directives.add(new Directive.import('dart:collection'))
-          ..body.add(new Field((b) => b
+        Library((b) => b
+          ..directives.add(Directive.import('dart:collection'))
+          ..body.add(Field((b) => b
             ..name = 'test'
             ..modifier = FieldModifier.final$
             ..assignment = $LinkedHashMap.newInstance([]).code))),
@@ -25,16 +25,16 @@ void main() {
             import 'dart:collection';
           
             final test = new LinkedHashMap();
-          ''', new DartEmitter()),
+          ''', DartEmitter()),
       );
     });
 
     test('should emit a source file with a deferred import', () {
       expect(
-        new Library(
+        Library(
           (b) => b
             ..directives.add(
-              new Directive.importDeferredAs(
+              Directive.importDeferredAs(
                 'package:foo/foo.dart',
                 'foo',
               ),
@@ -48,10 +48,10 @@ void main() {
 
     test('should emit a source file with a "show" combinator', () {
       expect(
-        new Library(
+        Library(
           (b) => b
             ..directives.add(
-              new Directive.import(
+              Directive.import(
                 'package:foo/foo.dart',
                 show: ['Foo', 'Bar'],
               ),
@@ -65,10 +65,10 @@ void main() {
 
     test('should emit a source file with a "hide" combinator', () {
       expect(
-        new Library(
+        Library(
           (b) => b
             ..directives.add(
-              new Directive.import(
+              Directive.import(
                 'package:foo/foo.dart',
                 hide: ['Foo', 'Bar'],
               ),
@@ -82,33 +82,31 @@ void main() {
 
     test('should emit a source file with allocation', () {
       expect(
-        new Library((b) => b
-          ..body.add(new Field((b) => b
+        Library((b) => b
+          ..body.add(Field((b) => b
             ..name = 'test'
             ..modifier = FieldModifier.final$
-            ..assignment =
-                new Code.scope((a) => 'new ${a($LinkedHashMap)}()')))),
+            ..assignment = Code.scope((a) => 'new ${a($LinkedHashMap)}()')))),
         equalsDart(r'''
           import 'dart:collection';
           
           final test = new LinkedHashMap();
-        ''', new DartEmitter(new Allocator())),
+        ''', DartEmitter(Allocator())),
       );
     });
 
     test('should emit a source file with allocation + prefixing', () {
       expect(
-        new Library((b) => b
-          ..body.add(new Field((b) => b
+        Library((b) => b
+          ..body.add(Field((b) => b
             ..name = 'test'
             ..modifier = FieldModifier.final$
-            ..assignment =
-                new Code.scope((a) => 'new ${a($LinkedHashMap)}()')))),
+            ..assignment = Code.scope((a) => 'new ${a($LinkedHashMap)}()')))),
         equalsDart(r'''
           import 'dart:collection' as _i1;
           
           final test = new _i1.LinkedHashMap();
-        ''', new DartEmitter(new Allocator.simplePrefixing())),
+        ''', DartEmitter(Allocator.simplePrefixing())),
       );
     });
   });

--- a/test/specs/method_test.dart
+++ b/test/specs/method_test.dart
@@ -12,7 +12,7 @@ void main() {
 
   test('should create a method', () {
     expect(
-      new Method((b) => b..name = 'foo'),
+      Method((b) => b..name = 'foo'),
       equalsDart(r'''
         foo();
       '''),
@@ -21,7 +21,7 @@ void main() {
 
   test('should create an async method', () {
     expect(
-      new Method((b) => b
+      Method((b) => b
         ..name = 'foo'
         ..modifier = MethodModifier.async
         ..body = literalNull.code),
@@ -33,7 +33,7 @@ void main() {
 
   test('should create an async* method', () {
     expect(
-      new Method((b) => b
+      Method((b) => b
         ..name = 'foo'
         ..modifier = MethodModifier.asyncStar
         ..body = literalNull.code),
@@ -45,7 +45,7 @@ void main() {
 
   test('should create an sync* method', () {
     expect(
-      new Method((b) => b
+      Method((b) => b
         ..name = 'foo'
         ..modifier = MethodModifier.syncStar
         ..body = literalNull.code),
@@ -57,7 +57,7 @@ void main() {
 
   test('should create a lambda method implicitly', () {
     expect(
-      new Method((b) => b
+      Method((b) => b
         ..name = 'returnsTrue'
         ..returns = refer('bool')
         ..body = literalTrue.code),
@@ -69,7 +69,7 @@ void main() {
 
   test('should create a normal method implicitly', () {
     expect(
-      new Method.returnsVoid((b) => b
+      Method.returnsVoid((b) => b
         ..name = 'assignTrue'
         ..body = refer('topLevelFoo').assign(literalTrue).statement),
       equalsDart(r'''
@@ -82,7 +82,7 @@ void main() {
 
   test('should create a getter', () {
     expect(
-      new Method((b) => b
+      Method((b) => b
         ..name = 'foo'
         ..external = true
         ..type = MethodType.getter),
@@ -94,10 +94,10 @@ void main() {
 
   test('should create a setter', () {
     expect(
-      new Method((b) => b
+      Method((b) => b
         ..name = 'foo'
         ..external = true
-        ..requiredParameters.add((new Parameter((b) => b..name = 'foo')))
+        ..requiredParameters.add((Parameter((b) => b..name = 'foo')))
         ..type = MethodType.setter),
       equalsDart(r'''
         external set foo(foo);
@@ -107,7 +107,7 @@ void main() {
 
   test('should create a method with a return type', () {
     expect(
-      new Method((b) => b
+      Method((b) => b
         ..name = 'foo'
         ..returns = refer('String')),
       equalsDart(r'''
@@ -118,7 +118,7 @@ void main() {
 
   test('should create a method with a void return type', () {
     expect(
-      new Method.returnsVoid((b) => b..name = 'foo'),
+      Method.returnsVoid((b) => b..name = 'foo'),
       equalsDart(r'''
         void foo();
       '''),
@@ -127,9 +127,9 @@ void main() {
 
   test('should create a method with a function type return type', () {
     expect(
-      new Method((b) => b
+      Method((b) => b
         ..name = 'foo'
-        ..returns = new FunctionType((b) => b
+        ..returns = FunctionType((b) => b
           ..returnType = refer('String')
           ..requiredParameters.addAll([
             refer('int'),
@@ -142,10 +142,10 @@ void main() {
 
   test('should create a method with a nested function type return type', () {
     expect(
-      new Method((b) => b
+      Method((b) => b
         ..name = 'foo'
-        ..returns = new FunctionType((b) => b
-          ..returnType = new FunctionType((b) => b
+        ..returns = FunctionType((b) => b
+          ..returnType = FunctionType((b) => b
             ..returnType = refer('String')
             ..requiredParameters.add(refer('String')))
           ..requiredParameters.addAll([
@@ -159,10 +159,10 @@ void main() {
 
   test('should create a method with a function type argument', () {
     expect(
-        new Method((b) => b
+        Method((b) => b
           ..name = 'foo'
-          ..requiredParameters.add(new Parameter((b) => b
-            ..type = new FunctionType((b) => b
+          ..requiredParameters.add(Parameter((b) => b
+            ..type = FunctionType((b) => b
               ..returnType = refer('String')
               ..requiredParameters.add(refer('int')))
             ..name = 'argument'))),
@@ -173,11 +173,11 @@ void main() {
 
   test('should create a method with a nested function type argument', () {
     expect(
-        new Method((b) => b
+        Method((b) => b
           ..name = 'foo'
-          ..requiredParameters.add(new Parameter((b) => b
-            ..type = new FunctionType((b) => b
-              ..returnType = new FunctionType((b) => b
+          ..requiredParameters.add(Parameter((b) => b
+            ..type = FunctionType((b) => b
+              ..returnType = FunctionType((b) => b
                 ..returnType = refer('String')
                 ..requiredParameters.add(refer('String')))
               ..requiredParameters.add(refer('int')))
@@ -189,7 +189,7 @@ void main() {
 
   test('should create a method with generic types', () {
     expect(
-      new Method((b) => b
+      Method((b) => b
         ..name = 'foo'
         ..types.add(refer('T'))),
       equalsDart(r'''
@@ -200,7 +200,7 @@ void main() {
 
   test('should create an external method', () {
     expect(
-      new Method((b) => b
+      Method((b) => b
         ..name = 'foo'
         ..external = true),
       equalsDart(r'''
@@ -211,7 +211,7 @@ void main() {
 
   test('should create a method with a body', () {
     expect(
-      new Method((b) => b
+      Method((b) => b
         ..name = 'foo'
         ..body = const Code('return 1+ 2;')),
       equalsDart(r'''
@@ -224,7 +224,7 @@ void main() {
 
   test('should create a lambda method (explicitly)', () {
     expect(
-      new Method((b) => b
+      Method((b) => b
         ..name = 'foo'
         ..lambda = true
         ..body = const Code('1 + 2')),
@@ -237,9 +237,9 @@ void main() {
   test('should create a method with a body with references', () {
     final $LinkedHashMap = refer('LinkedHashMap', 'dart:collection');
     expect(
-      new Method((b) => b
+      Method((b) => b
         ..name = 'foo'
-        ..body = new Code.scope(
+        ..body = Code.scope(
           (a) => 'return new ${a($LinkedHashMap)}();',
         )),
       equalsDart(r'''
@@ -252,11 +252,11 @@ void main() {
 
   test('should create a method with a paremter', () {
     expect(
-      new Method(
+      Method(
         (b) => b
           ..name = 'fib'
           ..requiredParameters.add(
-            new Parameter((b) => b.name = 'i'),
+            Parameter((b) => b.name = 'i'),
           ),
       ),
       equalsDart(r'''
@@ -267,11 +267,11 @@ void main() {
 
   test('should create a method with an annotated parameter', () {
     expect(
-      new Method(
+      Method(
         (b) => b
           ..name = 'fib'
           ..requiredParameters.add(
-            new Parameter((b) => b
+            Parameter((b) => b
               ..name = 'i'
               ..annotations.add(refer('deprecated'))),
           ),
@@ -284,11 +284,11 @@ void main() {
 
   test('should create a method with a parameter with a type', () {
     expect(
-      new Method(
+      Method(
         (b) => b
           ..name = 'fib'
           ..requiredParameters.add(
-            new Parameter(
+            Parameter(
               (b) => b
                 ..name = 'i'
                 ..type = refer('int').type,
@@ -303,21 +303,21 @@ void main() {
 
   test('should create a method with a parameter with a generic type', () {
     expect(
-      new Method(
+      Method(
         (b) => b
           ..name = 'foo'
-          ..types.add(new TypeReference((b) => b
+          ..types.add(TypeReference((b) => b
             ..symbol = 'T'
             ..bound = refer('Iterable')))
           ..requiredParameters.addAll([
-            new Parameter(
+            Parameter(
               (b) => b
                 ..name = 't'
                 ..type = refer('T'),
             ),
-            new Parameter((b) => b
+            Parameter((b) => b
               ..name = 'x'
-              ..type = new TypeReference((b) => b
+              ..type = TypeReference((b) => b
                 ..symbol = 'X'
                 ..types.add(refer('T')))),
           ]),
@@ -330,11 +330,11 @@ void main() {
 
   test('should create a method with an optional parameter', () {
     expect(
-      new Method(
+      Method(
         (b) => b
           ..name = 'fib'
           ..optionalParameters.add(
-            new Parameter((b) => b.name = 'i'),
+            Parameter((b) => b.name = 'i'),
           ),
       ),
       equalsDart(r'''
@@ -345,12 +345,12 @@ void main() {
 
   test('should create a method with multiple optional parameters', () {
     expect(
-      new Method(
+      Method(
         (b) => b
           ..name = 'foo'
           ..optionalParameters.addAll([
-            new Parameter((b) => b.name = 'a'),
-            new Parameter((b) => b.name = 'b'),
+            Parameter((b) => b.name = 'a'),
+            Parameter((b) => b.name = 'b'),
           ]),
       ),
       equalsDart(r'''
@@ -361,11 +361,11 @@ void main() {
 
   test('should create a method with an optional parameter with a value', () {
     expect(
-      new Method(
+      Method(
         (b) => b
           ..name = 'fib'
           ..optionalParameters.add(
-            new Parameter((b) => b
+            Parameter((b) => b
               ..name = 'i'
               ..defaultTo = const Code('0')),
           ),
@@ -378,11 +378,11 @@ void main() {
 
   test('should create a method with a named optional parameter', () {
     expect(
-      new Method(
+      Method(
         (b) => b
           ..name = 'fib'
           ..optionalParameters.add(
-            new Parameter((b) => b
+            Parameter((b) => b
               ..named = true
               ..name = 'i'),
           ),
@@ -395,11 +395,11 @@ void main() {
 
   test('should create a method with a named optional parameter with value', () {
     expect(
-      new Method(
+      Method(
         (b) => b
           ..name = 'fib'
           ..optionalParameters.add(
-            new Parameter((b) => b
+            Parameter((b) => b
               ..named = true
               ..name = 'i'
               ..defaultTo = const Code('0')),
@@ -413,14 +413,14 @@ void main() {
 
   test('should create a method with a mix of parameters', () {
     expect(
-      new Method(
+      Method(
         (b) => b
           ..name = 'foo'
           ..requiredParameters.add(
-            new Parameter((b) => b..name = 'a'),
+            Parameter((b) => b..name = 'a'),
           )
           ..optionalParameters.add(
-            new Parameter((b) => b
+            Parameter((b) => b
               ..named = true
               ..name = 'b'),
           ),

--- a/tool/src/builder.dart
+++ b/tool/src/builder.dart
@@ -8,7 +8,7 @@ import 'package:source_gen/source_gen.dart';
 
 /// Returns a [Builder] to generate `.g.dart` files for `built_value`.
 Builder builtValueBuilder(BuilderOptions _) {
-  return new PartBuilder([
+  return PartBuilder([
     const BuiltValueGenerator(),
   ], '.g.dart');
 }


### PR DESCRIPTION
- Update the SDK constraint to >=2.0.0
- Update README to drop `new` keyword.
- Hold back lib/**/*.g.dart files since they are generated.