### PR TITLE
Remove `new` from text references

### DIFF
--- a/lib/src/specs/code.dart
+++ b/lib/src/specs/code.dart
@@ -31,10 +31,10 @@ abstract class Code implements Spec {
   /// Create a code based that may use a provided [Allocator] for scoping:
   ///
   /// ```dart
-  /// // Emits `new _i123.FooType()`, where `_i123` is the import prefix.
+  /// // Emits `_i123.FooType()`, where `_i123` is the import prefix.
   ///
-  /// new Code.scope((a) {
-  ///   return 'new ${a.allocate(fooType)}()'
+  /// Code.scope((a) {
+  ///   return '${a.allocate(fooType)}()'
   /// });
   /// ```
   const factory Code.scope(

--- a/lib/src/specs/expression/literal.dart
+++ b/lib/src/specs/expression/literal.dart
@@ -92,7 +92,7 @@ LiteralMapExpression literalConstMap(
 
 /// Represents a literal value in Dart source code.
 ///
-/// For example, `new LiteralExpression('null')` should emit `null`.
+/// For example, `LiteralExpression('null')` should emit `null`.
 ///
 /// Some common literals and helpers are available as methods/fields:
 /// * [literal]

--- a/lib/src/specs/reference.dart
+++ b/lib/src/specs/reference.dart
@@ -13,7 +13,7 @@ import 'code.dart';
 import 'expression.dart';
 import 'type_reference.dart';
 
-/// Short-hand for `new Reference(symbol, url)`.
+/// Short-hand for `Reference(symbol, url)`.
 Reference refer(String symbol, [String url]) {
   return Reference(symbol, url);
 }

--- a/lib/src/specs/type_function.dart
+++ b/lib/src/specs/type_function.dart
@@ -63,7 +63,7 @@ abstract class FunctionType extends Expression
     Map<String, Expression> namedArguments = const {},
     List<Reference> typeArguments = const [],
   ]) =>
-      throw UnsupportedError('Cannot "new" a function type.');
+      throw UnsupportedError('Cannot instantiate a function type.');
 
   @override
   Expression newInstanceNamed(
@@ -72,7 +72,7 @@ abstract class FunctionType extends Expression
     Map<String, Expression> namedArguments = const {},
     List<Reference> typeArguments = const [],
   ]) =>
-      throw UnsupportedError('Cannot "new" a function type.');
+      throw UnsupportedError('Cannot instantiate a function type.');
 
   @override
   Expression constInstance(


### PR DESCRIPTION
Update code in Doc comments and text references for Dart 2 style code.