### PR TITLE
Bump the dependency range for built_collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.3-dev
+
+* Bump dependency on built_collection to include v4.0.0.
+
 ## 3.1.2
 
 * Set max SDK version to `<3.0.0`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
-  built_collection: '>=1.0.0 <4.0.0'
+  built_collection: '>=3.0.0 <5.0.0'
   built_value: ^6.0.0
   matcher: ^0.12.0
   meta: ^1.0.5


### PR DESCRIPTION
Updated the lower bound based on running `pub downgrade`.