### PR TITLE
fix redundant `,` in Function type

### DIFF
--- a/lib/src/emitter.dart
+++ b/lib/src/emitter.dart
@@ -313,8 +313,9 @@ class DartEmitter extends Object
     visitAll<Reference>(spec.requiredParameters, output, (spec) {
       spec.accept(this, output);
     });
-    if (spec.optionalParameters.isNotEmpty ||
-        spec.namedParameters.isNotEmpty && spec.requiredParameters.isNotEmpty) {
+    if (spec.requiredParameters.isNotEmpty &&
+        (spec.optionalParameters.isNotEmpty ||
+            spec.namedParameters.isNotEmpty)) {
       output.write(', ');
     }
     if (spec.optionalParameters.isNotEmpty) {

--- a/test/specs/method_test.dart
+++ b/test/specs/method_test.dart
@@ -140,6 +140,66 @@ void main() {
     );
   });
 
+  test('should create a function type with an optional positional parameter',
+      () {
+    expect(
+      FunctionType((b) => b
+        ..returnType = refer('String')
+        ..optionalParameters.add(refer('int'))),
+      equalsDart(r'''
+        String Function([int])
+      '''),
+    );
+  });
+
+  test(
+      'should create a function type with a required '
+      'and an optional positional parameter', () {
+    expect(
+      FunctionType((b) => b
+        ..returnType = refer('String')
+        ..requiredParameters.add(refer('int'))
+        ..optionalParameters.add(refer('int'))),
+      equalsDart(r'''
+        String Function(int, [int])
+      '''),
+    );
+  });
+
+  test('should create a function type without parameters', () {
+    expect(
+      FunctionType((b) => b..returnType = refer('String')),
+      equalsDart(r'''
+        String Function()
+      '''),
+    );
+  });
+
+  test('should create a function type with an optional named parameter', () {
+    expect(
+      FunctionType((b) => b
+        ..returnType = refer('String')
+        ..namedParameters['named'] = refer('int')),
+      equalsDart(r'''
+        String Function({int named})
+      '''),
+    );
+  });
+
+  test(
+      'should create a function type with a required '
+      'and an optional named parameter', () {
+    expect(
+      FunctionType((b) => b
+        ..returnType = refer('String')
+        ..requiredParameters.add(refer('int'))
+        ..namedParameters['named'] = refer('int')),
+      equalsDart(r'''
+        String Function(int, {int named})
+      '''),
+    );
+  });
+
   test('should create a method with a nested function type return type', () {
     expect(
       Method((b) => b


### PR DESCRIPTION
Function type with no requiredParameter adds a redundant `,` before
optional positional or named parameters.