### PR TITLE
Use `=` instead of `:` for default values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.2.0
+
+* Emit `=` instead of `:` for named parameter default values.
+
 ## 3.1.3
 
 * Bump dependency on built_collection to include v4.0.0.

--- a/lib/src/emitter.dart
+++ b/lib/src/emitter.dart
@@ -441,11 +441,7 @@ class DartEmitter extends Object
     }
     output.write(spec.name);
     if (optional && spec.defaultTo != null) {
-      if (spec.named) {
-        output.write(': ');
-      } else {
-        output.write(' = ');
-      }
+      output.write(' = ');
       spec.defaultTo.accept(this, output);
     }
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: code_builder
-version: 3.1.3
+version: 3.2.0
 
 description: A fluent API for generating Dart code
 author: Dart Team <misc@dartlang.org>

--- a/test/specs/method_test.dart
+++ b/test/specs/method_test.dart
@@ -406,7 +406,7 @@ void main() {
           ),
       ),
       equalsDart(r'''
-        fib({i: 0});
+        fib({i = 0});
       '''),
     );
   });


### PR DESCRIPTION
Fixes #232

This follows the recommendations in Effective Dart.