### PR TITLE
Escape newlines in String literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.2.1
+
+* Escape newlines in String literals.
+
 ## 3.2.0
 
 * Emit `=` instead of `:` for named parameter default values.

--- a/lib/src/specs/expression/literal.dart
+++ b/lib/src/specs/expression/literal.dart
@@ -53,12 +53,12 @@ Expression literalNum(num value) => LiteralExpression._('$value');
 ///
 /// If [raw] is `true`, creates a raw String formatted `r'<value>'` and the
 /// value may not contain a single quote.
-/// If [raw] is `false` escapes single quotes in the value.
+/// Escapes single quotes and newlines in the value.
 Expression literalString(String value, {bool raw = false}) {
   if (raw && value.contains('\'')) {
     throw ArgumentError('Cannot include a single quote in a raw string');
   }
-  final escaped = value.replaceAll('\'', '\\\'');
+  final escaped = value.replaceAll('\'', '\\\'').replaceAll('\n', '\\n');
   return LiteralExpression._("${raw ? 'r' : ''}'$escaped'");
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: code_builder
-version: 3.2.0
+version: 3.2.1
 
 description: >-
   A fluent, builder-based library for generating valid Dart code

--- a/test/specs/code/expression_test.dart
+++ b/test/specs/code/expression_test.dart
@@ -30,6 +30,10 @@ void main() {
     expect(() => literalString(r"don't", raw: true), throwsArgumentError);
   });
 
+  test('should escape a newline in a string', () {
+    expect(literalString('some\nthing'), equalsDart(r"'some\nthing'"));
+  });
+
   test('should emit a && expression', () {
     expect(literalTrue.and(literalFalse), equalsDart('true && false'));
   });


### PR DESCRIPTION
Fixes #241

It is never sensible to write a single quoted string with a newline
character, they should be written as `\n`.