### PR TITLE
Add support for `||` expressions

### DIFF
--- a/lib/src/specs/expression.dart
+++ b/lib/src/specs/expression.dart
@@ -44,6 +44,11 @@ abstract class Expression implements Spec {
     return BinaryExpression._(expression, other, '&&');
   }
 
+  /// Returns the result of `this` `||` [other].
+  Expression or(Expression other) {
+    return BinaryExpression._(expression, other, '||');
+  }
+
   /// Returns the result of `this` `as` [other].
   Expression asA(Expression other) {
     return CodeExpression(Block.of([

--- a/lib/src/specs/expression.dart
+++ b/lib/src/specs/expression.dart
@@ -19,6 +19,7 @@ part 'expression/closure.dart';
 part 'expression/code.dart';
 part 'expression/invoke.dart';
 part 'expression/literal.dart';
+part 'expression/unary.dart';
 
 /// Represents a [code] block that wraps an [Expression].
 
@@ -47,6 +48,11 @@ abstract class Expression implements Spec {
   /// Returns the result of `this` `||` [other].
   Expression or(Expression other) {
     return BinaryExpression._(expression, other, '||');
+  }
+
+  /// Returns the result of `!` `this`.
+  Expression not() {
+    return UnaryExpression._(expression, '!');
   }
 
   /// Returns the result of `this` `as` [other].
@@ -190,6 +196,11 @@ abstract class Expression implements Spec {
       other,
       '%',
     );
+  }
+
+  /// Returns the result of `-` `this`.
+  Expression neg() {
+    return UnaryExpression._(expression, '-');
   }
 
   Expression conditional(Expression whenTrue, Expression whenFalse) {
@@ -357,6 +368,7 @@ abstract class ExpressionVisitor<T> implements SpecVisitor<T> {
   T visitLiteralExpression(LiteralExpression expression, [T context]);
   T visitLiteralListExpression(LiteralListExpression expression, [T context]);
   T visitLiteralMapExpression(LiteralMapExpression expression, [T context]);
+  T visitUnaryExpression(UnaryExpression expression, [T context]);
 }
 
 /// Knowledge of how to write valid Dart code from [ExpressionVisitor].
@@ -439,6 +451,17 @@ abstract class ExpressionEmitter implements ExpressionVisitor<StringSink> {
   visitLiteralExpression(LiteralExpression expression, [StringSink output]) {
     output ??= StringBuffer();
     return output..write(expression.literal);
+  }
+
+  @override
+  visitUnaryExpression(UnaryExpression expression, [StringSink output]) {
+    output ??= StringBuffer();
+    output.write(expression.operator);
+    if (expression.addSpace) {
+      output.write(' ');
+    }
+    expression.target.accept(this, output);
+    return output;
   }
 
   void _acceptLiteral(Object literalOrSpec, StringSink output) {

--- a/lib/src/specs/expression/unary.dart
+++ b/lib/src/specs/expression/unary.dart
@@ -1,0 +1,21 @@
+part of code_builder.src.specs.expression;
+
+/// Represents an [operator] and expression [target].
+class UnaryExpression extends Expression {
+  final Expression target;
+  final String operator;
+  final bool addSpace;
+  final bool isConst;
+
+  const UnaryExpression._(
+    this.target,
+    this.operator, {
+    this.addSpace = false,
+    this.isConst = false,
+  });
+
+  @override
+  R accept<R>(ExpressionVisitor<R> visitor, [R context]) {
+    return visitor.visitUnaryExpression(this, context);
+  }
+}

--- a/test/specs/code/expression_test.dart
+++ b/test/specs/code/expression_test.dart
@@ -42,6 +42,10 @@ void main() {
     expect(literalFalse.or(literalTrue), equalsDart('false || true'));
   });
 
+  test('should emit a ! expression', () {
+    expect(literalFalse.not(), equalsDart('!false'));
+  });
+
   test('should emit a list', () {
     expect(literalList([]), equalsDart('[]'));
   });
@@ -443,5 +447,10 @@ void main() {
   test('should emit an euclidean modulo operator call', () {
     expect(refer('foo').operatorEuclideanModulo(refer('foo2')),
         equalsDart('foo % foo2'));
+  });
+
+  test('should emit an negate operator call', () {
+    expect(refer('foo').neg(),
+        equalsDart('-foo'));
   });
 }

--- a/test/specs/code/expression_test.dart
+++ b/test/specs/code/expression_test.dart
@@ -38,6 +38,10 @@ void main() {
     expect(literalTrue.and(literalFalse), equalsDart('true && false'));
   });
 
+  test('should emit a || expression', () {
+    expect(literalFalse.or(literalTrue), equalsDart('false || true'));
+  });
+
   test('should emit a list', () {
     expect(literalList([]), equalsDart('[]'));
   });


### PR DESCRIPTION
with simple test