### PR TITLE
add support for literal sets

### DIFF
--- a/lib/code_builder.dart
+++ b/lib/code_builder.dart
@@ -30,6 +30,8 @@ export 'src/specs/expression.dart'
         literalBool,
         literalList,
         literalConstList,
+        literalSet,
+        literalConstSet,
         literalMap,
         literalConstMap,
         literalString,

--- a/lib/src/specs/expression.dart
+++ b/lib/src/specs/expression.dart
@@ -351,6 +351,7 @@ abstract class ExpressionVisitor<T> implements SpecVisitor<T> {
   T visitInvokeExpression(InvokeExpression expression, [T context]);
   T visitLiteralExpression(LiteralExpression expression, [T context]);
   T visitLiteralListExpression(LiteralListExpression expression, [T context]);
+  T visitLiteralSetExpression(LiteralSetExpression expression, [T context]);
   T visitLiteralMapExpression(LiteralMapExpression expression, [T context]);
 }
 
@@ -464,6 +465,27 @@ abstract class ExpressionEmitter implements ExpressionVisitor<StringSink> {
         _acceptLiteral(value, output);
       });
       return output..write(']');
+    });
+  }
+
+  @override
+  visitLiteralSetExpression(
+    LiteralSetExpression expression, [
+    StringSink output,
+  ]) {
+    output ??= StringBuffer();
+
+    return _writeConstExpression(output, expression.isConst, () {
+      if (expression.type != null) {
+        output.write('<');
+        expression.type.accept(this, output);
+        output.write('>');
+      }
+      output.write('{');
+      visitAll<Object>(expression.values, output, (value) {
+        _acceptLiteral(value, output);
+      });
+      return output..write('}');
     });
   }
 

--- a/lib/src/specs/expression/literal.dart
+++ b/lib/src/specs/expression/literal.dart
@@ -20,6 +20,9 @@ Expression literal(Object literal, {Expression onError(Object value)}) {
   if (literal is List) {
     return literalList(literal);
   }
+  if (literal is Set) {
+    return literalSet(literal);
+  }
   if (literal is Map) {
     return literalMap(literal);
   }
@@ -72,6 +75,16 @@ LiteralListExpression literalConstList(List<Object> values, [Reference type]) {
   return LiteralListExpression._(true, values, type);
 }
 
+/// Creates a literal set expression from [values].
+LiteralSetExpression literalSet(Iterable<Object> values, [Reference type]) {
+  return LiteralSetExpression._(false, values.toSet(), type);
+}
+
+/// Creates a literal `const` set expression from [values].
+LiteralSetExpression literalConstSet(Set<Object> values, [Reference type]) {
+  return LiteralSetExpression._(true, values, type);
+}
+
 /// Create a literal map expression from [values].
 LiteralMapExpression literalMap(
   Map<Object, Object> values, [
@@ -99,6 +112,7 @@ LiteralMapExpression literalConstMap(
 /// * [literalBool] and [literalTrue], [literalFalse]
 /// * [literalNull]
 /// * [literalList] and [literalConstList]
+/// * [literalSet] and [literalConstSet]
 class LiteralExpression extends Expression {
   final String literal;
 
@@ -127,6 +141,22 @@ class LiteralListExpression extends Expression {
 
   @override
   String toString() => '[${values.map(literal).join(', ')}]';
+}
+
+class LiteralSetExpression extends Expression {
+  final bool isConst;
+  final Set<Object> values;
+  final Reference type;
+
+  const LiteralSetExpression._(this.isConst, this.values, this.type);
+
+  @override
+  R accept<R>(ExpressionVisitor<R> visitor, [R context]) {
+    return visitor.visitLiteralSetExpression(this, context);
+  }
+
+  @override
+  String toString() => '{${values.map(literal).join(', ')}}';
 }
 
 class LiteralMapExpression extends Expression {

--- a/test/specs/code/expression_test.dart
+++ b/test/specs/code/expression_test.dart
@@ -50,6 +50,21 @@ void main() {
     expect(literalList([], refer('int')), equalsDart('<int>[]'));
   });
 
+  test('should emit a set', () {
+    // ignore: prefer_collection_literals
+    expect(literalSet(Set()), equalsDart('{}'));
+  });
+
+  test('should emit a const set', () {
+    // ignore: prefer_collection_literals
+    expect(literalConstSet(Set()), equalsDart('const {}'));
+  });
+
+  test('should emit an explicitly typed set', () {
+    // ignore: prefer_collection_literals
+    expect(literalSet(Set(), refer('int')), equalsDart('<int>{}'));
+  });
+
   test('should emit a map', () {
     expect(literalMap({}), equalsDart('{}'));
   });
@@ -79,8 +94,30 @@ void main() {
 
   test('should emit a list of other literals and expressions', () {
     expect(
-      literalList([<dynamic>[], true, null, refer('Map').newInstance([])]),
-      equalsDart('[[], true, null, Map()]'),
+      literalList([
+        <dynamic>[],
+        // ignore: prefer_collection_literals
+        Set<dynamic>(),
+        true,
+        null,
+        refer('Map').newInstance([])
+      ]),
+      equalsDart('[[], {}, true, null, Map()]'),
+    );
+  });
+
+  test('should emit a set of other literals and expressions', () {
+    expect(
+      // ignore: prefer_collection_literals
+      literalSet([
+        <dynamic>[],
+        // ignore: prefer_collection_literals
+        Set<dynamic>(),
+        true,
+        null,
+        refer('Map').newInstance([])
+      ]),
+      equalsDart('{[], {}, true, null, Map()}'),
     );
   });
 


### PR DESCRIPTION
This pull request adds the `literalSet` and `literalConstSet` functions.

It does the same thing for Sets as `literalList` is doing for Lists. 