### PR TITLE
Remove visibleForTesting from constructor used in lib/src/specs/refer…

### DIFF
--- a/lib/src/specs/expression/code.dart
+++ b/lib/src/specs/expression/code.dart
@@ -10,7 +10,6 @@ class CodeExpression extends Expression {
   final Code code;
 
   /// **INTERNAL ONLY**: Used to wrap [Code] as an [Expression].
-  @visibleForTesting
   const CodeExpression(this.code);
 
   @override


### PR DESCRIPTION
…ence.dart

Due to a bug in the analyzer, this is currently not reported. In order to land a fix, I have to clean up violations like this.