### PR TITLE
`OR` and `NOT` expressions

### DIFF
--- a/lib/src/specs/expression.dart
+++ b/lib/src/specs/expression.dart
@@ -54,7 +54,7 @@ abstract class Expression implements Spec {
 
   /// Returns the result of `!this`.
   Expression negate() {
-    return BinaryExpression._(_empty, expression, '!');
+    return BinaryExpression._(_empty, expression, '!', addSpace: false);
   }
 
   /// Returns the result of `this` `as` [other].

--- a/lib/src/specs/expression.dart
+++ b/lib/src/specs/expression.dart
@@ -28,6 +28,9 @@ part 'expression/literal.dart';
 abstract class Expression implements Spec {
   const Expression();
 
+  /// An empty expression.
+  static const _empty = CodeExpression(Code(''));
+
   @override
   R accept<R>(covariant ExpressionVisitor<R> visitor, [R context]);
 
@@ -42,6 +45,16 @@ abstract class Expression implements Spec {
   /// Returns the result of `this` `&&` [other].
   Expression and(Expression other) {
     return BinaryExpression._(expression, other, '&&');
+  }
+
+  /// Returns the result of `this` `||` [other].
+  Expression or(Expression other) {
+    return BinaryExpression._(expression, other, '||');
+  }
+
+  /// Returns the result of `!this`.
+  Expression negate() {
+    return BinaryExpression._(_empty, expression, '!');
   }
 
   /// Returns the result of `this` `as` [other].

--- a/lib/src/specs/expression.dart
+++ b/lib/src/specs/expression.dart
@@ -211,9 +211,9 @@ abstract class Expression implements Spec {
   /// This expression preceded by `await`.
   Expression get awaited {
     return BinaryExpression._(
-      const LiteralExpression._('await'),
+      _empty,
       this,
-      '',
+      'await',
     );
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: code_builder
-version: 3.2.1
+version: 3.2.2
 
 description: >-
   A fluent, builder-based library for generating valid Dart code

--- a/test/specs/code/expression_test.dart
+++ b/test/specs/code/expression_test.dart
@@ -38,6 +38,14 @@ void main() {
     expect(literalTrue.and(literalFalse), equalsDart('true && false'));
   });
 
+  test('should emit a || expression', () {
+    expect(literalTrue.or(literalFalse), equalsDart('true || false'));
+  });
+
+  test('should emit a ! expression', () {
+    expect(literalTrue.negate(), equalsDart('!true'));
+  });
+
   test('should emit a list', () {
     expect(literalList([]), equalsDart('[]'));
   });


### PR DESCRIPTION
This pull request adds support for `OR` and `NOT` logical operator expressions.
Previously, there was only an `AND` expression.

For this, we add `Expression.or(Expression)` and `Expression.negate()` methods.

Fixes #247.