### PR TITLE
Changelog for 3.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 * No longer emits redundant `,`s in `FunctionType`s.
 * Added support for `literalSet` and `literalConstSet`.
 
+## 3.2.2
+
+* Introduce `Expression.or` for boolean OR.
+* Introduce `Expression.negate` for boolean NOT.
+
 ## 3.2.1
 
 * Escape newlines in String literals.


### PR DESCRIPTION
This PR adds a missing changelog entry for the `3.2.2` version.