### PR TITLE
add support to generate mixins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 .packages
 .pub
 pubspec.lock
+
+# IntelliJ stuff
+.idea/
+*.iml

--- a/example/example.dart
+++ b/example/example.dart
@@ -10,6 +10,7 @@ final _dartfmt = DartFormatter();
 void main() {
   print('animalClass():\n${'=' * 40}\n${animalClass()}');
   print('scopedLibrary():\n${'=' * 40}\n${scopedLibrary()}');
+  print('classWithMixin():\n${'=' * 40}\n${classWithMixin()}');
 }
 
 /// Outputs:
@@ -50,5 +51,42 @@ String scopedLibrary() {
       ..returns = refer('Other', 'package:b/b.dart')),
   ];
   final library = Library((b) => b.body.addAll(methods));
+  return _dartfmt.format('${library.accept(DartEmitter.scoped())}');
+}
+
+/// Outputs:
+///
+/// ```dart
+/// import 'package:food/food.dart' as _i1;
+///
+/// mixin Eat {
+///   void eat(_i1.Food food) => print('Yum!');
+/// }
+///
+/// class Animal with Eat {
+///   void feed(_i1.Food food) => eat(food);
+/// }
+/// ```
+String classWithMixin() {
+  final foodRefer = refer('Food', 'package:food/food.dart');
+  final mixinRefer = refer('Eat');
+  final mixin = Mixin((b) => b
+    ..name = mixinRefer.symbol
+    ..methods.add(Method.returnsVoid((b) => b
+      ..name = 'eat'
+      ..requiredParameters.add(Parameter((b) => b
+        ..type = foodRefer
+        ..name = 'food'))
+      ..body = refer('print').call([literalString('Yum!')]).code)));
+  final animal = Class((b) => b
+    ..name = 'Animal'
+    ..mixins.add(mixinRefer)
+    ..methods.add(Method.returnsVoid((b) => b
+      ..name = 'feed'
+      ..requiredParameters.add(Parameter((b) => b
+        ..type = foodRefer
+        ..name = 'food'))
+      ..body = refer('eat').call([refer('food')]).code)));
+  final library = Library((b) => b..body.addAll([mixin, animal]));
   return _dartfmt.format('${library.accept(DartEmitter.scoped())}');
 }

--- a/lib/code_builder.dart
+++ b/lib/code_builder.dart
@@ -47,6 +47,7 @@ export 'src/specs/method.dart'
         MethodType,
         Parameter,
         ParameterBuilder;
+export 'src/specs/mixin.dart' show Mixin, MixinBuilder;
 export 'src/specs/reference.dart' show refer, Reference;
 export 'src/specs/type_function.dart' show FunctionType, FunctionTypeBuilder;
 export 'src/specs/type_reference.dart' show TypeReference, TypeReferenceBuilder;

--- a/lib/src/emitter.dart
+++ b/lib/src/emitter.dart
@@ -12,6 +12,7 @@ import 'specs/expression.dart';
 import 'specs/field.dart';
 import 'specs/library.dart';
 import 'specs/method.dart';
+import 'specs/mixin.dart';
 import 'specs/reference.dart';
 import 'specs/type_function.dart';
 import 'specs/type_reference.dart';
@@ -125,6 +126,35 @@ class DartEmitter extends Object
       visitField(f, output);
       output.writeln();
     });
+    spec.methods.forEach((m) {
+      visitMethod(m, output);
+      if (_isLambdaMethod(m)) {
+        output.write(';');
+      }
+      output.writeln();
+    });
+    output.writeln(' }');
+    return output;
+  }
+
+  @override
+  StringSink visitMixin(Mixin spec, [StringSink output]) {
+    output ??= StringBuffer();
+    spec.docs.forEach(output.writeln);
+    spec.annotations.forEach((a) => visitAnnotation(a, output));
+    output.write('mixin ${spec.name}');
+    visitTypeParameters(spec.types.map((r) => r.type), output);
+    if (spec.on != null) {
+      output.write(' on ');
+      spec.on.type.accept(this, output);
+    }
+    if (spec.implements.isNotEmpty) {
+      output
+        ..write(' implements ')
+        ..writeAll(
+            spec.implements.map<StringSink>((m) => m.type.accept(this)), ',');
+    }
+    output.write(' {');
     spec.methods.forEach((m) {
       visitMethod(m, output);
       if (_isLambdaMethod(m)) {

--- a/lib/src/specs/mixin.dart
+++ b/lib/src/specs/mixin.dart
@@ -1,0 +1,80 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+import 'package:meta/meta.dart';
+
+import '../base.dart';
+import '../mixins/annotations.dart';
+import '../mixins/dartdoc.dart';
+import '../mixins/generics.dart';
+import '../visitors.dart';
+import 'expression.dart';
+import 'method.dart';
+import 'reference.dart';
+
+part 'mixin.g.dart';
+
+@immutable
+abstract class Mixin extends Object
+    with HasAnnotations, HasDartDocs, HasGenerics
+    implements Built<Mixin, MixinBuilder>, Spec {
+  factory Mixin([void updates(MixinBuilder b)]) = _$Mixin;
+
+  Mixin._();
+
+  @override
+  BuiltList<Expression> get annotations;
+
+  @override
+  BuiltList<String> get docs;
+
+  @nullable
+  Reference get on;
+
+  BuiltList<Reference> get implements;
+
+  @override
+  BuiltList<Reference> get types;
+
+  BuiltList<Method> get methods;
+
+  /// Name of the mixin.
+  String get name;
+
+  @override
+  R accept<R>(
+    SpecVisitor<R> visitor, [
+    R context,
+  ]) {
+    return visitor.visitMixin(this, context);
+  }
+}
+
+abstract class MixinBuilder extends Object
+    with HasAnnotationsBuilder, HasDartDocsBuilder, HasGenericsBuilder
+    implements Builder<Mixin, MixinBuilder> {
+  factory MixinBuilder() = _$MixinBuilder;
+
+  MixinBuilder._();
+
+  @override
+  ListBuilder<Expression> annotations = ListBuilder<Expression>();
+
+  @override
+  ListBuilder<String> docs = ListBuilder<String>();
+
+  Reference on;
+
+  ListBuilder<Reference> implements = ListBuilder<Reference>();
+
+  @override
+  ListBuilder<Reference> types = ListBuilder<Reference>();
+
+  ListBuilder<Method> methods = ListBuilder<Method>();
+
+  /// Name of the mixin.
+  String name;
+}

--- a/lib/src/specs/mixin.dart
+++ b/lib/src/specs/mixin.dart
@@ -21,7 +21,7 @@ part 'mixin.g.dart';
 abstract class Mixin extends Object
     with HasAnnotations, HasDartDocs, HasGenerics
     implements Built<Mixin, MixinBuilder>, Spec {
-  factory Mixin([void updates(MixinBuilder b)]) = _$Mixin;
+  factory Mixin([void Function(MixinBuilder) updates]) = _$Mixin;
 
   Mixin._();
 

--- a/lib/src/specs/mixin.g.dart
+++ b/lib/src/specs/mixin.g.dart
@@ -1,0 +1,259 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'mixin.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+class _$Mixin extends Mixin {
+  @override
+  final BuiltList<Expression> annotations;
+  @override
+  final BuiltList<String> docs;
+  @override
+  final Reference on;
+  @override
+  final BuiltList<Reference> implements;
+  @override
+  final BuiltList<Reference> types;
+  @override
+  final BuiltList<Method> methods;
+  @override
+  final String name;
+
+  factory _$Mixin([void Function(MixinBuilder) updates]) =>
+      (new MixinBuilder()..update(updates)).build() as _$Mixin;
+
+  _$Mixin._(
+      {this.annotations,
+      this.docs,
+      this.on,
+      this.implements,
+      this.types,
+      this.methods,
+      this.name})
+      : super._() {
+    if (annotations == null) {
+      throw new BuiltValueNullFieldError('Mixin', 'annotations');
+    }
+    if (docs == null) {
+      throw new BuiltValueNullFieldError('Mixin', 'docs');
+    }
+    if (implements == null) {
+      throw new BuiltValueNullFieldError('Mixin', 'implements');
+    }
+    if (types == null) {
+      throw new BuiltValueNullFieldError('Mixin', 'types');
+    }
+    if (methods == null) {
+      throw new BuiltValueNullFieldError('Mixin', 'methods');
+    }
+    if (name == null) {
+      throw new BuiltValueNullFieldError('Mixin', 'name');
+    }
+  }
+
+  @override
+  Mixin rebuild(void Function(MixinBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  _$MixinBuilder toBuilder() => new _$MixinBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is Mixin &&
+        annotations == other.annotations &&
+        docs == other.docs &&
+        on == other.on &&
+        implements == other.implements &&
+        types == other.types &&
+        methods == other.methods &&
+        name == other.name;
+  }
+
+  @override
+  int get hashCode {
+    return $jf($jc(
+        $jc(
+            $jc(
+                $jc(
+                    $jc($jc($jc(0, annotations.hashCode), docs.hashCode),
+                        on.hashCode),
+                    implements.hashCode),
+                types.hashCode),
+            methods.hashCode),
+        name.hashCode));
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper('Mixin')
+          ..add('annotations', annotations)
+          ..add('docs', docs)
+          ..add('on', on)
+          ..add('implements', implements)
+          ..add('types', types)
+          ..add('methods', methods)
+          ..add('name', name))
+        .toString();
+  }
+}
+
+class _$MixinBuilder extends MixinBuilder {
+  _$Mixin _$v;
+
+  @override
+  ListBuilder<Expression> get annotations {
+    _$this;
+    return super.annotations ??= new ListBuilder<Expression>();
+  }
+
+  @override
+  set annotations(ListBuilder<Expression> annotations) {
+    _$this;
+    super.annotations = annotations;
+  }
+
+  @override
+  ListBuilder<String> get docs {
+    _$this;
+    return super.docs ??= new ListBuilder<String>();
+  }
+
+  @override
+  set docs(ListBuilder<String> docs) {
+    _$this;
+    super.docs = docs;
+  }
+
+  @override
+  Reference get on {
+    _$this;
+    return super.on;
+  }
+
+  @override
+  set on(Reference on) {
+    _$this;
+    super.on = on;
+  }
+
+  @override
+  ListBuilder<Reference> get implements {
+    _$this;
+    return super.implements ??= new ListBuilder<Reference>();
+  }
+
+  @override
+  set implements(ListBuilder<Reference> implements) {
+    _$this;
+    super.implements = implements;
+  }
+
+  @override
+  ListBuilder<Reference> get types {
+    _$this;
+    return super.types ??= new ListBuilder<Reference>();
+  }
+
+  @override
+  set types(ListBuilder<Reference> types) {
+    _$this;
+    super.types = types;
+  }
+
+  @override
+  ListBuilder<Method> get methods {
+    _$this;
+    return super.methods ??= new ListBuilder<Method>();
+  }
+
+  @override
+  set methods(ListBuilder<Method> methods) {
+    _$this;
+    super.methods = methods;
+  }
+
+  @override
+  String get name {
+    _$this;
+    return super.name;
+  }
+
+  @override
+  set name(String name) {
+    _$this;
+    super.name = name;
+  }
+
+  _$MixinBuilder() : super._();
+
+  MixinBuilder get _$this {
+    if (_$v != null) {
+      super.annotations = _$v.annotations?.toBuilder();
+      super.docs = _$v.docs?.toBuilder();
+      super.on = _$v.on;
+      super.implements = _$v.implements?.toBuilder();
+      super.types = _$v.types?.toBuilder();
+      super.methods = _$v.methods?.toBuilder();
+      super.name = _$v.name;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(Mixin other) {
+    if (other == null) {
+      throw new ArgumentError.notNull('other');
+    }
+    _$v = other as _$Mixin;
+  }
+
+  @override
+  void update(void Function(MixinBuilder) updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  _$Mixin build() {
+    _$Mixin _$result;
+    try {
+      _$result = _$v ??
+          new _$Mixin._(
+              annotations: annotations.build(),
+              docs: docs.build(),
+              on: on,
+              implements: implements.build(),
+              types: types.build(),
+              methods: methods.build(),
+              name: name);
+    } catch (_) {
+      String _$failedField;
+      try {
+        _$failedField = 'annotations';
+        annotations.build();
+        _$failedField = 'docs';
+        docs.build();
+
+        _$failedField = 'implements';
+        implements.build();
+        _$failedField = 'types';
+        types.build();
+        _$failedField = 'methods';
+        methods.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            'Mixin', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new

--- a/lib/src/visitors.dart
+++ b/lib/src/visitors.dart
@@ -12,6 +12,7 @@ import 'specs/expression.dart';
 import 'specs/field.dart';
 import 'specs/library.dart';
 import 'specs/method.dart';
+import 'specs/mixin.dart';
 import 'specs/reference.dart';
 import 'specs/type_function.dart';
 import 'specs/type_reference.dart';
@@ -23,6 +24,8 @@ abstract class SpecVisitor<T> {
   T visitAnnotation(Expression spec, [T context]);
 
   T visitClass(Class spec, [T context]);
+
+  T visitMixin(Mixin mixin, [T context]);
 
   T visitConstructor(Constructor spec, String clazz, [T context]);
 

--- a/test/specs/mixin_test.dart
+++ b/test/specs/mixin_test.dart
@@ -1,0 +1,139 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:code_builder/code_builder.dart';
+import 'package:test/test.dart';
+
+import '../common.dart';
+
+void main() {
+  useDartfmt();
+
+  test('should create a mixin', () {
+    expect(
+      Mixin((b) => b..name = 'Foo'),
+      equalsDart(r'''
+        mixin Foo {}
+      '''),
+    );
+  });
+
+  test('should create a mixin with documentations', () {
+    expect(
+      Mixin(
+        (b) => b
+          ..name = 'Foo'
+          ..docs.addAll(
+            const [
+              '/// My favorite mixin.',
+            ],
+          ),
+      ),
+      equalsDart(r'''
+        /// My favorite mixin.
+        mixin Foo {}
+      '''),
+    );
+  });
+
+  test('should create a mixin with annotations', () {
+    expect(
+      Mixin(
+        (b) => b
+          ..name = 'Foo'
+          ..annotations.addAll([
+            refer('deprecated'),
+            refer('Deprecated').call([literalString('This is an old mixin')])
+          ]),
+      ),
+      equalsDart(r'''
+        @deprecated
+        @Deprecated('This is an old mixin')
+        mixin Foo {}
+      '''),
+    );
+  });
+
+  test('should create a mixin with a generic type', () {
+    expect(
+      Mixin((b) => b
+        ..name = 'List'
+        ..types.add(refer('T'))),
+      equalsDart(r'''
+        mixin List<T> {}
+      '''),
+    );
+  });
+
+  test('should create a mixin with multiple generic types', () {
+    expect(
+      Mixin(
+        (b) => b
+          ..name = 'Map'
+          ..types.addAll([
+            refer('K'),
+            refer('V'),
+          ]),
+      ),
+      equalsDart(r'''
+        mixin Map<K, V> {}
+      '''),
+    );
+  });
+
+  test('should create a mixin with a bound generic type', () {
+    expect(
+      Mixin((b) => b
+        ..name = 'Comparable'
+        ..types.add(TypeReference((b) => b
+          ..symbol = 'T'
+          ..bound = TypeReference((b) => b
+            ..symbol = 'Comparable'
+            ..types.add(refer('T').type))))),
+      equalsDart(r'''
+        mixin Comparable<T extends Comparable<T>> {}
+      '''),
+    );
+  });
+
+  test('should create a mixin on another mixin', () {
+    expect(
+      Mixin((b) => b
+        ..name = 'Foo'
+        ..on = TypeReference((b) => b.symbol = 'Bar')),
+      equalsDart(r'''
+        mixin Foo on Bar {}
+      '''),
+    );
+  });
+
+  test('should create a mixin implementing another mixin', () {
+    expect(
+      Mixin((b) => b
+        ..name = 'Foo'
+        ..on = TypeReference((b) => b.symbol = 'Bar')
+        ..implements.add(TypeReference((b) => b.symbol = 'Foo'))),
+      equalsDart(r'''
+        mixin Foo on Bar implements Foo {}
+      '''),
+    );
+  });
+
+  test('should create a mixin with a method', () {
+    expect(
+      Mixin((b) => b
+        ..name = 'Foo'
+        ..methods.add(Method((b) => b
+          ..name = 'foo'
+          ..body = const Code('return 1+ 2;')))),
+      equalsDart(r'''
+        mixin Foo {
+          foo() {
+            return 1 + 2;
+          }
+        }
+      '''),
+    );
+  });
+}


### PR DESCRIPTION
adds `specs/mixin.dart` to generate `Mixin`s

see also [Dart 2 Mixin Declarations](https://github.com/dart-lang/language/blob/master/accepted/2.1/super-mixins/feature-specification.md)