### PR TITLE
Update contributing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,9 @@ will be on a best-effort basis.
 Use [`build_runner`][build_runner]:
 
 ```bash
+$ pub global activate build_runner
 $ mv build.disabled.yaml build.yaml
-$ pub run build_runner build --delete-conflicting-outputs
+$ pub global run build_runner build --delete-conflicting-outputs
 $ mv build.yaml build.disabled.yaml
 ```
 

--- a/build.disabled.yaml
+++ b/build.disabled.yaml
@@ -6,7 +6,7 @@ targets:
 builders:
   _built_value:
     target: ":code_builder"
-    import: "../../../tool/src/builder.dart"
+    import: "tool/src/builder.dart"
     builder_factories:
       - "builtValueBuilder"
     build_extensions:


### PR DESCRIPTION
1. `pub run build_runner build` was never happy if my existing foo.dart and foo.g.dart files were not in agreement. Errors like:

```none
Unable to spawn isolate: lib/src/specs/type_reference.g.dart:9:7: Error: The non-abstract class '_$TypeReference' is missing implementations for these members:                                                                                                                                                 
 - TypeReference.isNullable                                                                                                                             
Try to either                                                                                                                                           
 - provide an implementation,                                                                                                                           
 - inherit an implementation from a superclass or mixin,                                                                                                
 - mark the class as abstract, or                                                                                                                       
 - provide a 'noSuchMethod' implementation.                                                                                                             
                                                                                                                                                        
class _$TypeReference extends TypeReference {                                                                                                           
      ^^^^^^^^^^^^^^^                                                                                                                                   
lib/src/specs/type_reference.dart:43:12: Context: 'TypeReference.isNullable' is defined here.                                                           
  bool get isNullable;                                                                                                                                  
           ^^^^^^^^^^
```

2. `pub run build_runner build` complained about using `..` in build.yaml:

```none
[WARNING] The `../` import syntax in build.yaml is now deprecated, instead do a normal relative import as if it was from the root of the package. Found `../../../tool/src/builder.dart` in your `build.yaml` file.
```