### PR TITLE
Add isNullable field to TypeReference, and isNullSafety to DartEmitter

### DIFF
--- a/lib/src/emitter.dart
+++ b/lib/src/emitter.dart
@@ -59,15 +59,24 @@ class DartEmitter extends Object
   /// lint.
   final bool orderDirectives;
 
+  /// If nullable types should be emitted with the nullable suffix ("?").
+  final bool _isNullSafety;
+
   /// Creates a new instance of [DartEmitter].
   ///
   /// May specify an [Allocator] to use for symbols, otherwise uses a no-op.
-  DartEmitter([this.allocator = Allocator.none, bool orderDirectives = false])
-      : orderDirectives = orderDirectives ?? false;
+  DartEmitter(
+      [this.allocator = Allocator.none,
+      bool orderDirectives = false,
+      bool isNullSafety = false])
+      : orderDirectives = orderDirectives ?? false,
+        _isNullSafety = isNullSafety ?? false;
 
   /// Creates a new instance of [DartEmitter] with simple automatic imports.
-  factory DartEmitter.scoped({bool orderDirectives = false}) {
-    return DartEmitter(Allocator.simplePrefixing(), orderDirectives);
+  factory DartEmitter.scoped(
+      {bool orderDirectives = false, bool isNullSafety = false}) {
+    return DartEmitter(
+        Allocator.simplePrefixing(), orderDirectives, isNullSafety);
   }
 
   static bool _isLambdaBody(Code code) =>
@@ -490,6 +499,9 @@ class DartEmitter extends Object
       spec.bound.type.accept(this, output);
     }
     visitTypeParameters(spec.types.map((r) => r.type), output);
+    if (_isNullSafety && (spec.isNullable ?? false)) {
+      output.write('?');
+    }
     return output;
   }
 

--- a/lib/src/emitter.dart
+++ b/lib/src/emitter.dart
@@ -60,7 +60,10 @@ class DartEmitter extends Object
   final bool orderDirectives;
 
   /// If nullable types should be emitted with the nullable suffix ("?").
-  final bool _isNullSafety;
+  ///
+  /// Null safety syntax should only be enabled if the output will be used with
+  /// a Dart language version which supports it.
+  final bool _useNullSafetySyntax;
 
   /// Creates a new instance of [DartEmitter].
   ///
@@ -68,15 +71,15 @@ class DartEmitter extends Object
   DartEmitter(
       [this.allocator = Allocator.none,
       bool orderDirectives = false,
-      bool isNullSafety = false])
+      bool useNullSafetySyntax = false])
       : orderDirectives = orderDirectives ?? false,
-        _isNullSafety = isNullSafety ?? false;
+        _useNullSafetySyntax = useNullSafetySyntax ?? false;
 
   /// Creates a new instance of [DartEmitter] with simple automatic imports.
   factory DartEmitter.scoped(
-      {bool orderDirectives = false, bool isNullSafety = false}) {
+      {bool orderDirectives = false, bool useNullSafetySyntax = false}) {
     return DartEmitter(
-        Allocator.simplePrefixing(), orderDirectives, isNullSafety);
+        Allocator.simplePrefixing(), orderDirectives, useNullSafetySyntax);
   }
 
   static bool _isLambdaBody(Code code) =>
@@ -499,7 +502,7 @@ class DartEmitter extends Object
       spec.bound.type.accept(this, output);
     }
     visitTypeParameters(spec.types.map((r) => r.type), output);
-    if (_isNullSafety && (spec.isNullable ?? false)) {
+    if (_useNullSafetySyntax && (spec.isNullable ?? false)) {
       output.write('?');
     }
     return output;

--- a/lib/src/specs/type_reference.dart
+++ b/lib/src/specs/type_reference.dart
@@ -40,6 +40,9 @@ abstract class TypeReference extends Expression
   BuiltList<Reference> get types;
 
   /// Optional nullability.
+  ///
+  /// An emitter may ignore this if the output is not targeting a Dart language
+  /// version that supports null safety.
   @nullable
   bool get isNullable;
 
@@ -139,5 +142,8 @@ abstract class TypeReferenceBuilder extends Object
   ListBuilder<Reference> types = ListBuilder<Reference>();
 
   /// Optional nullability.
+  ///
+  /// An emitter may ignore this if the output is not targeting a Dart language
+  /// version that supports null safety.
   bool isNullable;
 }

--- a/lib/src/specs/type_reference.dart
+++ b/lib/src/specs/type_reference.dart
@@ -139,6 +139,5 @@ abstract class TypeReferenceBuilder extends Object
   ListBuilder<Reference> types = ListBuilder<Reference>();
 
   /// Optional nullability.
-  @override
   bool isNullable;
 }

--- a/lib/src/specs/type_reference.dart
+++ b/lib/src/specs/type_reference.dart
@@ -39,6 +39,10 @@ abstract class TypeReference extends Expression
   @override
   BuiltList<Reference> get types;
 
+  /// Optional nullability.
+  @nullable
+  bool get isNullable;
+
   @override
   R accept<R>(
     SpecVisitor<R> visitor, [
@@ -133,4 +137,8 @@ abstract class TypeReferenceBuilder extends Object
 
   @override
   ListBuilder<Reference> types = ListBuilder<Reference>();
+
+  /// Optional nullability.
+  @override
+  bool isNullable;
 }

--- a/lib/src/specs/type_reference.g.dart
+++ b/lib/src/specs/type_reference.g.dart
@@ -15,11 +15,14 @@ class _$TypeReference extends TypeReference {
   final Reference bound;
   @override
   final BuiltList<Reference> types;
+  @override
+  final bool isNullable;
 
   factory _$TypeReference([void Function(TypeReferenceBuilder) updates]) =>
       (new TypeReferenceBuilder()..update(updates)).build() as _$TypeReference;
 
-  _$TypeReference._({this.symbol, this.url, this.bound, this.types})
+  _$TypeReference._(
+      {this.symbol, this.url, this.bound, this.types, this.isNullable})
       : super._() {
     if (symbol == null) {
       throw new BuiltValueNullFieldError('TypeReference', 'symbol');
@@ -44,14 +47,16 @@ class _$TypeReference extends TypeReference {
         symbol == other.symbol &&
         url == other.url &&
         bound == other.bound &&
-        types == other.types;
+        types == other.types &&
+        isNullable == other.isNullable;
   }
 
   @override
   int get hashCode {
     return $jf($jc(
-        $jc($jc($jc(0, symbol.hashCode), url.hashCode), bound.hashCode),
-        types.hashCode));
+        $jc($jc($jc($jc(0, symbol.hashCode), url.hashCode), bound.hashCode),
+            types.hashCode),
+        isNullable.hashCode));
   }
 
   @override
@@ -60,7 +65,8 @@ class _$TypeReference extends TypeReference {
           ..add('symbol', symbol)
           ..add('url', url)
           ..add('bound', bound)
-          ..add('types', types))
+          ..add('types', types)
+          ..add('isNullable', isNullable))
         .toString();
   }
 }
@@ -116,6 +122,18 @@ class _$TypeReferenceBuilder extends TypeReferenceBuilder {
     super.types = types;
   }
 
+  @override
+  bool get isNullable {
+    _$this;
+    return super.isNullable;
+  }
+
+  @override
+  set isNullable(bool isNullable) {
+    _$this;
+    super.isNullable = isNullable;
+  }
+
   _$TypeReferenceBuilder() : super._();
 
   TypeReferenceBuilder get _$this {
@@ -124,6 +142,7 @@ class _$TypeReferenceBuilder extends TypeReferenceBuilder {
       super.url = _$v.url;
       super.bound = _$v.bound;
       super.types = _$v.types?.toBuilder();
+      super.isNullable = _$v.isNullable;
       _$v = null;
     }
     return this;
@@ -148,7 +167,11 @@ class _$TypeReferenceBuilder extends TypeReferenceBuilder {
     try {
       _$result = _$v ??
           new _$TypeReference._(
-              symbol: symbol, url: url, bound: bound, types: types.build());
+              symbol: symbol,
+              url: url,
+              bound: bound,
+              types: types.build(),
+              isNullable: isNullable);
     } catch (_) {
       String _$failedField;
       try {

--- a/test/specs/type_reference_test.dart
+++ b/test/specs/type_reference_test.dart
@@ -1,0 +1,56 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:code_builder/code_builder.dart';
+import 'package:test/test.dart';
+
+import '../common.dart';
+
+void main() {
+  useDartfmt();
+
+  test('should create a nullable type in a pre-Null Safety library', () {
+    expect(
+      TypeReference((b) => b
+        ..symbol = 'Foo'
+        ..isNullable = true),
+      equalsDart(r'''
+        Foo
+      '''),
+    );
+  });
+
+  group('in a Null Safety library', () {
+    DartEmitter emitter;
+
+    setUp(() => emitter = DartEmitter.scoped(isNullSafety: true));
+
+    test('should create a nullable type', () {
+      expect(
+        TypeReference((b) => b
+          ..symbol = 'Foo'
+          ..isNullable = true),
+        equalsDart(r'Foo?', emitter),
+      );
+    });
+
+    test('should create a non-nullable type', () {
+      expect(
+        TypeReference((b) => b.symbol = 'Foo'),
+        equalsDart(r'Foo', emitter),
+      );
+    });
+
+    test('should create a type with nullable type arguments', () {
+      expect(
+        TypeReference((b) => b
+          ..symbol = 'List'
+          ..types.add(TypeReference((b) => b
+            ..symbol = 'int'
+            ..isNullable = true))),
+        equalsDart(r'List<int?>', emitter),
+      );
+    });
+  });
+}

--- a/test/specs/type_reference_test.dart
+++ b/test/specs/type_reference_test.dart
@@ -24,7 +24,7 @@ void main() {
   group('in a Null Safety library', () {
     DartEmitter emitter;
 
-    setUp(() => emitter = DartEmitter.scoped(isNullSafety: true));
+    setUp(() => emitter = DartEmitter.scoped(useNullSafetySyntax: true));
 
     test('should create a nullable type', () {
       expect(


### PR DESCRIPTION
Fixes #270 

I'm _very_ open on better names to the DartEmitter constructor parameter, `isNullSafety`. The analyzer's LibraryElement has the deprecated name, `isNonNullableByDefault`. WDYT? `hasNullSafety`?

I'd like to have tested a nullable function type, but it didn't seem possible other than setting `symbol` to, e.g. `void Function(int)`.