### PR TITLE
Make Reference.type return TypeReference

### DIFF
--- a/lib/src/specs/reference.dart
+++ b/lib/src/specs/reference.dart
@@ -123,7 +123,7 @@ class Reference extends Expression implements Spec {
       .toString();
 
   /// Returns as a [TypeReference], which allows adding generic type parameters.
-  Reference get type => TypeReference((b) => b
+  TypeReference get type => TypeReference((b) => b
     ..url = url
     ..symbol = symbol);
 }


### PR DESCRIPTION
My motivation here is to make it easier to create generic type references (e.g., `BuiltList<Foo>`). Since this method is documented as returning `TypeReference`, this seems like a safe change.

As far as I can tell, the only way to create `BuiltList<Foo>` is:

```dart
TypeReference(
  (b) => b
    ..url = 'package:built_collection/built_collection.dart'
    ..symbol = 'BuiltList'
    ..types.add(refer('Foo')));
```

It would be more ergonomic if `Reference.type` returned a `TypeReference` instead of a `Reference` so that we can call rebuild on it.

```dart
refer('BuiltList', 'package:built_collection/built_collection.dart')
  .type
  .rebuild((b) => b..types.add(refer('Foo')));
```