### PR TITLE
Sort allocator imports before other directives

### DIFF
--- a/lib/src/emitter.dart
+++ b/lib/src/emitter.dart
@@ -315,7 +315,7 @@ class DartEmitter extends Object
       }
     }
 
-    final directives = <Directive>[...spec.directives, ...allocator.imports];
+    final directives = <Directive>[...allocator.imports, ...spec.directives];
 
     if (orderDirectives) {
       directives.sort();

--- a/test/directive_test.dart
+++ b/test/directive_test.dart
@@ -38,20 +38,20 @@ void main() {
     expect(
       library,
       equalsDart(r'''
-          export '../relative.dart';
-          export 'package:foo/foo.dart';
-          part 'lib.g.dart';
           import '../relative.dart' as _i1;
           import 'package:foo/foo.dart' as _i2;
           import 'package:foo/bar.dart' as _i3;
           import 'dart:collection' as _i4;
+          export '../relative.dart';
+          export 'package:foo/foo.dart';
+          part 'lib.g.dart';
 
           final relativeRef = _i1.Relative();
           final pkgRefFoo = _i2.Foo();
           final pkgRefBar = _i3.Bar();
           final collectionRef = _i4.LinkedHashMap();''', DartEmitter.scoped()),
     );
-  }, skip: 'failing due to whitespace issue in equalsDart');
+  });
 
   test('should emit a source file with ordered', () {
     expect(


### PR DESCRIPTION
Manually specified directive, most likely exports or part directives,
should generally follow imports. Move imports from `refer` URIs to the
beginning so that they get the correct order as long as manually
specified directives where in the correct order, regardless of sorting
directives.