### PR TITLE
Add an isNullable field to FunctionType

### DIFF
--- a/lib/src/emitter.dart
+++ b/lib/src/emitter.dart
@@ -373,7 +373,11 @@ class DartEmitter extends Object
       });
       output.write('}');
     }
-    return output..write(')');
+    output.write(')');
+    if (_useNullSafetySyntax && (spec.isNullable ?? false)) {
+      output.write('?');
+    }
+    return output;
   }
 
   @override

--- a/lib/src/specs/type_function.dart
+++ b/lib/src/specs/type_function.dart
@@ -57,6 +57,13 @@ abstract class FunctionType extends Expression
   @override
   Reference get type => this;
 
+  /// Optional nullability.
+  ///
+  /// An emitter may ignore this if the output is not targeting a Dart language
+  /// version that supports null safety.
+  @nullable
+  bool get isNullable;
+
   @override
   Expression newInstance(
     Iterable<Expression> positionalArguments, [
@@ -113,4 +120,6 @@ abstract class FunctionTypeBuilder extends Object
 
   MapBuilder<String, Reference> namedParameters =
       MapBuilder<String, Reference>();
+
+  bool isNullable;
 }

--- a/lib/src/specs/type_function.g.dart
+++ b/lib/src/specs/type_function.g.dart
@@ -17,6 +17,8 @@ class _$FunctionType extends FunctionType {
   final BuiltList<Reference> optionalParameters;
   @override
   final BuiltMap<String, Reference> namedParameters;
+  @override
+  final bool isNullable;
 
   factory _$FunctionType([void Function(FunctionTypeBuilder) updates]) =>
       (new FunctionTypeBuilder()..update(updates)).build() as _$FunctionType;
@@ -26,7 +28,8 @@ class _$FunctionType extends FunctionType {
       this.types,
       this.requiredParameters,
       this.optionalParameters,
-      this.namedParameters})
+      this.namedParameters,
+      this.isNullable})
       : super._() {
     if (types == null) {
       throw new BuiltValueNullFieldError('FunctionType', 'types');
@@ -58,17 +61,20 @@ class _$FunctionType extends FunctionType {
         types == other.types &&
         requiredParameters == other.requiredParameters &&
         optionalParameters == other.optionalParameters &&
-        namedParameters == other.namedParameters;
+        namedParameters == other.namedParameters &&
+        isNullable == other.isNullable;
   }
 
   @override
   int get hashCode {
     return $jf($jc(
         $jc(
-            $jc($jc($jc(0, returnType.hashCode), types.hashCode),
-                requiredParameters.hashCode),
-            optionalParameters.hashCode),
-        namedParameters.hashCode));
+            $jc(
+                $jc($jc($jc(0, returnType.hashCode), types.hashCode),
+                    requiredParameters.hashCode),
+                optionalParameters.hashCode),
+            namedParameters.hashCode),
+        isNullable.hashCode));
   }
 
   @override
@@ -78,7 +84,8 @@ class _$FunctionType extends FunctionType {
           ..add('types', types)
           ..add('requiredParameters', requiredParameters)
           ..add('optionalParameters', optionalParameters)
-          ..add('namedParameters', namedParameters))
+          ..add('namedParameters', namedParameters)
+          ..add('isNullable', isNullable))
         .toString();
   }
 }
@@ -146,6 +153,18 @@ class _$FunctionTypeBuilder extends FunctionTypeBuilder {
     super.namedParameters = namedParameters;
   }
 
+  @override
+  bool get isNullable {
+    _$this;
+    return super.isNullable;
+  }
+
+  @override
+  set isNullable(bool isNullable) {
+    _$this;
+    super.isNullable = isNullable;
+  }
+
   _$FunctionTypeBuilder() : super._();
 
   FunctionTypeBuilder get _$this {
@@ -155,6 +174,7 @@ class _$FunctionTypeBuilder extends FunctionTypeBuilder {
       super.requiredParameters = _$v.requiredParameters?.toBuilder();
       super.optionalParameters = _$v.optionalParameters?.toBuilder();
       super.namedParameters = _$v.namedParameters?.toBuilder();
+      super.isNullable = _$v.isNullable;
       _$v = null;
     }
     return this;
@@ -183,7 +203,8 @@ class _$FunctionTypeBuilder extends FunctionTypeBuilder {
               types: types.build(),
               requiredParameters: requiredParameters.build(),
               optionalParameters: optionalParameters.build(),
-              namedParameters: namedParameters.build());
+              namedParameters: namedParameters.build(),
+              isNullable: isNullable);
     } catch (_) {
       String _$failedField;
       try {

--- a/test/specs/code/expression_test.dart
+++ b/test/specs/code/expression_test.dart
@@ -301,6 +301,45 @@ void main() {
     );
   });
 
+  test('should emit a nullable function type in a Null Safety library', () {
+    final emitter = DartEmitter.scoped(useNullSafetySyntax: true);
+    expect(
+      FunctionType((b) => b
+        ..requiredParameters.add(refer('String'))
+        ..isNullable = true),
+      equalsDart('Function(String)?', emitter),
+    );
+  });
+
+  test('should emit a nullable function type in pre-Null Safety library', () {
+    expect(
+      FunctionType((b) => b
+        ..requiredParameters.add(refer('String'))
+        ..isNullable = true),
+      equalsDart('Function(String)'),
+    );
+  });
+
+  test('should emit a non-nullable function type in a Null Safety library', () {
+    final emitter = DartEmitter.scoped(useNullSafetySyntax: true);
+    expect(
+      FunctionType((b) => b
+        ..requiredParameters.add(refer('String'))
+        ..isNullable = false),
+      equalsDart('Function(String)', emitter),
+    );
+  });
+
+  test('should emit a non-nullable function type in pre-Null Safety library',
+      () {
+    expect(
+      FunctionType((b) => b
+        ..requiredParameters.add(refer('String'))
+        ..isNullable = false),
+      equalsDart('Function(String)'),
+    );
+  });
+
   test('should emit a closure', () {
     expect(
       refer('map').property('putIfAbsent').call([


### PR DESCRIPTION
This new field allows FunctionTypes to be written as nullable, using an Emitter that uses null-safety syntax.

Fixes #283 