### PR TITLE
Add a thrown getter to Expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.4.0-dev
+
+* Introduce `Expression.thrown` for throwing an expression.
+
 ## 3.3.0
 
 * Add `??` null-aware operator.

--- a/lib/src/specs/expression.dart
+++ b/lib/src/specs/expression.dart
@@ -286,6 +286,13 @@ abstract class Expression implements Spec {
         '',
       );
 
+  /// This expression preceded by `throw`.
+  Expression get thrown => BinaryExpression._(
+        const LiteralExpression._('throw'),
+        this,
+        '',
+      );
+
   /// May be overridden to support other types implementing [Expression].
   @visibleForOverriding
   Expression get expression => this;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: code_builder
-version: 3.3.0
+version: 3.4.0-dev
 
 description: >-
   A fluent, builder-based library for generating valid Dart code

--- a/test/specs/code/expression_test.dart
+++ b/test/specs/code/expression_test.dart
@@ -453,6 +453,13 @@ void main() {
     );
   });
 
+  test('should emit throw', () {
+    expect(
+      literalNull.thrown,
+      equalsDart('throw null'),
+    );
+  });
+
   test('should emit an explicit cast', () {
     expect(
       refer('foo').asA(refer('String')).property('length'),


### PR DESCRIPTION
Fixes #286 

With this change, an expression can be thrown. This can be done as part of an function expression body, or as a statement, by using `.statement`.