### PR TITLE
Bump min Dart SDK to 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: dart
 
 dart:
   - dev
-  - 2.6.0
+  - 2.7.0
 
 dart_task:
 - test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.4.0-dev
 
 * Introduce `Expression.thrown` for throwing an expression.
+* Update SDK requirement to `>=2.7.0 <3.0.0`.
 
 ## 3.3.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ description: >-
 homepage: https://github.com/dart-lang/code_builder
 
 environment:
-  sdk: '>=2.6.0 <3.0.0'
+  sdk: '>=2.7.0 <3.0.0'
 
 dependencies:
   built_collection: '>=3.0.0 <5.0.0'


### PR DESCRIPTION
Works-around issue with testing Dart 2.6 in CI and changes to
pkg:analyzer

Specifically, it seems there was a change to a non-public analyzer API
that is picked up by packages on Dart 2.6 but the SDK constraint on
`dart_style` prevents picking up a version of that package with the fix.