### PR TITLE
Flip expected and actual in mismatch description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.4.1-dev
+
+* Fix confusing mismatch description from `equalsDart`.
+  https://github.com/dart-lang/code_builder/issues/293
+
 ## 3.4.0
 
 * Introduce `Expression.thrown` for throwing an expression.

--- a/lib/src/matchers.dart
+++ b/lib/src/matchers.dart
@@ -11,7 +11,11 @@ import 'emitter.dart';
 String _dart(Spec spec, DartEmitter emitter) =>
     EqualsDart._format(spec.accept<StringSink>(emitter).toString());
 
-/// Returns a matcher for Dart source code.
+/// Returns a matcher for [Spec] objects that emit code matching [source].
+///
+/// Both [source] and the result emitted from the compared [Spec] are formatted
+/// with [EqualsDart.format]. A plain [DartEmitter] is used by default and may
+/// be overridden with [emitter].
 Matcher equalsDart(
   String source, [
   DartEmitter emitter,
@@ -39,12 +43,13 @@ class EqualsDart extends Matcher {
   }
 
   final DartEmitter _emitter;
-  final String _source;
+  final String _expectedSource;
 
-  const EqualsDart._(this._source, this._emitter);
+  const EqualsDart._(this._expectedSource, this._emitter);
 
   @override
-  Description describe(Description description) => description.add(_source);
+  Description describe(Description description) =>
+      description.add(_expectedSource);
 
   @override
   Description describeMismatch(
@@ -53,10 +58,10 @@ class EqualsDart extends Matcher {
     matchState,
     verbose,
   ) {
-    final result = _dart(item, _emitter);
-    return equals(result).describeMismatch(
-      _source,
-      mismatchDescription.add(result),
+    final actualSource = _dart(item, _emitter);
+    return equals(_expectedSource).describeMismatch(
+      actualSource,
+      mismatchDescription,
       matchState,
       verbose,
     );
@@ -64,5 +69,5 @@ class EqualsDart extends Matcher {
 
   @override
   bool matches(covariant Spec item, matchState) =>
-      _dart(item, _emitter) == _source;
+      _dart(item, _emitter) == _expectedSource;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: code_builder
-version: 3.4.0
+version: 3.4.1-dev
 
 description: >-
   A fluent, builder-based library for generating valid Dart code

--- a/test/matcher_test.dart
+++ b/test/matcher_test.dart
@@ -1,0 +1,30 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:code_builder/code_builder.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('describes mismatches', () {
+    const actual = Code('final x=1;');
+    equalsDart('final y=2;').expectMismatch(actual, '''
+  Expected: final y=2;
+    Actual: StaticCode:<final x=1;>
+     Which: is different.
+            Expected: final y=2;
+              Actual: final x=1;
+                            ^
+             Differ at offset 6
+''');
+  });
+}
+
+extension on Matcher {
+  void expectMismatch(dynamic actual, String mismatch) {
+    expect(
+        () => expect(actual, this),
+        throwsA(isA<TestFailure>().having(
+            (e) => e.message, 'message', equalsIgnoringWhitespace(mismatch))));
+  }
+}


### PR DESCRIPTION
Fixes #293

When describing a mismatch the _expected_ value should be passed to
`equals`, not the actual value. Also remove the source from the start of
the mismatch description since it's already present in the nested
"Actual" field.

Other refactoring:
- Rename `_source` to `_expectedSource` and `result` to `actualSource`
  for clarity.
- Expand the doc comment for `equalsDart`.