### PR TITLE
Add genericClosure on Method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.7.0-dev
+
+* Add support for converting a Method to a generic closure, with
+  `Method.genericClosure`.
+
 ## 3.6.0
 
 * Add support for creating `extension` methods.

--- a/lib/src/specs/expression/closure.dart
+++ b/lib/src/specs/expression/closure.dart
@@ -4,12 +4,21 @@
 
 part of code_builder.src.specs.expression;
 
+/// Returns [method] as closure, removing its return type and type parameters.
 Expression toClosure(Method method) {
   final withoutTypes = method.rebuild((b) {
     b.returns = null;
     b.types.clear();
   });
   return ClosureExpression._(withoutTypes);
+}
+
+/// Returns [method] as a (possibly) generic closure, removing its return type.
+Expression toGenericClosure(Method method) {
+  final withoutReturnType = method.rebuild((b) {
+    b.returns = null;
+  });
+  return ClosureExpression._(withoutReturnType);
 }
 
 class ClosureExpression extends Expression {

--- a/lib/src/specs/method.dart
+++ b/lib/src/specs/method.dart
@@ -94,6 +94,9 @@ abstract class Method extends Object
 
   /// This method as a closure.
   Expression get closure => toClosure(this);
+
+  /// This method as a (possibly) generic closure.
+  Expression get genericClosure => toGenericClosure(this);
 }
 
 abstract class MethodBuilder extends Object

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: code_builder
-version: 3.6.0
+version: 3.7.0-dev
 
 description: >-
   A fluent, builder-based library for generating valid Dart code

--- a/test/specs/code/expression_test.dart
+++ b/test/specs/code/expression_test.dart
@@ -350,6 +350,18 @@ void main() {
     );
   });
 
+  test('should emit a generic closure', () {
+    expect(
+      refer('map').property('putIfAbsent').call([
+        literalString('foo'),
+        Method((b) => b
+          ..types.add(refer('T'))
+          ..body = literalTrue.code).genericClosure,
+      ]),
+      equalsDart("map.putIfAbsent('foo', <T>() => true)"),
+    );
+  });
+
   test('should emit an assignment', () {
     expect(
       refer('foo').assign(literalTrue),


### PR DESCRIPTION
Fixes #309 

The existing `closure` getter strips a Method of its return type and type parameters. This new API, `genericClosure` keeps the type parameters, as they are legal, and can be useful.