### PR TITLE
Migrate to null safety

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   # Check code formatting and static analysis on a single OS (linux)
-  # against Dart dev and 2.7.0.
+  # against Dart dev and 2.12.0.
   analyze:
     runs-on: ubuntu-latest
     strategy:
@@ -24,7 +24,7 @@ jobs:
         version: [latest]
         include:
           - sdk: stable
-            version: 2.7.0
+            version: 2.12.0
     steps:
       - uses: actions/checkout@v2
       - uses: cedx/setup-dart@v2 # TODO(dart-lang/setup-dart#3): use the official setup-dart action
@@ -43,7 +43,7 @@ jobs:
 
   # Run tests on a matrix consisting of two dimensions:
   # 1. OS: ubuntu-latest, (macos-latest, windows-latest)
-  # 2. release channel: dev, 2.7.0
+  # 2. release channel: dev, 2.12.0
   test:
     needs: analyze
     runs-on: ${{ matrix.os }}
@@ -57,7 +57,7 @@ jobs:
         include:
           - os: ubuntu-latest
             sdk: stable
-            version: 2.7.0
+            version: 2.12.0
     steps:
       - uses: actions/checkout@v2
       - uses: cedx/setup-dart@v2 # TODO(dart-lang/setup-dart#3): use the official setup-dart action

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 4.0.0
+## 4.0.0-dev
 
 * Migrate to null safety.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.0
+
+* Migrate to null safety.
+
 ## 3.7.0
 
 * Add support for converting a Method to a generic closure, with

--- a/lib/src/allocator.dart
+++ b/lib/src/allocator.dart
@@ -51,7 +51,7 @@ class _Allocator implements Allocator {
   @override
   String allocate(Reference reference) {
     if (reference.url != null) {
-      _imports.add(reference.url);
+      _imports.add(reference.url!);
     }
     return reference.symbol;
   }
@@ -82,7 +82,7 @@ class _PrefixedAllocator implements Allocator {
     if (reference.url == null || _doNotPrefix.contains(reference.url)) {
       return symbol;
     }
-    return '_i${_imports.putIfAbsent(reference.url, _nextKey)}.$symbol';
+    return '_i${_imports.putIfAbsent(reference.url!, _nextKey)}.$symbol';
   }
 
   int _nextKey() => _keys++;

--- a/lib/src/allocator.dart
+++ b/lib/src/allocator.dart
@@ -50,8 +50,9 @@ class _Allocator implements Allocator {
 
   @override
   String allocate(Reference reference) {
-    if (reference.url != null) {
-      _imports.add(reference.url!);
+    final url = reference.url;
+    if (url != null) {
+      _imports.add(url);
     }
     return reference.symbol;
   }
@@ -79,10 +80,11 @@ class _PrefixedAllocator implements Allocator {
   @override
   String allocate(Reference reference) {
     final symbol = reference.symbol;
-    if (reference.url == null || _doNotPrefix.contains(reference.url)) {
+    final url = reference.url;
+    if (url == null || _doNotPrefix.contains(url)) {
       return symbol;
     }
-    return '_i${_imports.putIfAbsent(reference.url!, _nextKey)}.$symbol';
+    return '_i${_imports.putIfAbsent(url, _nextKey)}.$symbol';
   }
 
   int _nextKey() => _keys++;

--- a/lib/src/base.dart
+++ b/lib/src/base.dart
@@ -5,7 +5,7 @@
 import 'visitors.dart';
 
 abstract class Spec {
-  R accept<R>(SpecVisitor<R> visitor, [R context]);
+  R accept<R>(SpecVisitor<R> visitor, [R? context]);
 }
 
 /// Returns a generic [Spec] that is lazily generated when visited.
@@ -17,6 +17,6 @@ class _LazySpec implements Spec {
   const _LazySpec(this.generate);
 
   @override
-  R accept<R>(SpecVisitor<R> visitor, [R context]) =>
+  R accept<R>(SpecVisitor<R> visitor, [R? context]) =>
       generate().accept(visitor, context);
 }

--- a/lib/src/emitter.dart
+++ b/lib/src/emitter.dart
@@ -72,8 +72,8 @@ class DartEmitter extends Object
   /// May specify an [Allocator] to use for symbols, otherwise uses a no-op.
   DartEmitter(
       [this.allocator = Allocator.none,
-      bool orderDirectives = false,
-      bool useNullSafetySyntax = false])
+      bool? orderDirectives = false,
+      bool? useNullSafetySyntax = false])
       : orderDirectives = orderDirectives ?? false,
         _useNullSafetySyntax = useNullSafetySyntax ?? false;
 
@@ -83,7 +83,7 @@ class DartEmitter extends Object
       DartEmitter(
           Allocator.simplePrefixing(), orderDirectives, useNullSafetySyntax);
 
-  static bool _isLambdaBody(Code code) =>
+  static bool _isLambdaBody(Code? code) =>
       code is ToCodeExpression && !code.isStatement;
 
   /// Whether the provided [method] is considered a lambda method.
@@ -96,7 +96,7 @@ class DartEmitter extends Object
       constructor.factory && _isLambdaBody(constructor.body);
 
   @override
-  StringSink visitAnnotation(Expression spec, [StringSink output]) {
+  StringSink visitAnnotation(Expression spec, [StringSink? output]) {
     (output ??= StringBuffer()).write('@');
     spec.accept(this, output);
     output.write(' ');
@@ -104,54 +104,54 @@ class DartEmitter extends Object
   }
 
   @override
-  StringSink visitClass(Class spec, [StringSink output]) {
-    output ??= StringBuffer();
-    spec.docs.forEach(output.writeln);
-    spec.annotations.forEach((a) => visitAnnotation(a, output));
+  StringSink visitClass(Class spec, [StringSink? output]) {
+    final out = output ??= StringBuffer();
+    spec.docs.forEach(out.writeln);
+    spec.annotations.forEach((a) => visitAnnotation(a, out));
     if (spec.abstract) {
-      output.write('abstract ');
+      out.write('abstract ');
     }
-    output.write('class ${spec.name}');
-    visitTypeParameters(spec.types.map((r) => r.type), output);
+    out.write('class ${spec.name}');
+    visitTypeParameters(spec.types.map((r) => r.type), out);
     if (spec.extend != null) {
-      output.write(' extends ');
-      spec.extend.type.accept(this, output);
+      out.write(' extends ');
+      spec.extend!.type.accept(this, out);
     }
     if (spec.mixins.isNotEmpty) {
-      output
+      out
         ..write(' with ')
         ..writeAll(
             spec.mixins.map<StringSink>((m) => m.type.accept(this)), ',');
     }
     if (spec.implements.isNotEmpty) {
-      output
+      out
         ..write(' implements ')
         ..writeAll(
             spec.implements.map<StringSink>((m) => m.type.accept(this)), ',');
     }
-    output.write(' {');
+    out.write(' {');
     spec.constructors.forEach((c) {
-      visitConstructor(c, spec.name, output);
-      output.writeln();
+      visitConstructor(c, spec.name, out);
+      out.writeln();
     });
     spec.fields.forEach((f) {
-      visitField(f, output);
-      output.writeln();
+      visitField(f, out);
+      out.writeln();
     });
     spec.methods.forEach((m) {
-      visitMethod(m, output);
+      visitMethod(m, out);
       if (_isLambdaMethod(m)) {
-        output.write(';');
+        out.write(';');
       }
-      output.writeln();
+      out.writeln();
     });
-    output.writeln(' }');
-    return output;
+    out.writeln(' }');
+    return out;
   }
 
   @override
   StringSink visitConstructor(Constructor spec, String clazz,
-      [StringSink output]) {
+      [StringSink? output]) {
     output ??= StringBuffer();
     spec.docs.forEach(output.writeln);
     spec.annotations.forEach((a) => visitAnnotation(a, output));
@@ -215,16 +215,16 @@ class DartEmitter extends Object
     }
     if (spec.redirect != null) {
       output.write(' = ');
-      spec.redirect.type.accept(this, output);
+      spec.redirect!.type.accept(this, output);
       output.write(';');
     } else if (spec.body != null) {
       if (_isLambdaConstructor(spec)) {
         output.write(' => ');
-        spec.body.accept(this, output);
+        spec.body!.accept(this, output);
         output.write(';');
       } else {
         output.write(' { ');
-        spec.body.accept(this, output);
+        spec.body!.accept(this, output);
         output.write(' }');
       }
     } else {
@@ -235,38 +235,38 @@ class DartEmitter extends Object
   }
 
   @override
-  StringSink visitExtension(Extension spec, [StringSink output]) {
-    output ??= StringBuffer();
-    spec.docs.forEach(output.writeln);
-    spec.annotations.forEach((a) => visitAnnotation(a, output));
+  StringSink visitExtension(Extension spec, [StringSink? output]) {
+    final out = output ??= StringBuffer();
+    spec.docs.forEach(out.writeln);
+    spec.annotations.forEach((a) => visitAnnotation(a, out));
 
-    output.write('extension');
+    out.write('extension');
     if (spec.name != null) {
-      output.write(' ${spec.name}');
+      out.write(' ${spec.name}');
     }
-    visitTypeParameters(spec.types.map((r) => r.type), output);
+    visitTypeParameters(spec.types.map((r) => r.type), out);
     if (spec.on != null) {
-      output.write(' on ');
-      spec.on.type.accept(this, output);
+      out.write(' on ');
+      spec.on!.type.accept(this, out);
     }
-    output.write(' {');
+    out.write(' {');
     spec.fields.forEach((f) {
-      visitField(f, output);
-      output.writeln();
+      visitField(f, out);
+      out.writeln();
     });
     spec.methods.forEach((m) {
-      visitMethod(m, output);
+      visitMethod(m, out);
       if (_isLambdaMethod(m)) {
-        output.write(';');
+        out.write(';');
       }
-      output.writeln();
+      out.writeln();
     });
-    output.writeln(' }');
-    return output;
+    out.writeln(' }');
+    return out;
   }
 
   @override
-  StringSink visitDirective(Directive spec, [StringSink output]) {
+  StringSink visitDirective(Directive spec, [StringSink? output]) {
     output ??= StringBuffer();
     switch (spec.type) {
       case DirectiveType.import:
@@ -303,7 +303,7 @@ class DartEmitter extends Object
   }
 
   @override
-  StringSink visitField(Field spec, [StringSink output]) {
+  StringSink visitField(Field spec, [StringSink? output]) {
     output ??= StringBuffer();
     spec.docs.forEach(output.writeln);
     spec.annotations.forEach((a) => visitAnnotation(a, output));
@@ -324,14 +324,14 @@ class DartEmitter extends Object
         break;
     }
     if (spec.type != null) {
-      spec.type.type.accept(this, output);
+      spec.type!.type.accept(this, output);
       output.write(' ');
     }
     output.write(spec.name);
     if (spec.assignment != null) {
       output.write(' = ');
       startConstCode(spec.modifier == FieldModifier.constant, () {
-        spec.assignment.accept(this, output);
+        spec.assignment!.accept(this, output);
       });
     }
     output.writeln(';');
@@ -339,7 +339,7 @@ class DartEmitter extends Object
   }
 
   @override
-  StringSink visitLibrary(Library spec, [StringSink output]) {
+  StringSink visitLibrary(Library spec, [StringSink? output]) {
     output ??= StringBuffer();
     // Process the body first in order to prime the allocators.
     final body = StringBuffer();
@@ -356,7 +356,7 @@ class DartEmitter extends Object
       directives.sort();
     }
 
-    Directive previous;
+    Directive? previous;
     for (final directive in directives) {
       if (_newLineBetween(orderDirectives, previous, directive)) {
         // Note: dartfmt handles creating new lines between directives.
@@ -372,52 +372,52 @@ class DartEmitter extends Object
   }
 
   @override
-  StringSink visitFunctionType(FunctionType spec, [StringSink output]) {
-    output ??= StringBuffer();
+  StringSink visitFunctionType(FunctionType spec, [StringSink? output]) {
+    final out = output ??= StringBuffer();
     if (spec.returnType != null) {
-      spec.returnType.accept(this, output);
-      output.write(' ');
+      spec.returnType!.accept(this, out);
+      out.write(' ');
     }
-    output.write('Function');
+    out.write('Function');
     if (spec.types.isNotEmpty) {
-      output.write('<');
-      visitAll<Reference>(spec.types, output, (spec) {
-        spec.accept(this, output);
+      out.write('<');
+      visitAll<Reference>(spec.types, out, (spec) {
+        spec.accept(this, out);
       });
-      output.write('>');
+      out.write('>');
     }
-    output.write('(');
-    visitAll<Reference>(spec.requiredParameters, output, (spec) {
-      spec.accept(this, output);
+    out.write('(');
+    visitAll<Reference>(spec.requiredParameters, out, (spec) {
+      spec.accept(this, out);
     });
     if (spec.requiredParameters.isNotEmpty &&
         (spec.optionalParameters.isNotEmpty ||
             spec.namedParameters.isNotEmpty)) {
-      output.write(', ');
+      out.write(', ');
     }
     if (spec.optionalParameters.isNotEmpty) {
-      output.write('[');
-      visitAll<Reference>(spec.optionalParameters, output, (spec) {
-        spec.accept(this, output);
+      out.write('[');
+      visitAll<Reference>(spec.optionalParameters, out, (spec) {
+        spec.accept(this, out);
       });
-      output.write(']');
+      out.write(']');
     } else if (spec.namedParameters.isNotEmpty) {
-      output.write('{');
-      visitAll<String>(spec.namedParameters.keys, output, (name) {
-        spec.namedParameters[name].accept(this, output);
-        output..write(' ')..write(name);
+      out.write('{');
+      visitAll<String>(spec.namedParameters.keys, out, (name) {
+        spec.namedParameters[name]!.accept(this, out);
+        out..write(' ')..write(name);
       });
-      output.write('}');
+      out.write('}');
     }
-    output.write(')');
+    out.write(')');
     if (_useNullSafetySyntax && (spec.isNullable ?? false)) {
-      output.write('?');
+      out.write('?');
     }
-    return output;
+    return out;
   }
 
   @override
-  StringSink visitMethod(Method spec, [StringSink output]) {
+  StringSink visitMethod(Method spec, [StringSink? output]) {
     output ??= StringBuffer();
     spec.docs.forEach(output.writeln);
     spec.annotations.forEach((a) => visitAnnotation(a, output));
@@ -428,7 +428,7 @@ class DartEmitter extends Object
       output.write('static ');
     }
     if (spec.returns != null) {
-      spec.returns.accept(this, output);
+      spec.returns!.accept(this, output);
       output.write(' ');
     }
     if (spec.type == MethodType.getter) {
@@ -478,7 +478,7 @@ class DartEmitter extends Object
     }
     if (spec.body != null) {
       if (spec.modifier != null) {
-        switch (spec.modifier) {
+        switch (spec.modifier!) {
           case MethodModifier.async:
             output.write(' async ');
             break;
@@ -495,7 +495,7 @@ class DartEmitter extends Object
       } else {
         output.write(' { ');
       }
-      spec.body.accept(this, output);
+      spec.body!.accept(this, output);
       if (!_isLambdaMethod(spec)) {
         output.write(' } ');
       }
@@ -522,7 +522,7 @@ class DartEmitter extends Object
       output.write('covariant ');
     }
     if (spec.type != null) {
-      spec.type.type.accept(this, output);
+      spec.type!.type.accept(this, output);
       output.write(' ');
     }
     if (spec.toThis) {
@@ -531,26 +531,26 @@ class DartEmitter extends Object
     output.write(spec.name);
     if (optional && spec.defaultTo != null) {
       output.write(' = ');
-      spec.defaultTo.accept(this, output);
+      spec.defaultTo!.accept(this, output);
     }
   }
 
   @override
-  StringSink visitReference(Reference spec, [StringSink output]) =>
+  StringSink visitReference(Reference spec, [StringSink? output]) =>
       (output ??= StringBuffer())..write(allocator.allocate(spec));
 
   @override
-  StringSink visitSpec(Spec spec, [StringSink output]) =>
+  StringSink visitSpec(Spec spec, [StringSink? output]) =>
       spec.accept(this, output);
 
   @override
-  StringSink visitType(TypeReference spec, [StringSink output]) {
+  StringSink visitType(TypeReference spec, [StringSink? output]) {
     output ??= StringBuffer();
     // Intentionally not .accept to avoid stack overflow.
     visitReference(spec, output);
     if (spec.bound != null) {
       output.write(' extends ');
-      spec.bound.type.accept(this, output);
+      spec.bound!.type.accept(this, output);
     }
     visitTypeParameters(spec.types.map((r) => r.type), output);
     if (_useNullSafetySyntax && (spec.isNullable ?? false)) {
@@ -561,7 +561,7 @@ class DartEmitter extends Object
 
   @override
   StringSink visitTypeParameters(Iterable<Reference> specs,
-      [StringSink output]) {
+      [StringSink? output]) {
     output ??= StringBuffer();
     if (specs.isNotEmpty) {
       output
@@ -573,21 +573,21 @@ class DartEmitter extends Object
   }
 
   @override
-  StringSink visitEnum(Enum spec, [StringSink output]) {
-    output ??= StringBuffer();
-    spec.docs.forEach(output.writeln);
-    spec.annotations.forEach((a) => visitAnnotation(a, output));
-    output.writeln('enum ${spec.name} {');
+  StringSink visitEnum(Enum spec, [StringSink? output]) {
+    final out = output ??= StringBuffer();
+    spec.docs.forEach(out.writeln);
+    spec.annotations.forEach((a) => visitAnnotation(a, out));
+    out.writeln('enum ${spec.name} {');
     spec.values.forEach((v) {
-      v.docs.forEach(output.writeln);
-      v.annotations.forEach((a) => visitAnnotation(a, output));
-      output.write(v.name);
+      v.docs.forEach(out.writeln);
+      v.annotations.forEach((a) => visitAnnotation(a, out));
+      out.write(v.name);
       if (v != spec.values.last) {
-        output.writeln(',');
+        out.writeln(',');
       }
     });
-    output.writeln('}');
-    return output;
+    out.writeln('}');
+    return out;
   }
 }
 
@@ -596,14 +596,14 @@ class DartEmitter extends Object
 /// * [ordered] is `true`
 /// * [a] is non-`null`
 /// * If there should be an empty line before [b] if it's emitted after [a].
-bool _newLineBetween(bool ordered, Directive a, Directive b) {
+bool _newLineBetween(bool ordered, Directive? a, Directive? b) {
   if (!ordered) return false;
   if (a == null) return false;
 
   assert(b != null);
 
   // Put a line between imports and exports
-  if (a.type != b.type) return true;
+  if (a.type != b!.type) return true;
 
   // Within exports, don't put in extra blank lines
   if (a.type == DirectiveType.export) {

--- a/lib/src/matchers.dart
+++ b/lib/src/matchers.dart
@@ -18,7 +18,7 @@ String _dart(Spec spec, DartEmitter emitter) =>
 /// be overridden with [emitter].
 Matcher equalsDart(
   String source, [
-  DartEmitter emitter,
+  DartEmitter? emitter,
 ]) =>
     EqualsDart._(EqualsDart._format(source), emitter ?? DartEmitter());
 

--- a/lib/src/mixins/annotations.dart
+++ b/lib/src/mixins/annotations.dart
@@ -15,5 +15,5 @@ abstract class HasAnnotations {
 /// Compliment to the [HasAnnotations] mixin for metadata [annotations].
 abstract class HasAnnotationsBuilder {
   /// Annotations as metadata on the node.
-  ListBuilder<Expression> annotations;
+  abstract ListBuilder<Expression> annotations;
 }

--- a/lib/src/mixins/dartdoc.dart
+++ b/lib/src/mixins/dartdoc.dart
@@ -11,5 +11,5 @@ abstract class HasDartDocs {
 
 abstract class HasDartDocsBuilder {
   /// Dart docs.
-  ListBuilder<String> docs;
+  abstract ListBuilder<String> docs;
 }

--- a/lib/src/mixins/generics.dart
+++ b/lib/src/mixins/generics.dart
@@ -13,5 +13,5 @@ abstract class HasGenerics {
 
 abstract class HasGenericsBuilder {
   /// Generic type parameters.
-  ListBuilder<Reference> types;
+  abstract ListBuilder<Reference> types;
 }

--- a/lib/src/specs/class.dart
+++ b/lib/src/specs/class.dart
@@ -36,8 +36,7 @@ abstract class Class extends Object
   @override
   BuiltList<String> get docs;
 
-  @nullable
-  Reference get extend;
+  Reference? get extend;
 
   BuiltList<Reference> get implements;
 
@@ -56,7 +55,7 @@ abstract class Class extends Object
   @override
   R accept<R>(
     SpecVisitor<R> visitor, [
-    R context,
+    R? context,
   ]) =>
       visitor.visitClass(this, context);
 }
@@ -68,6 +67,11 @@ abstract class ClassBuilder extends Object
 
   ClassBuilder._();
 
+  @override
+  void update(void Function(ClassBuilder)? updates) {
+    updates?.call(this);
+  }
+
   /// Whether the class is `abstract`.
   bool abstract = false;
 
@@ -77,7 +81,7 @@ abstract class ClassBuilder extends Object
   @override
   ListBuilder<String> docs = ListBuilder<String>();
 
-  Reference extend;
+  Reference? extend;
 
   ListBuilder<Reference> implements = ListBuilder<Reference>();
   ListBuilder<Reference> mixins = ListBuilder<Reference>();
@@ -90,5 +94,5 @@ abstract class ClassBuilder extends Object
   ListBuilder<Field> fields = ListBuilder<Field>();
 
   /// Name of the class.
-  String name;
+  String? name;
 }

--- a/lib/src/specs/class.g.dart
+++ b/lib/src/specs/class.g.dart
@@ -45,7 +45,19 @@ class _$Class extends Class {
       required this.methods,
       required this.fields,
       required this.name})
-      : super._();
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(abstract, 'Class', 'abstract');
+    BuiltValueNullFieldError.checkNotNull(annotations, 'Class', 'annotations');
+    BuiltValueNullFieldError.checkNotNull(docs, 'Class', 'docs');
+    BuiltValueNullFieldError.checkNotNull(implements, 'Class', 'implements');
+    BuiltValueNullFieldError.checkNotNull(mixins, 'Class', 'mixins');
+    BuiltValueNullFieldError.checkNotNull(types, 'Class', 'types');
+    BuiltValueNullFieldError.checkNotNull(
+        constructors, 'Class', 'constructors');
+    BuiltValueNullFieldError.checkNotNull(methods, 'Class', 'methods');
+    BuiltValueNullFieldError.checkNotNull(fields, 'Class', 'fields');
+    BuiltValueNullFieldError.checkNotNull(name, 'Class', 'name');
+  }
 
   @override
   Class rebuild(void Function(ClassBuilder) updates) =>
@@ -101,7 +113,7 @@ class _$Class extends Class {
           ..add('abstract', abstract)
           ..add('annotations', annotations)
           ..add('docs', docs)
-          ..add('extend', extend ?? 'null')
+          ..add('extend', extend)
           ..add('implements', implements)
           ..add('mixins', mixins)
           ..add('types', types)
@@ -251,28 +263,27 @@ class _$ClassBuilder extends ClassBuilder {
   _$ClassBuilder() : super._();
 
   ClassBuilder get _$this {
-    if (_$v != null) {
-      super.abstract = _$v!.abstract;
-      super.annotations = _$v!.annotations.toBuilder();
-      super.docs = _$v!.docs.toBuilder();
-      super.extend = _$v!.extend;
-      super.implements = _$v!.implements.toBuilder();
-      super.mixins = _$v!.mixins.toBuilder();
-      super.types = _$v!.types.toBuilder();
-      super.constructors = _$v!.constructors.toBuilder();
-      super.methods = _$v!.methods.toBuilder();
-      super.fields = _$v!.fields.toBuilder();
-      super.name = _$v!.name;
+    final $v = _$v;
+    if ($v != null) {
+      super.abstract = $v.abstract;
+      super.annotations = $v.annotations.toBuilder();
+      super.docs = $v.docs.toBuilder();
+      super.extend = $v.extend;
+      super.implements = $v.implements.toBuilder();
+      super.mixins = $v.mixins.toBuilder();
+      super.types = $v.types.toBuilder();
+      super.constructors = $v.constructors.toBuilder();
+      super.methods = $v.methods.toBuilder();
+      super.fields = $v.fields.toBuilder();
+      super.name = $v.name;
       _$v = null;
     }
     return this;
   }
 
   @override
-  void replace(Class? other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+  void replace(Class other) {
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$Class;
   }
 
@@ -287,7 +298,8 @@ class _$ClassBuilder extends ClassBuilder {
     try {
       _$result = _$v ??
           new _$Class._(
-              abstract: abstract,
+              abstract: BuiltValueNullFieldError.checkNotNull(
+                  abstract, 'Class', 'abstract'),
               annotations: annotations.build(),
               docs: docs.build(),
               extend: extend,
@@ -297,7 +309,8 @@ class _$ClassBuilder extends ClassBuilder {
               constructors: constructors.build(),
               methods: methods.build(),
               fields: fields.build(),
-              name: name!);
+              name:
+                  BuiltValueNullFieldError.checkNotNull(name, 'Class', 'name'));
     } catch (_) {
       late String _$failedField;
       try {

--- a/lib/src/specs/class.g.dart
+++ b/lib/src/specs/class.g.dart
@@ -14,7 +14,7 @@ class _$Class extends Class {
   @override
   final BuiltList<String> docs;
   @override
-  final Reference extend;
+  final Reference? extend;
   @override
   final BuiltList<Reference> implements;
   @override
@@ -30,53 +30,22 @@ class _$Class extends Class {
   @override
   final String name;
 
-  factory _$Class([void Function(ClassBuilder) updates]) =>
+  factory _$Class([void Function(ClassBuilder)? updates]) =>
       (new ClassBuilder()..update(updates)).build() as _$Class;
 
   _$Class._(
-      {this.abstract,
-      this.annotations,
-      this.docs,
+      {required this.abstract,
+      required this.annotations,
+      required this.docs,
       this.extend,
-      this.implements,
-      this.mixins,
-      this.types,
-      this.constructors,
-      this.methods,
-      this.fields,
-      this.name})
-      : super._() {
-    if (abstract == null) {
-      throw new BuiltValueNullFieldError('Class', 'abstract');
-    }
-    if (annotations == null) {
-      throw new BuiltValueNullFieldError('Class', 'annotations');
-    }
-    if (docs == null) {
-      throw new BuiltValueNullFieldError('Class', 'docs');
-    }
-    if (implements == null) {
-      throw new BuiltValueNullFieldError('Class', 'implements');
-    }
-    if (mixins == null) {
-      throw new BuiltValueNullFieldError('Class', 'mixins');
-    }
-    if (types == null) {
-      throw new BuiltValueNullFieldError('Class', 'types');
-    }
-    if (constructors == null) {
-      throw new BuiltValueNullFieldError('Class', 'constructors');
-    }
-    if (methods == null) {
-      throw new BuiltValueNullFieldError('Class', 'methods');
-    }
-    if (fields == null) {
-      throw new BuiltValueNullFieldError('Class', 'fields');
-    }
-    if (name == null) {
-      throw new BuiltValueNullFieldError('Class', 'name');
-    }
-  }
+      required this.implements,
+      required this.mixins,
+      required this.types,
+      required this.constructors,
+      required this.methods,
+      required this.fields,
+      required this.name})
+      : super._();
 
   @override
   Class rebuild(void Function(ClassBuilder) updates) =>
@@ -132,7 +101,7 @@ class _$Class extends Class {
           ..add('abstract', abstract)
           ..add('annotations', annotations)
           ..add('docs', docs)
-          ..add('extend', extend)
+          ..add('extend', extend ?? 'null')
           ..add('implements', implements)
           ..add('mixins', mixins)
           ..add('types', types)
@@ -145,7 +114,7 @@ class _$Class extends Class {
 }
 
 class _$ClassBuilder extends ClassBuilder {
-  _$Class _$v;
+  _$Class? _$v;
 
   @override
   bool get abstract {
@@ -162,7 +131,7 @@ class _$ClassBuilder extends ClassBuilder {
   @override
   ListBuilder<Expression> get annotations {
     _$this;
-    return super.annotations ??= new ListBuilder<Expression>();
+    return super.annotations;
   }
 
   @override
@@ -174,7 +143,7 @@ class _$ClassBuilder extends ClassBuilder {
   @override
   ListBuilder<String> get docs {
     _$this;
-    return super.docs ??= new ListBuilder<String>();
+    return super.docs;
   }
 
   @override
@@ -184,13 +153,13 @@ class _$ClassBuilder extends ClassBuilder {
   }
 
   @override
-  Reference get extend {
+  Reference? get extend {
     _$this;
     return super.extend;
   }
 
   @override
-  set extend(Reference extend) {
+  set extend(Reference? extend) {
     _$this;
     super.extend = extend;
   }
@@ -198,7 +167,7 @@ class _$ClassBuilder extends ClassBuilder {
   @override
   ListBuilder<Reference> get implements {
     _$this;
-    return super.implements ??= new ListBuilder<Reference>();
+    return super.implements;
   }
 
   @override
@@ -210,7 +179,7 @@ class _$ClassBuilder extends ClassBuilder {
   @override
   ListBuilder<Reference> get mixins {
     _$this;
-    return super.mixins ??= new ListBuilder<Reference>();
+    return super.mixins;
   }
 
   @override
@@ -222,7 +191,7 @@ class _$ClassBuilder extends ClassBuilder {
   @override
   ListBuilder<Reference> get types {
     _$this;
-    return super.types ??= new ListBuilder<Reference>();
+    return super.types;
   }
 
   @override
@@ -234,7 +203,7 @@ class _$ClassBuilder extends ClassBuilder {
   @override
   ListBuilder<Constructor> get constructors {
     _$this;
-    return super.constructors ??= new ListBuilder<Constructor>();
+    return super.constructors;
   }
 
   @override
@@ -246,7 +215,7 @@ class _$ClassBuilder extends ClassBuilder {
   @override
   ListBuilder<Method> get methods {
     _$this;
-    return super.methods ??= new ListBuilder<Method>();
+    return super.methods;
   }
 
   @override
@@ -258,7 +227,7 @@ class _$ClassBuilder extends ClassBuilder {
   @override
   ListBuilder<Field> get fields {
     _$this;
-    return super.fields ??= new ListBuilder<Field>();
+    return super.fields;
   }
 
   @override
@@ -268,13 +237,13 @@ class _$ClassBuilder extends ClassBuilder {
   }
 
   @override
-  String get name {
+  String? get name {
     _$this;
     return super.name;
   }
 
   @override
-  set name(String name) {
+  set name(String? name) {
     _$this;
     super.name = name;
   }
@@ -283,24 +252,24 @@ class _$ClassBuilder extends ClassBuilder {
 
   ClassBuilder get _$this {
     if (_$v != null) {
-      super.abstract = _$v.abstract;
-      super.annotations = _$v.annotations?.toBuilder();
-      super.docs = _$v.docs?.toBuilder();
-      super.extend = _$v.extend;
-      super.implements = _$v.implements?.toBuilder();
-      super.mixins = _$v.mixins?.toBuilder();
-      super.types = _$v.types?.toBuilder();
-      super.constructors = _$v.constructors?.toBuilder();
-      super.methods = _$v.methods?.toBuilder();
-      super.fields = _$v.fields?.toBuilder();
-      super.name = _$v.name;
+      super.abstract = _$v!.abstract;
+      super.annotations = _$v!.annotations.toBuilder();
+      super.docs = _$v!.docs.toBuilder();
+      super.extend = _$v!.extend;
+      super.implements = _$v!.implements.toBuilder();
+      super.mixins = _$v!.mixins.toBuilder();
+      super.types = _$v!.types.toBuilder();
+      super.constructors = _$v!.constructors.toBuilder();
+      super.methods = _$v!.methods.toBuilder();
+      super.fields = _$v!.fields.toBuilder();
+      super.name = _$v!.name;
       _$v = null;
     }
     return this;
   }
 
   @override
-  void replace(Class other) {
+  void replace(Class? other) {
     if (other == null) {
       throw new ArgumentError.notNull('other');
     }
@@ -308,7 +277,7 @@ class _$ClassBuilder extends ClassBuilder {
   }
 
   @override
-  void update(void Function(ClassBuilder) updates) {
+  void update(void Function(ClassBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -328,9 +297,9 @@ class _$ClassBuilder extends ClassBuilder {
               constructors: constructors.build(),
               methods: methods.build(),
               fields: fields.build(),
-              name: name);
+              name: name!);
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'annotations';
         annotations.build();

--- a/lib/src/specs/code.dart
+++ b/lib/src/specs/code.dart
@@ -41,7 +41,7 @@ abstract class Code implements Spec {
   ) = ScopedCode._;
 
   @override
-  R accept<R>(covariant CodeVisitor<R> visitor, [R context]);
+  R accept<R>(covariant CodeVisitor<R> visitor, [R? context]);
 }
 
 /// Represents blocks of statements of Dart code.
@@ -54,7 +54,7 @@ abstract class Block implements Built<Block, BlockBuilder>, Code, Spec {
   Block._();
 
   @override
-  R accept<R>(covariant CodeVisitor<R> visitor, [R context]) =>
+  R accept<R>(covariant CodeVisitor<R> visitor, [R? context]) =>
       visitor.visitBlock(this, context);
 
   BuiltList<Code> get statements;
@@ -79,11 +79,11 @@ abstract class BlockBuilder implements Builder<Block, BlockBuilder> {
 ///
 /// **INTERNAL ONLY**.
 abstract class CodeVisitor<T> implements SpecVisitor<T> {
-  T visitBlock(Block code, [T context]);
+  T visitBlock(Block code, [T? context]);
 
-  T visitStaticCode(StaticCode code, [T context]);
+  T visitStaticCode(StaticCode code, [T? context]);
 
-  T visitScopedCode(ScopedCode code, [T context]);
+  T visitScopedCode(ScopedCode code, [T? context]);
 }
 
 /// Knowledge of how to write valid Dart code from [CodeVisitor].
@@ -92,7 +92,7 @@ abstract class CodeEmitter implements CodeVisitor<StringSink> {
   Allocator get allocator;
 
   @override
-  StringSink visitBlock(Block block, [StringSink output]) {
+  StringSink visitBlock(Block block, [StringSink? output]) {
     output ??= StringBuffer();
     return visitAll<Code>(block.statements, output, (statement) {
       statement.accept(this, output);
@@ -100,13 +100,13 @@ abstract class CodeEmitter implements CodeVisitor<StringSink> {
   }
 
   @override
-  StringSink visitStaticCode(StaticCode code, [StringSink output]) {
+  StringSink visitStaticCode(StaticCode code, [StringSink? output]) {
     output ??= StringBuffer();
     return output..write(code.code);
   }
 
   @override
-  StringSink visitScopedCode(ScopedCode code, [StringSink output]) {
+  StringSink visitScopedCode(ScopedCode code, [StringSink? output]) {
     output ??= StringBuffer();
     return output..write(code.code(allocator.allocate));
   }
@@ -119,7 +119,7 @@ class LazyCode implements Code {
   const LazyCode._(this.generate);
 
   @override
-  R accept<R>(CodeVisitor<R> visitor, [R context]) =>
+  R accept<R>(CodeVisitor<R> visitor, [R? context]) =>
       generate(visitor).accept(visitor, context);
 }
 
@@ -132,7 +132,7 @@ class _LazyCode implements Code {
   const _LazyCode(this.generate);
 
   @override
-  R accept<R>(CodeVisitor<R> visitor, [R context]) =>
+  R accept<R>(CodeVisitor<R> visitor, [R? context]) =>
       generate().accept(visitor, context);
 }
 
@@ -143,7 +143,7 @@ class StaticCode implements Code {
   const StaticCode._(this.code);
 
   @override
-  R accept<R>(CodeVisitor<R> visitor, [R context]) =>
+  R accept<R>(CodeVisitor<R> visitor, [R? context]) =>
       visitor.visitStaticCode(this, context);
 
   @override
@@ -157,7 +157,7 @@ class ScopedCode implements Code {
   const ScopedCode._(this.code);
 
   @override
-  R accept<R>(CodeVisitor<R> visitor, [R context]) =>
+  R accept<R>(CodeVisitor<R> visitor, [R? context]) =>
       visitor.visitScopedCode(this, context);
 
   @override

--- a/lib/src/specs/code.g.dart
+++ b/lib/src/specs/code.g.dart
@@ -10,13 +10,11 @@ class _$Block extends Block {
   @override
   final BuiltList<Code> statements;
 
-  factory _$Block([void Function(BlockBuilder) updates]) =>
+  factory _$Block([void Function(BlockBuilder)? updates]) =>
       (new BlockBuilder()..update(updates)).build() as _$Block;
 
-  _$Block._({this.statements}) : super._() {
-    if (statements == null) {
-      throw new BuiltValueNullFieldError('Block', 'statements');
-    }
+  _$Block._({required this.statements}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(statements, 'Block', 'statements');
   }
 
   @override
@@ -45,12 +43,12 @@ class _$Block extends Block {
 }
 
 class _$BlockBuilder extends BlockBuilder {
-  _$Block _$v;
+  _$Block? _$v;
 
   @override
   ListBuilder<Code> get statements {
     _$this;
-    return super.statements ??= new ListBuilder<Code>();
+    return super.statements;
   }
 
   @override
@@ -62,8 +60,9 @@ class _$BlockBuilder extends BlockBuilder {
   _$BlockBuilder() : super._();
 
   BlockBuilder get _$this {
-    if (_$v != null) {
-      super.statements = _$v.statements?.toBuilder();
+    final $v = _$v;
+    if ($v != null) {
+      super.statements = $v.statements.toBuilder();
       _$v = null;
     }
     return this;
@@ -71,14 +70,12 @@ class _$BlockBuilder extends BlockBuilder {
 
   @override
   void replace(Block other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$Block;
   }
 
   @override
-  void update(void Function(BlockBuilder) updates) {
+  void update(void Function(BlockBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -88,7 +85,7 @@ class _$BlockBuilder extends BlockBuilder {
     try {
       _$result = _$v ?? new _$Block._(statements: statements.build());
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'statements';
         statements.build();

--- a/lib/src/specs/constructor.dart
+++ b/lib/src/specs/constructor.dart
@@ -84,7 +84,7 @@ abstract class ConstructorBuilder extends Object
   ListBuilder<Code> initializers = ListBuilder<Code>();
 
   /// Body of the constructor.
-  Code body;
+  Code? body;
 
   /// Whether the constructor should be prefixed with `const`.
   bool constant = false;
@@ -96,10 +96,10 @@ abstract class ConstructorBuilder extends Object
   bool factory = false;
 
   /// Whether this constructor is a simple lambda expression.
-  bool lambda;
+  bool? lambda;
 
   /// Name of the constructor - optional.
-  String name;
+  String? name;
 
   /// If non-null, redirect to this constructor.
   Reference? redirect;

--- a/lib/src/specs/constructor.dart
+++ b/lib/src/specs/constructor.dart
@@ -40,8 +40,7 @@ abstract class Constructor extends Object
   BuiltList<Code> get initializers;
 
   /// Body of the method.
-  @nullable
-  Code get body;
+  Code? get body;
 
   /// Whether the constructor should be prefixed with `external`.
   bool get external;
@@ -53,16 +52,13 @@ abstract class Constructor extends Object
   bool get factory;
 
   /// Whether this constructor is a simple lambda expression.
-  @nullable
-  bool get lambda;
+  bool? get lambda;
 
   /// Name of the constructor - optional.
-  @nullable
-  String get name;
+  String? get name;
 
   /// If non-null, redirect to this constructor.
-  @nullable
-  Reference get redirect;
+  Reference? get redirect;
 }
 
 abstract class ConstructorBuilder extends Object
@@ -106,6 +102,5 @@ abstract class ConstructorBuilder extends Object
   String name;
 
   /// If non-null, redirect to this constructor.
-  @nullable
-  Reference redirect;
+  Reference? redirect;
 }

--- a/lib/src/specs/constructor.g.dart
+++ b/lib/src/specs/constructor.g.dart
@@ -18,7 +18,7 @@ class _$Constructor extends Constructor {
   @override
   final BuiltList<Code> initializers;
   @override
-  final Code body;
+  final Code? body;
   @override
   final bool external;
   @override
@@ -26,53 +26,41 @@ class _$Constructor extends Constructor {
   @override
   final bool factory;
   @override
-  final bool lambda;
+  final bool? lambda;
   @override
-  final String name;
+  final String? name;
   @override
-  final Reference redirect;
+  final Reference? redirect;
 
-  factory _$Constructor([void Function(ConstructorBuilder) updates]) =>
+  factory _$Constructor([void Function(ConstructorBuilder)? updates]) =>
       (new ConstructorBuilder()..update(updates)).build() as _$Constructor;
 
   _$Constructor._(
-      {this.annotations,
-      this.docs,
-      this.optionalParameters,
-      this.requiredParameters,
-      this.initializers,
+      {required this.annotations,
+      required this.docs,
+      required this.optionalParameters,
+      required this.requiredParameters,
+      required this.initializers,
       this.body,
-      this.external,
-      this.constant,
-      this.factory,
+      required this.external,
+      required this.constant,
+      required this.factory,
       this.lambda,
       this.name,
       this.redirect})
       : super._() {
-    if (annotations == null) {
-      throw new BuiltValueNullFieldError('Constructor', 'annotations');
-    }
-    if (docs == null) {
-      throw new BuiltValueNullFieldError('Constructor', 'docs');
-    }
-    if (optionalParameters == null) {
-      throw new BuiltValueNullFieldError('Constructor', 'optionalParameters');
-    }
-    if (requiredParameters == null) {
-      throw new BuiltValueNullFieldError('Constructor', 'requiredParameters');
-    }
-    if (initializers == null) {
-      throw new BuiltValueNullFieldError('Constructor', 'initializers');
-    }
-    if (external == null) {
-      throw new BuiltValueNullFieldError('Constructor', 'external');
-    }
-    if (constant == null) {
-      throw new BuiltValueNullFieldError('Constructor', 'constant');
-    }
-    if (factory == null) {
-      throw new BuiltValueNullFieldError('Constructor', 'factory');
-    }
+    BuiltValueNullFieldError.checkNotNull(
+        annotations, 'Constructor', 'annotations');
+    BuiltValueNullFieldError.checkNotNull(docs, 'Constructor', 'docs');
+    BuiltValueNullFieldError.checkNotNull(
+        optionalParameters, 'Constructor', 'optionalParameters');
+    BuiltValueNullFieldError.checkNotNull(
+        requiredParameters, 'Constructor', 'requiredParameters');
+    BuiltValueNullFieldError.checkNotNull(
+        initializers, 'Constructor', 'initializers');
+    BuiltValueNullFieldError.checkNotNull(external, 'Constructor', 'external');
+    BuiltValueNullFieldError.checkNotNull(constant, 'Constructor', 'constant');
+    BuiltValueNullFieldError.checkNotNull(factory, 'Constructor', 'factory');
   }
 
   @override
@@ -146,12 +134,12 @@ class _$Constructor extends Constructor {
 }
 
 class _$ConstructorBuilder extends ConstructorBuilder {
-  _$Constructor _$v;
+  _$Constructor? _$v;
 
   @override
   ListBuilder<Expression> get annotations {
     _$this;
-    return super.annotations ??= new ListBuilder<Expression>();
+    return super.annotations;
   }
 
   @override
@@ -163,7 +151,7 @@ class _$ConstructorBuilder extends ConstructorBuilder {
   @override
   ListBuilder<String> get docs {
     _$this;
-    return super.docs ??= new ListBuilder<String>();
+    return super.docs;
   }
 
   @override
@@ -175,7 +163,7 @@ class _$ConstructorBuilder extends ConstructorBuilder {
   @override
   ListBuilder<Parameter> get optionalParameters {
     _$this;
-    return super.optionalParameters ??= new ListBuilder<Parameter>();
+    return super.optionalParameters;
   }
 
   @override
@@ -187,7 +175,7 @@ class _$ConstructorBuilder extends ConstructorBuilder {
   @override
   ListBuilder<Parameter> get requiredParameters {
     _$this;
-    return super.requiredParameters ??= new ListBuilder<Parameter>();
+    return super.requiredParameters;
   }
 
   @override
@@ -199,7 +187,7 @@ class _$ConstructorBuilder extends ConstructorBuilder {
   @override
   ListBuilder<Code> get initializers {
     _$this;
-    return super.initializers ??= new ListBuilder<Code>();
+    return super.initializers;
   }
 
   @override
@@ -281,13 +269,13 @@ class _$ConstructorBuilder extends ConstructorBuilder {
   }
 
   @override
-  Reference get redirect {
+  Reference? get redirect {
     _$this;
     return super.redirect;
   }
 
   @override
-  set redirect(Reference redirect) {
+  set redirect(Reference? redirect) {
     _$this;
     super.redirect = redirect;
   }
@@ -295,19 +283,20 @@ class _$ConstructorBuilder extends ConstructorBuilder {
   _$ConstructorBuilder() : super._();
 
   ConstructorBuilder get _$this {
-    if (_$v != null) {
-      super.annotations = _$v.annotations?.toBuilder();
-      super.docs = _$v.docs?.toBuilder();
-      super.optionalParameters = _$v.optionalParameters?.toBuilder();
-      super.requiredParameters = _$v.requiredParameters?.toBuilder();
-      super.initializers = _$v.initializers?.toBuilder();
-      super.body = _$v.body;
-      super.external = _$v.external;
-      super.constant = _$v.constant;
-      super.factory = _$v.factory;
-      super.lambda = _$v.lambda;
-      super.name = _$v.name;
-      super.redirect = _$v.redirect;
+    final $v = _$v;
+    if ($v != null) {
+      super.annotations = $v.annotations.toBuilder();
+      super.docs = $v.docs.toBuilder();
+      super.optionalParameters = $v.optionalParameters.toBuilder();
+      super.requiredParameters = $v.requiredParameters.toBuilder();
+      super.initializers = $v.initializers.toBuilder();
+      super.body = $v.body;
+      super.external = $v.external;
+      super.constant = $v.constant;
+      super.factory = $v.factory;
+      super.lambda = $v.lambda;
+      super.name = $v.name;
+      super.redirect = $v.redirect;
       _$v = null;
     }
     return this;
@@ -315,14 +304,12 @@ class _$ConstructorBuilder extends ConstructorBuilder {
 
   @override
   void replace(Constructor other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$Constructor;
   }
 
   @override
-  void update(void Function(ConstructorBuilder) updates) {
+  void update(void Function(ConstructorBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -338,14 +325,17 @@ class _$ConstructorBuilder extends ConstructorBuilder {
               requiredParameters: requiredParameters.build(),
               initializers: initializers.build(),
               body: body,
-              external: external,
-              constant: constant,
-              factory: factory,
+              external: BuiltValueNullFieldError.checkNotNull(
+                  external, 'Constructor', 'external'),
+              constant: BuiltValueNullFieldError.checkNotNull(
+                  constant, 'Constructor', 'constant'),
+              factory: BuiltValueNullFieldError.checkNotNull(
+                  factory, 'Constructor', 'factory'),
               lambda: lambda,
               name: name,
               redirect: redirect);
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'annotations';
         annotations.build();

--- a/lib/src/specs/constructor.g.dart
+++ b/lib/src/specs/constructor.g.dart
@@ -197,13 +197,13 @@ class _$ConstructorBuilder extends ConstructorBuilder {
   }
 
   @override
-  Code get body {
+  Code? get body {
     _$this;
     return super.body;
   }
 
   @override
-  set body(Code body) {
+  set body(Code? body) {
     _$this;
     super.body = body;
   }
@@ -245,25 +245,25 @@ class _$ConstructorBuilder extends ConstructorBuilder {
   }
 
   @override
-  bool get lambda {
+  bool? get lambda {
     _$this;
     return super.lambda;
   }
 
   @override
-  set lambda(bool lambda) {
+  set lambda(bool? lambda) {
     _$this;
     super.lambda = lambda;
   }
 
   @override
-  String get name {
+  String? get name {
     _$this;
     return super.name;
   }
 
   @override
-  set name(String name) {
+  set name(String? name) {
     _$this;
     super.name = name;
   }

--- a/lib/src/specs/directive.dart
+++ b/lib/src/specs/directive.dart
@@ -18,7 +18,7 @@ abstract class Directive
 
   factory Directive.import(
     String url, {
-    String as,
+    String? as,
     List<String> show = const [],
     List<String> hide = const [],
   }) =>
@@ -79,7 +79,7 @@ abstract class Directive
   @override
   R accept<R>(
     SpecVisitor<R> visitor, [
-    R context,
+    R? context,
   ]) =>
       visitor.visitDirective(this, context);
 
@@ -95,15 +95,15 @@ abstract class DirectiveBuilder
 
   bool deferred = false;
 
-  String as;
+  String? as;
 
-  String url;
+  String? url;
 
   List<String> show = <String>[];
 
   List<String> hide = <String>[];
 
-  DirectiveType type;
+  DirectiveType? type;
 }
 
 enum DirectiveType {

--- a/lib/src/specs/directive.dart
+++ b/lib/src/specs/directive.dart
@@ -64,8 +64,7 @@ abstract class Directive
 
   Directive._();
 
-  @nullable
-  String get as;
+  String? get as;
 
   String get url;
 

--- a/lib/src/specs/directive.g.dart
+++ b/lib/src/specs/directive.g.dart
@@ -8,7 +8,7 @@ part of 'directive.dart';
 
 class _$Directive extends Directive {
   @override
-  final String as;
+  final String? as;
   @override
   final String url;
   @override
@@ -20,27 +20,22 @@ class _$Directive extends Directive {
   @override
   final bool deferred;
 
-  factory _$Directive([void Function(DirectiveBuilder) updates]) =>
+  factory _$Directive([void Function(DirectiveBuilder)? updates]) =>
       (new DirectiveBuilder()..update(updates)).build() as _$Directive;
 
   _$Directive._(
-      {this.as, this.url, this.type, this.show, this.hide, this.deferred})
+      {this.as,
+      required this.url,
+      required this.type,
+      required this.show,
+      required this.hide,
+      required this.deferred})
       : super._() {
-    if (url == null) {
-      throw new BuiltValueNullFieldError('Directive', 'url');
-    }
-    if (type == null) {
-      throw new BuiltValueNullFieldError('Directive', 'type');
-    }
-    if (show == null) {
-      throw new BuiltValueNullFieldError('Directive', 'show');
-    }
-    if (hide == null) {
-      throw new BuiltValueNullFieldError('Directive', 'hide');
-    }
-    if (deferred == null) {
-      throw new BuiltValueNullFieldError('Directive', 'deferred');
-    }
+    BuiltValueNullFieldError.checkNotNull(url, 'Directive', 'url');
+    BuiltValueNullFieldError.checkNotNull(type, 'Directive', 'type');
+    BuiltValueNullFieldError.checkNotNull(show, 'Directive', 'show');
+    BuiltValueNullFieldError.checkNotNull(hide, 'Directive', 'hide');
+    BuiltValueNullFieldError.checkNotNull(deferred, 'Directive', 'deferred');
   }
 
   @override
@@ -86,7 +81,7 @@ class _$Directive extends Directive {
 }
 
 class _$DirectiveBuilder extends DirectiveBuilder {
-  _$Directive _$v;
+  _$Directive? _$v;
 
   @override
   String get as {
@@ -163,13 +158,14 @@ class _$DirectiveBuilder extends DirectiveBuilder {
   _$DirectiveBuilder() : super._();
 
   DirectiveBuilder get _$this {
-    if (_$v != null) {
-      super.as = _$v.as;
-      super.url = _$v.url;
-      super.type = _$v.type;
-      super.show = _$v.show;
-      super.hide = _$v.hide;
-      super.deferred = _$v.deferred;
+    final $v = _$v;
+    if ($v != null) {
+      super.as = $v.as;
+      super.url = $v.url;
+      super.type = $v.type;
+      super.show = $v.show;
+      super.hide = $v.hide;
+      super.deferred = $v.deferred;
       _$v = null;
     }
     return this;
@@ -177,14 +173,12 @@ class _$DirectiveBuilder extends DirectiveBuilder {
 
   @override
   void replace(Directive other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$Directive;
   }
 
   @override
-  void update(void Function(DirectiveBuilder) updates) {
+  void update(void Function(DirectiveBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -193,11 +187,15 @@ class _$DirectiveBuilder extends DirectiveBuilder {
     final _$result = _$v ??
         new _$Directive._(
             as: as,
-            url: url,
-            type: type,
-            show: show,
-            hide: hide,
-            deferred: deferred);
+            url: BuiltValueNullFieldError.checkNotNull(url, 'Directive', 'url'),
+            type: BuiltValueNullFieldError.checkNotNull(
+                type, 'Directive', 'type'),
+            show: BuiltValueNullFieldError.checkNotNull(
+                show, 'Directive', 'show'),
+            hide: BuiltValueNullFieldError.checkNotNull(
+                hide, 'Directive', 'hide'),
+            deferred: BuiltValueNullFieldError.checkNotNull(
+                deferred, 'Directive', 'deferred'));
     replace(_$result);
     return _$result;
   }

--- a/lib/src/specs/directive.g.dart
+++ b/lib/src/specs/directive.g.dart
@@ -84,37 +84,37 @@ class _$DirectiveBuilder extends DirectiveBuilder {
   _$Directive? _$v;
 
   @override
-  String get as {
+  String? get as {
     _$this;
     return super.as;
   }
 
   @override
-  set as(String as) {
+  set as(String? as) {
     _$this;
     super.as = as;
   }
 
   @override
-  String get url {
+  String? get url {
     _$this;
     return super.url;
   }
 
   @override
-  set url(String url) {
+  set url(String? url) {
     _$this;
     super.url = url;
   }
 
   @override
-  DirectiveType get type {
+  DirectiveType? get type {
     _$this;
     return super.type;
   }
 
   @override
-  set type(DirectiveType type) {
+  set type(DirectiveType? type) {
     _$this;
     super.type = type;
   }

--- a/lib/src/specs/enum.dart
+++ b/lib/src/specs/enum.dart
@@ -34,7 +34,7 @@ abstract class Enum extends Object
   @override
   R accept<R>(
     SpecVisitor<R> visitor, [
-    R context,
+    R? context,
   ]) =>
       visitor.visitEnum(this, context);
 }
@@ -46,7 +46,7 @@ abstract class EnumBuilder extends Object
 
   EnumBuilder._();
 
-  String name;
+  String? name;
 
   ListBuilder<EnumValue> values = ListBuilder<EnumValue>();
 
@@ -81,7 +81,7 @@ abstract class EnumValueBuilder extends Object
 
   EnumValueBuilder._();
 
-  String name;
+  String? name;
 
   @override
   ListBuilder<Expression> annotations = ListBuilder<Expression>();

--- a/lib/src/specs/enum.g.dart
+++ b/lib/src/specs/enum.g.dart
@@ -70,13 +70,13 @@ class _$EnumBuilder extends EnumBuilder {
   _$Enum? _$v;
 
   @override
-  String get name {
+  String? get name {
     _$this;
     return super.name;
   }
 
   @override
-  set name(String name) {
+  set name(String? name) {
     _$this;
     super.name = name;
   }
@@ -228,13 +228,13 @@ class _$EnumValueBuilder extends EnumValueBuilder {
   _$EnumValue? _$v;
 
   @override
-  String get name {
+  String? get name {
     _$this;
     return super.name;
   }
 
   @override
-  set name(String name) {
+  set name(String? name) {
     _$this;
     super.name = name;
   }

--- a/lib/src/specs/enum.g.dart
+++ b/lib/src/specs/enum.g.dart
@@ -16,22 +16,19 @@ class _$Enum extends Enum {
   @override
   final BuiltList<String> docs;
 
-  factory _$Enum([void Function(EnumBuilder) updates]) =>
+  factory _$Enum([void Function(EnumBuilder)? updates]) =>
       (new EnumBuilder()..update(updates)).build() as _$Enum;
 
-  _$Enum._({this.name, this.values, this.annotations, this.docs}) : super._() {
-    if (name == null) {
-      throw new BuiltValueNullFieldError('Enum', 'name');
-    }
-    if (values == null) {
-      throw new BuiltValueNullFieldError('Enum', 'values');
-    }
-    if (annotations == null) {
-      throw new BuiltValueNullFieldError('Enum', 'annotations');
-    }
-    if (docs == null) {
-      throw new BuiltValueNullFieldError('Enum', 'docs');
-    }
+  _$Enum._(
+      {required this.name,
+      required this.values,
+      required this.annotations,
+      required this.docs})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(name, 'Enum', 'name');
+    BuiltValueNullFieldError.checkNotNull(values, 'Enum', 'values');
+    BuiltValueNullFieldError.checkNotNull(annotations, 'Enum', 'annotations');
+    BuiltValueNullFieldError.checkNotNull(docs, 'Enum', 'docs');
   }
 
   @override
@@ -70,7 +67,7 @@ class _$Enum extends Enum {
 }
 
 class _$EnumBuilder extends EnumBuilder {
-  _$Enum _$v;
+  _$Enum? _$v;
 
   @override
   String get name {
@@ -87,7 +84,7 @@ class _$EnumBuilder extends EnumBuilder {
   @override
   ListBuilder<EnumValue> get values {
     _$this;
-    return super.values ??= new ListBuilder<EnumValue>();
+    return super.values;
   }
 
   @override
@@ -99,7 +96,7 @@ class _$EnumBuilder extends EnumBuilder {
   @override
   ListBuilder<Expression> get annotations {
     _$this;
-    return super.annotations ??= new ListBuilder<Expression>();
+    return super.annotations;
   }
 
   @override
@@ -111,7 +108,7 @@ class _$EnumBuilder extends EnumBuilder {
   @override
   ListBuilder<String> get docs {
     _$this;
-    return super.docs ??= new ListBuilder<String>();
+    return super.docs;
   }
 
   @override
@@ -123,11 +120,12 @@ class _$EnumBuilder extends EnumBuilder {
   _$EnumBuilder() : super._();
 
   EnumBuilder get _$this {
-    if (_$v != null) {
-      super.name = _$v.name;
-      super.values = _$v.values?.toBuilder();
-      super.annotations = _$v.annotations?.toBuilder();
-      super.docs = _$v.docs?.toBuilder();
+    final $v = _$v;
+    if ($v != null) {
+      super.name = $v.name;
+      super.values = $v.values.toBuilder();
+      super.annotations = $v.annotations.toBuilder();
+      super.docs = $v.docs.toBuilder();
       _$v = null;
     }
     return this;
@@ -135,14 +133,12 @@ class _$EnumBuilder extends EnumBuilder {
 
   @override
   void replace(Enum other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$Enum;
   }
 
   @override
-  void update(void Function(EnumBuilder) updates) {
+  void update(void Function(EnumBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -152,12 +148,12 @@ class _$EnumBuilder extends EnumBuilder {
     try {
       _$result = _$v ??
           new _$Enum._(
-              name: name,
+              name: BuiltValueNullFieldError.checkNotNull(name, 'Enum', 'name'),
               values: values.build(),
               annotations: annotations.build(),
               docs: docs.build());
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'values';
         values.build();
@@ -184,19 +180,16 @@ class _$EnumValue extends EnumValue {
   @override
   final BuiltList<String> docs;
 
-  factory _$EnumValue([void Function(EnumValueBuilder) updates]) =>
+  factory _$EnumValue([void Function(EnumValueBuilder)? updates]) =>
       (new EnumValueBuilder()..update(updates)).build() as _$EnumValue;
 
-  _$EnumValue._({this.name, this.annotations, this.docs}) : super._() {
-    if (name == null) {
-      throw new BuiltValueNullFieldError('EnumValue', 'name');
-    }
-    if (annotations == null) {
-      throw new BuiltValueNullFieldError('EnumValue', 'annotations');
-    }
-    if (docs == null) {
-      throw new BuiltValueNullFieldError('EnumValue', 'docs');
-    }
+  _$EnumValue._(
+      {required this.name, required this.annotations, required this.docs})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(name, 'EnumValue', 'name');
+    BuiltValueNullFieldError.checkNotNull(
+        annotations, 'EnumValue', 'annotations');
+    BuiltValueNullFieldError.checkNotNull(docs, 'EnumValue', 'docs');
   }
 
   @override
@@ -232,7 +225,7 @@ class _$EnumValue extends EnumValue {
 }
 
 class _$EnumValueBuilder extends EnumValueBuilder {
-  _$EnumValue _$v;
+  _$EnumValue? _$v;
 
   @override
   String get name {
@@ -249,7 +242,7 @@ class _$EnumValueBuilder extends EnumValueBuilder {
   @override
   ListBuilder<Expression> get annotations {
     _$this;
-    return super.annotations ??= new ListBuilder<Expression>();
+    return super.annotations;
   }
 
   @override
@@ -261,7 +254,7 @@ class _$EnumValueBuilder extends EnumValueBuilder {
   @override
   ListBuilder<String> get docs {
     _$this;
-    return super.docs ??= new ListBuilder<String>();
+    return super.docs;
   }
 
   @override
@@ -273,10 +266,11 @@ class _$EnumValueBuilder extends EnumValueBuilder {
   _$EnumValueBuilder() : super._();
 
   EnumValueBuilder get _$this {
-    if (_$v != null) {
-      super.name = _$v.name;
-      super.annotations = _$v.annotations?.toBuilder();
-      super.docs = _$v.docs?.toBuilder();
+    final $v = _$v;
+    if ($v != null) {
+      super.name = $v.name;
+      super.annotations = $v.annotations.toBuilder();
+      super.docs = $v.docs.toBuilder();
       _$v = null;
     }
     return this;
@@ -284,14 +278,12 @@ class _$EnumValueBuilder extends EnumValueBuilder {
 
   @override
   void replace(EnumValue other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$EnumValue;
   }
 
   @override
-  void update(void Function(EnumValueBuilder) updates) {
+  void update(void Function(EnumValueBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -301,9 +293,12 @@ class _$EnumValueBuilder extends EnumValueBuilder {
     try {
       _$result = _$v ??
           new _$EnumValue._(
-              name: name, annotations: annotations.build(), docs: docs.build());
+              name: BuiltValueNullFieldError.checkNotNull(
+                  name, 'EnumValue', 'name'),
+              annotations: annotations.build(),
+              docs: docs.build());
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'annotations';
         annotations.build();

--- a/lib/src/specs/expression.dart
+++ b/lib/src/specs/expression.dart
@@ -447,7 +447,7 @@ abstract class ExpressionEmitter implements ExpressionVisitor<StringSink> {
         out.write('>');
       }
       out.write('[');
-      visitAll<Object>(expression.values, out, (value) {
+      visitAll<Object?>(expression.values, out, (value) {
         _acceptLiteral(value, out);
       });
       return out..write(']');

--- a/lib/src/specs/expression.dart
+++ b/lib/src/specs/expression.dart
@@ -203,7 +203,7 @@ abstract class Expression implements Spec {
       );
 
   /// Return `var {name} = {this}`.
-  Expression assignVar(String name, [Reference type]) => BinaryExpression._(
+  Expression assignVar(String name, [Reference? type]) => BinaryExpression._(
         type == null
             ? LiteralExpression._('var $name')
             : BinaryExpression._(
@@ -216,7 +216,7 @@ abstract class Expression implements Spec {
       );
 
   /// Return `final {name} = {this}`.
-  Expression assignFinal(String name, [Reference type]) => BinaryExpression._(
+  Expression assignFinal(String name, [Reference? type]) => BinaryExpression._(
         type == null
             ? const LiteralExpression._('final')
             : BinaryExpression._(
@@ -229,7 +229,7 @@ abstract class Expression implements Spec {
       );
 
   /// Return `const {name} = {this}`.
-  Expression assignConst(String name, [Reference type]) => BinaryExpression._(
+  Expression assignConst(String name, [Reference? type]) => BinaryExpression._(
         type == null
             ? const LiteralExpression._('const')
             : BinaryExpression._(
@@ -313,7 +313,7 @@ class ToCodeExpression implements Code {
   const ToCodeExpression(this.code, [this.isStatement = false]);
 
   @override
-  R accept<R>(CodeVisitor<R> visitor, [R context]) =>
+  R accept<R>(CodeVisitor<R> visitor, [R? context]) =>
       (visitor as ExpressionVisitor<R>).visitToCodeExpression(this, context);
 
   @override
@@ -324,15 +324,15 @@ class ToCodeExpression implements Code {
 ///
 /// **INTERNAL ONLY**.
 abstract class ExpressionVisitor<T> implements SpecVisitor<T> {
-  T visitToCodeExpression(ToCodeExpression code, [T context]);
-  T visitBinaryExpression(BinaryExpression expression, [T context]);
-  T visitClosureExpression(ClosureExpression expression, [T context]);
-  T visitCodeExpression(CodeExpression expression, [T context]);
-  T visitInvokeExpression(InvokeExpression expression, [T context]);
-  T visitLiteralExpression(LiteralExpression expression, [T context]);
-  T visitLiteralListExpression(LiteralListExpression expression, [T context]);
-  T visitLiteralSetExpression(LiteralSetExpression expression, [T context]);
-  T visitLiteralMapExpression(LiteralMapExpression expression, [T context]);
+  T visitToCodeExpression(ToCodeExpression code, [T? context]);
+  T visitBinaryExpression(BinaryExpression expression, [T? context]);
+  T visitClosureExpression(ClosureExpression expression, [T? context]);
+  T visitCodeExpression(CodeExpression expression, [T? context]);
+  T visitInvokeExpression(InvokeExpression expression, [T? context]);
+  T visitLiteralExpression(LiteralExpression expression, [T? context]);
+  T visitLiteralListExpression(LiteralListExpression expression, [T? context]);
+  T visitLiteralSetExpression(LiteralSetExpression expression, [T? context]);
+  T visitLiteralMapExpression(LiteralMapExpression expression, [T? context]);
 }
 
 /// Knowledge of how to write valid Dart code from [ExpressionVisitor].
@@ -341,7 +341,7 @@ abstract class ExpressionVisitor<T> implements SpecVisitor<T> {
 abstract class ExpressionEmitter implements ExpressionVisitor<StringSink> {
   @override
   StringSink visitToCodeExpression(ToCodeExpression expression,
-      [StringSink output]) {
+      [StringSink? output]) {
     output ??= StringBuffer();
     expression.code.accept(this, output);
     if (expression.isStatement) {
@@ -352,7 +352,7 @@ abstract class ExpressionEmitter implements ExpressionVisitor<StringSink> {
 
   @override
   StringSink visitBinaryExpression(BinaryExpression expression,
-      [StringSink output]) {
+      [StringSink? output]) {
     output ??= StringBuffer();
     expression.left.accept(this, output);
     if (expression.addSpace) {
@@ -370,14 +370,14 @@ abstract class ExpressionEmitter implements ExpressionVisitor<StringSink> {
 
   @override
   StringSink visitClosureExpression(ClosureExpression expression,
-      [StringSink output]) {
+      [StringSink? output]) {
     output ??= StringBuffer();
     return expression.method.accept(this, output);
   }
 
   @override
   StringSink visitCodeExpression(CodeExpression expression,
-      [StringSink output]) {
+      [StringSink? output]) {
     output ??= StringBuffer();
     final visitor = this as CodeVisitor<StringSink>;
     return expression.code.accept(visitor, output);
@@ -385,45 +385,45 @@ abstract class ExpressionEmitter implements ExpressionVisitor<StringSink> {
 
   @override
   StringSink visitInvokeExpression(InvokeExpression expression,
-      [StringSink output]) {
-    output ??= StringBuffer();
+      [StringSink? output]) {
+    final out = output ??= StringBuffer();
     return _writeConstExpression(
-        output, expression.type == InvokeExpressionType.constInstance, () {
-      expression.target.accept(this, output);
+        out, expression.type == InvokeExpressionType.constInstance, () {
+      expression.target.accept(this, out);
       if (expression.name != null) {
-        output..write('.')..write(expression.name);
+        out..write('.')..write(expression.name);
       }
       if (expression.typeArguments.isNotEmpty) {
-        output.write('<');
-        visitAll<Reference>(expression.typeArguments, output, (type) {
-          type.accept(this, output);
+        out.write('<');
+        visitAll<Reference>(expression.typeArguments, out, (type) {
+          type.accept(this, out);
         });
-        output.write('>');
+        out.write('>');
       }
-      output.write('(');
-      visitAll<Spec>(expression.positionalArguments, output, (spec) {
-        spec.accept(this, output);
+      out.write('(');
+      visitAll<Spec>(expression.positionalArguments, out, (spec) {
+        spec.accept(this, out);
       });
       if (expression.positionalArguments.isNotEmpty &&
           expression.namedArguments.isNotEmpty) {
-        output.write(', ');
+        out.write(', ');
       }
-      visitAll<String>(expression.namedArguments.keys, output, (name) {
-        output..write(name)..write(': ');
-        expression.namedArguments[name].accept(this, output);
+      visitAll<String>(expression.namedArguments.keys, out, (name) {
+        out..write(name)..write(': ');
+        expression.namedArguments[name]!.accept(this, out);
       });
-      return output..write(')');
+      return out..write(')');
     });
   }
 
   @override
   StringSink visitLiteralExpression(LiteralExpression expression,
-      [StringSink output]) {
+      [StringSink? output]) {
     output ??= StringBuffer();
     return output..write(expression.literal);
   }
 
-  void _acceptLiteral(Object literalOrSpec, StringSink output) {
+  void _acceptLiteral(Object? literalOrSpec, StringSink output) {
     if (literalOrSpec is Spec) {
       literalOrSpec.accept(this, output);
       return;
@@ -436,71 +436,71 @@ abstract class ExpressionEmitter implements ExpressionVisitor<StringSink> {
   @override
   StringSink visitLiteralListExpression(
     LiteralListExpression expression, [
-    StringSink output,
+    StringSink? output,
   ]) {
-    output ??= StringBuffer();
+    final out = output ??= StringBuffer();
 
     return _writeConstExpression(output, expression.isConst, () {
       if (expression.type != null) {
-        output.write('<');
-        expression.type.accept(this, output);
-        output.write('>');
+        out.write('<');
+        expression.type!.accept(this, output);
+        out.write('>');
       }
-      output.write('[');
-      visitAll<Object>(expression.values, output, (value) {
-        _acceptLiteral(value, output);
+      out.write('[');
+      visitAll<Object>(expression.values, out, (value) {
+        _acceptLiteral(value, out);
       });
-      return output..write(']');
+      return out..write(']');
     });
   }
 
   @override
   StringSink visitLiteralSetExpression(
     LiteralSetExpression expression, [
-    StringSink output,
+    StringSink? output,
   ]) {
-    output ??= StringBuffer();
+    final out = output ??= StringBuffer();
 
     return _writeConstExpression(output, expression.isConst, () {
       if (expression.type != null) {
-        output.write('<');
-        expression.type.accept(this, output);
-        output.write('>');
+        out.write('<');
+        expression.type!.accept(this, output);
+        out.write('>');
       }
-      output.write('{');
-      visitAll<Object>(expression.values, output, (value) {
-        _acceptLiteral(value, output);
+      out.write('{');
+      visitAll<Object>(expression.values, out, (value) {
+        _acceptLiteral(value, out);
       });
-      return output..write('}');
+      return out..write('}');
     });
   }
 
   @override
   StringSink visitLiteralMapExpression(
     LiteralMapExpression expression, [
-    StringSink output,
+    StringSink? output,
   ]) {
-    output ??= StringBuffer();
-    return _writeConstExpression(output, expression.isConst, () {
+    final out = output ??= StringBuffer();
+    return _writeConstExpression(out, expression.isConst, () {
       if (expression.keyType != null) {
-        output.write('<');
-        expression.keyType.accept(this, output);
-        output.write(', ');
+        out.write('<');
+        expression.keyType!.accept(this, out);
+        out.write(', ');
         if (expression.valueType == null) {
-          const Reference('dynamic', 'dart:core').accept(this, output);
+          const Reference('dynamic', 'dart:core').accept(this, out);
         } else {
-          expression.valueType.accept(this, output);
+          expression.valueType!.accept(this, out);
         }
-        output.write('>');
+        out.write('>');
       }
-      output.write('{');
-      visitAll<Object>(expression.values.keys, output, (key) {
+      out.write('{');
+      visitAll<Object>(expression.values.keys, out, (key) {
         final value = expression.values[key];
-        _acceptLiteral(key, output);
-        output.write(': ');
-        _acceptLiteral(value, output);
+        _acceptLiteral(key, out);
+        out.write(': ');
+        _acceptLiteral(value, out);
       });
-      return output..write('}');
+      return out..write('}');
     });
   }
 

--- a/lib/src/specs/expression.dart
+++ b/lib/src/specs/expression.dart
@@ -32,7 +32,7 @@ abstract class Expression implements Spec {
   static const _empty = CodeExpression(Code(''));
 
   @override
-  R accept<R>(covariant ExpressionVisitor<R> visitor, [R context]);
+  R accept<R>(covariant ExpressionVisitor<R> visitor, [R? context]);
 
   /// The expression as a valid [Code] block.
   ///
@@ -468,7 +468,7 @@ abstract class ExpressionEmitter implements ExpressionVisitor<StringSink> {
         out.write('>');
       }
       out.write('{');
-      visitAll<Object>(expression.values, out, (value) {
+      visitAll<Object?>(expression.values, out, (value) {
         _acceptLiteral(value, out);
       });
       return out..write('}');
@@ -494,7 +494,7 @@ abstract class ExpressionEmitter implements ExpressionVisitor<StringSink> {
         out.write('>');
       }
       out.write('{');
-      visitAll<Object>(expression.values.keys, out, (key) {
+      visitAll<Object?>(expression.values.keys, out, (key) {
         final value = expression.values[key];
         _acceptLiteral(key, out);
         out.write(': ');

--- a/lib/src/specs/expression/binary.dart
+++ b/lib/src/specs/expression/binary.dart
@@ -21,6 +21,6 @@ class BinaryExpression extends Expression {
   });
 
   @override
-  R accept<R>(ExpressionVisitor<R> visitor, [R context]) =>
+  R accept<R>(ExpressionVisitor<R> visitor, [R? context]) =>
       visitor.visitBinaryExpression(this, context);
 }

--- a/lib/src/specs/expression/closure.dart
+++ b/lib/src/specs/expression/closure.dart
@@ -27,6 +27,6 @@ class ClosureExpression extends Expression {
   const ClosureExpression._(this.method);
 
   @override
-  R accept<R>(ExpressionVisitor<R> visitor, [R context]) =>
+  R accept<R>(ExpressionVisitor<R> visitor, [R? context]) =>
       visitor.visitClosureExpression(this, context);
 }

--- a/lib/src/specs/expression/code.dart
+++ b/lib/src/specs/expression/code.dart
@@ -13,6 +13,6 @@ class CodeExpression extends Expression {
   const CodeExpression(this.code);
 
   @override
-  R accept<R>(ExpressionVisitor<R> visitor, [R context]) =>
+  R accept<R>(ExpressionVisitor<R> visitor, [R? context]) =>
       visitor.visitCodeExpression(this, context);
 }

--- a/lib/src/specs/expression/invoke.dart
+++ b/lib/src/specs/expression/invoke.dart
@@ -10,18 +10,18 @@ class InvokeExpression extends Expression {
   final Expression target;
 
   /// Optional; type of invocation.
-  final InvokeExpressionType type;
+  final InvokeExpressionType? type;
 
   final List<Expression> positionalArguments;
   final Map<String, Expression> namedArguments;
   final List<Reference> typeArguments;
-  final String name;
+  final String? name;
 
   const InvokeExpression._(
     this.target,
     this.positionalArguments, [
     this.namedArguments = const {},
-    this.typeArguments,
+    this.typeArguments = const [],
     this.name,
   ]) : type = null;
 
@@ -29,7 +29,7 @@ class InvokeExpression extends Expression {
     this.target,
     this.positionalArguments, [
     this.namedArguments = const {},
-    this.typeArguments,
+    this.typeArguments = const [],
     this.name,
   ]) : type = InvokeExpressionType.newInstance;
 
@@ -37,12 +37,12 @@ class InvokeExpression extends Expression {
     this.target,
     this.positionalArguments, [
     this.namedArguments = const {},
-    this.typeArguments,
+    this.typeArguments = const [],
     this.name,
   ]) : type = InvokeExpressionType.constInstance;
 
   @override
-  R accept<R>(ExpressionVisitor<R> visitor, [R context]) =>
+  R accept<R>(ExpressionVisitor<R> visitor, [R? context]) =>
       visitor.visitInvokeExpression(this, context);
 
   @override

--- a/lib/src/specs/expression/literal.dart
+++ b/lib/src/specs/expression/literal.dart
@@ -7,7 +7,7 @@ part of code_builder.src.specs.expression;
 /// Converts a runtime Dart [literal] value into an [Expression].
 ///
 /// Unsupported inputs invoke the [onError] callback.
-Expression literal(Object literal, {Expression Function(Object) onError}) {
+Expression literal(Object? literal, {Expression Function(Object)? onError}) {
   if (literal is bool) {
     return literalBool(literal);
   }
@@ -66,34 +66,36 @@ Expression literalString(String value, {bool raw = false}) {
 }
 
 /// Creates a literal list expression from [values].
-LiteralListExpression literalList(Iterable<Object> values, [Reference type]) =>
+LiteralListExpression literalList(Iterable<Object?> values,
+        [Reference? type]) =>
     LiteralListExpression._(false, values.toList(), type);
 
 /// Creates a literal `const` list expression from [values].
-LiteralListExpression literalConstList(List<Object> values, [Reference type]) =>
+LiteralListExpression literalConstList(List<Object?> values,
+        [Reference? type]) =>
     LiteralListExpression._(true, values, type);
 
 /// Creates a literal set expression from [values].
-LiteralSetExpression literalSet(Iterable<Object> values, [Reference type]) =>
+LiteralSetExpression literalSet(Iterable<Object?> values, [Reference? type]) =>
     LiteralSetExpression._(false, values.toSet(), type);
 
 /// Creates a literal `const` set expression from [values].
-LiteralSetExpression literalConstSet(Set<Object> values, [Reference type]) =>
+LiteralSetExpression literalConstSet(Set<Object?> values, [Reference? type]) =>
     LiteralSetExpression._(true, values, type);
 
 /// Create a literal map expression from [values].
 LiteralMapExpression literalMap(
-  Map<Object, Object> values, [
-  Reference keyType,
-  Reference valueType,
+  Map<Object?, Object?> values, [
+  Reference? keyType,
+  Reference? valueType,
 ]) =>
     LiteralMapExpression._(false, values, keyType, valueType);
 
 /// Create a literal `const` map expression from [values].
 LiteralMapExpression literalConstMap(
-  Map<Object, Object> values, [
-  Reference keyType,
-  Reference valueType,
+  Map<Object?, Object?> values, [
+  Reference? keyType,
+  Reference? valueType,
 ]) =>
     LiteralMapExpression._(true, values, keyType, valueType);
 
@@ -113,7 +115,7 @@ class LiteralExpression extends Expression {
   const LiteralExpression._(this.literal);
 
   @override
-  R accept<R>(ExpressionVisitor<R> visitor, [R context]) =>
+  R accept<R>(ExpressionVisitor<R> visitor, [R? context]) =>
       visitor.visitLiteralExpression(this, context);
 
   @override
@@ -122,13 +124,13 @@ class LiteralExpression extends Expression {
 
 class LiteralListExpression extends Expression {
   final bool isConst;
-  final List<Object> values;
-  final Reference type;
+  final List<Object?> values;
+  final Reference? type;
 
   const LiteralListExpression._(this.isConst, this.values, this.type);
 
   @override
-  R accept<R>(ExpressionVisitor<R> visitor, [R context]) =>
+  R accept<R>(ExpressionVisitor<R> visitor, [R? context]) =>
       visitor.visitLiteralListExpression(this, context);
 
   @override
@@ -137,13 +139,13 @@ class LiteralListExpression extends Expression {
 
 class LiteralSetExpression extends Expression {
   final bool isConst;
-  final Set<Object> values;
-  final Reference type;
+  final Set<Object?> values;
+  final Reference? type;
 
   const LiteralSetExpression._(this.isConst, this.values, this.type);
 
   @override
-  R accept<R>(ExpressionVisitor<R> visitor, [R context]) =>
+  R accept<R>(ExpressionVisitor<R> visitor, [R? context]) =>
       visitor.visitLiteralSetExpression(this, context);
 
   @override
@@ -152,9 +154,9 @@ class LiteralSetExpression extends Expression {
 
 class LiteralMapExpression extends Expression {
   final bool isConst;
-  final Map<Object, Object> values;
-  final Reference keyType;
-  final Reference valueType;
+  final Map<Object?, Object?> values;
+  final Reference? keyType;
+  final Reference? valueType;
 
   const LiteralMapExpression._(
     this.isConst,
@@ -164,7 +166,7 @@ class LiteralMapExpression extends Expression {
   );
 
   @override
-  R accept<R>(ExpressionVisitor<R> visitor, [R context]) =>
+  R accept<R>(ExpressionVisitor<R> visitor, [R? context]) =>
       visitor.visitLiteralMapExpression(this, context);
 
   @override

--- a/lib/src/specs/extension.dart
+++ b/lib/src/specs/extension.dart
@@ -33,8 +33,7 @@ abstract class Extension extends Object
   @override
   BuiltList<String> get docs;
 
-  @nullable
-  Reference get on;
+  Reference? get on;
 
   @override
   BuiltList<Reference> get types;
@@ -43,8 +42,7 @@ abstract class Extension extends Object
   BuiltList<Field> get fields;
 
   /// Name of the extension - optional.
-  @nullable
-  String get name;
+  String? get name;
 
   @override
   R accept<R>(

--- a/lib/src/specs/extension.dart
+++ b/lib/src/specs/extension.dart
@@ -47,7 +47,7 @@ abstract class Extension extends Object
   @override
   R accept<R>(
     SpecVisitor<R> visitor, [
-    R context,
+    R? context,
   ]) =>
       visitor.visitExtension(this, context);
 }
@@ -65,7 +65,7 @@ abstract class ExtensionBuilder extends Object
   @override
   ListBuilder<String> docs = ListBuilder<String>();
 
-  Reference on;
+  Reference? on;
 
   @override
   ListBuilder<Reference> types = ListBuilder<Reference>();
@@ -74,5 +74,5 @@ abstract class ExtensionBuilder extends Object
   ListBuilder<Field> fields = ListBuilder<Field>();
 
   /// Name of the extension - optional.
-  String name;
+  String? name;
 }

--- a/lib/src/specs/extension.g.dart
+++ b/lib/src/specs/extension.g.dart
@@ -12,7 +12,7 @@ class _$Extension extends Extension {
   @override
   final BuiltList<String> docs;
   @override
-  final Reference on;
+  final Reference? on;
   @override
   final BuiltList<Reference> types;
   @override
@@ -20,35 +20,26 @@ class _$Extension extends Extension {
   @override
   final BuiltList<Field> fields;
   @override
-  final String name;
+  final String? name;
 
-  factory _$Extension([void Function(ExtensionBuilder) updates]) =>
+  factory _$Extension([void Function(ExtensionBuilder)? updates]) =>
       (new ExtensionBuilder()..update(updates)).build() as _$Extension;
 
   _$Extension._(
-      {this.annotations,
-      this.docs,
+      {required this.annotations,
+      required this.docs,
       this.on,
-      this.types,
-      this.methods,
-      this.fields,
+      required this.types,
+      required this.methods,
+      required this.fields,
       this.name})
       : super._() {
-    if (annotations == null) {
-      throw new BuiltValueNullFieldError('Extension', 'annotations');
-    }
-    if (docs == null) {
-      throw new BuiltValueNullFieldError('Extension', 'docs');
-    }
-    if (types == null) {
-      throw new BuiltValueNullFieldError('Extension', 'types');
-    }
-    if (methods == null) {
-      throw new BuiltValueNullFieldError('Extension', 'methods');
-    }
-    if (fields == null) {
-      throw new BuiltValueNullFieldError('Extension', 'fields');
-    }
+    BuiltValueNullFieldError.checkNotNull(
+        annotations, 'Extension', 'annotations');
+    BuiltValueNullFieldError.checkNotNull(docs, 'Extension', 'docs');
+    BuiltValueNullFieldError.checkNotNull(types, 'Extension', 'types');
+    BuiltValueNullFieldError.checkNotNull(methods, 'Extension', 'methods');
+    BuiltValueNullFieldError.checkNotNull(fields, 'Extension', 'fields');
   }
 
   @override
@@ -100,12 +91,12 @@ class _$Extension extends Extension {
 }
 
 class _$ExtensionBuilder extends ExtensionBuilder {
-  _$Extension _$v;
+  _$Extension? _$v;
 
   @override
   ListBuilder<Expression> get annotations {
     _$this;
-    return super.annotations ??= new ListBuilder<Expression>();
+    return super.annotations;
   }
 
   @override
@@ -117,7 +108,7 @@ class _$ExtensionBuilder extends ExtensionBuilder {
   @override
   ListBuilder<String> get docs {
     _$this;
-    return super.docs ??= new ListBuilder<String>();
+    return super.docs;
   }
 
   @override
@@ -141,7 +132,7 @@ class _$ExtensionBuilder extends ExtensionBuilder {
   @override
   ListBuilder<Reference> get types {
     _$this;
-    return super.types ??= new ListBuilder<Reference>();
+    return super.types;
   }
 
   @override
@@ -153,7 +144,7 @@ class _$ExtensionBuilder extends ExtensionBuilder {
   @override
   ListBuilder<Method> get methods {
     _$this;
-    return super.methods ??= new ListBuilder<Method>();
+    return super.methods;
   }
 
   @override
@@ -165,7 +156,7 @@ class _$ExtensionBuilder extends ExtensionBuilder {
   @override
   ListBuilder<Field> get fields {
     _$this;
-    return super.fields ??= new ListBuilder<Field>();
+    return super.fields;
   }
 
   @override
@@ -189,14 +180,15 @@ class _$ExtensionBuilder extends ExtensionBuilder {
   _$ExtensionBuilder() : super._();
 
   ExtensionBuilder get _$this {
-    if (_$v != null) {
-      super.annotations = _$v.annotations?.toBuilder();
-      super.docs = _$v.docs?.toBuilder();
-      super.on = _$v.on;
-      super.types = _$v.types?.toBuilder();
-      super.methods = _$v.methods?.toBuilder();
-      super.fields = _$v.fields?.toBuilder();
-      super.name = _$v.name;
+    final $v = _$v;
+    if ($v != null) {
+      super.annotations = $v.annotations.toBuilder();
+      super.docs = $v.docs.toBuilder();
+      super.on = $v.on;
+      super.types = $v.types.toBuilder();
+      super.methods = $v.methods.toBuilder();
+      super.fields = $v.fields.toBuilder();
+      super.name = $v.name;
       _$v = null;
     }
     return this;
@@ -204,14 +196,12 @@ class _$ExtensionBuilder extends ExtensionBuilder {
 
   @override
   void replace(Extension other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$Extension;
   }
 
   @override
-  void update(void Function(ExtensionBuilder) updates) {
+  void update(void Function(ExtensionBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -229,7 +219,7 @@ class _$ExtensionBuilder extends ExtensionBuilder {
               fields: fields.build(),
               name: name);
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'annotations';
         annotations.build();

--- a/lib/src/specs/extension.g.dart
+++ b/lib/src/specs/extension.g.dart
@@ -118,13 +118,13 @@ class _$ExtensionBuilder extends ExtensionBuilder {
   }
 
   @override
-  Reference get on {
+  Reference? get on {
     _$this;
     return super.on;
   }
 
   @override
-  set on(Reference on) {
+  set on(Reference? on) {
     _$this;
     super.on = on;
   }
@@ -166,13 +166,13 @@ class _$ExtensionBuilder extends ExtensionBuilder {
   }
 
   @override
-  String get name {
+  String? get name {
     _$this;
     return super.name;
   }
 
   @override
-  set name(String name) {
+  set name(String? name) {
     _$this;
     super.name = name;
   }

--- a/lib/src/specs/field.dart
+++ b/lib/src/specs/field.dart
@@ -31,8 +31,7 @@ abstract class Field extends Object
   BuiltList<String> get docs;
 
   /// Field assignment, if any.
-  @nullable
-  Code get assignment;
+  Code? get assignment;
 
   /// Whether this field should be prefixed with `static`.
   ///
@@ -42,8 +41,7 @@ abstract class Field extends Object
   /// Name of the field.
   String get name;
 
-  @nullable
-  Reference get type;
+  Reference? get type;
 
   FieldModifier get modifier;
 

--- a/lib/src/specs/field.dart
+++ b/lib/src/specs/field.dart
@@ -48,7 +48,7 @@ abstract class Field extends Object
   @override
   R accept<R>(
     SpecVisitor<R> visitor, [
-    R context,
+    R? context,
   ]) =>
       visitor.visitField(this, context);
 }
@@ -73,7 +73,7 @@ abstract class FieldBuilder extends Object
   ListBuilder<String> docs = ListBuilder<String>();
 
   /// Field assignment, if any.
-  Code assignment;
+  Code? assignment;
 
   /// Whether this field should be prefixed with `static`.
   ///
@@ -81,9 +81,9 @@ abstract class FieldBuilder extends Object
   bool static = false;
 
   /// Name of the field.
-  String name;
+  String? name;
 
-  Reference type;
+  Reference? type;
 
   FieldModifier modifier = FieldModifier.var$;
 }

--- a/lib/src/specs/field.g.dart
+++ b/lib/src/specs/field.g.dart
@@ -12,43 +12,33 @@ class _$Field extends Field {
   @override
   final BuiltList<String> docs;
   @override
-  final Code assignment;
+  final Code? assignment;
   @override
   final bool static;
   @override
   final String name;
   @override
-  final Reference type;
+  final Reference? type;
   @override
   final FieldModifier modifier;
 
-  factory _$Field([void Function(FieldBuilder) updates]) =>
+  factory _$Field([void Function(FieldBuilder)? updates]) =>
       (new FieldBuilder()..update(updates)).build() as _$Field;
 
   _$Field._(
-      {this.annotations,
-      this.docs,
+      {required this.annotations,
+      required this.docs,
       this.assignment,
-      this.static,
-      this.name,
+      required this.static,
+      required this.name,
       this.type,
-      this.modifier})
+      required this.modifier})
       : super._() {
-    if (annotations == null) {
-      throw new BuiltValueNullFieldError('Field', 'annotations');
-    }
-    if (docs == null) {
-      throw new BuiltValueNullFieldError('Field', 'docs');
-    }
-    if (static == null) {
-      throw new BuiltValueNullFieldError('Field', 'static');
-    }
-    if (name == null) {
-      throw new BuiltValueNullFieldError('Field', 'name');
-    }
-    if (modifier == null) {
-      throw new BuiltValueNullFieldError('Field', 'modifier');
-    }
+    BuiltValueNullFieldError.checkNotNull(annotations, 'Field', 'annotations');
+    BuiltValueNullFieldError.checkNotNull(docs, 'Field', 'docs');
+    BuiltValueNullFieldError.checkNotNull(static, 'Field', 'static');
+    BuiltValueNullFieldError.checkNotNull(name, 'Field', 'name');
+    BuiltValueNullFieldError.checkNotNull(modifier, 'Field', 'modifier');
   }
 
   @override
@@ -100,12 +90,12 @@ class _$Field extends Field {
 }
 
 class _$FieldBuilder extends FieldBuilder {
-  _$Field _$v;
+  _$Field? _$v;
 
   @override
   ListBuilder<Expression> get annotations {
     _$this;
-    return super.annotations ??= new ListBuilder<Expression>();
+    return super.annotations;
   }
 
   @override
@@ -117,7 +107,7 @@ class _$FieldBuilder extends FieldBuilder {
   @override
   ListBuilder<String> get docs {
     _$this;
-    return super.docs ??= new ListBuilder<String>();
+    return super.docs;
   }
 
   @override
@@ -189,14 +179,15 @@ class _$FieldBuilder extends FieldBuilder {
   _$FieldBuilder() : super._();
 
   FieldBuilder get _$this {
-    if (_$v != null) {
-      super.annotations = _$v.annotations?.toBuilder();
-      super.docs = _$v.docs?.toBuilder();
-      super.assignment = _$v.assignment;
-      super.static = _$v.static;
-      super.name = _$v.name;
-      super.type = _$v.type;
-      super.modifier = _$v.modifier;
+    final $v = _$v;
+    if ($v != null) {
+      super.annotations = $v.annotations.toBuilder();
+      super.docs = $v.docs.toBuilder();
+      super.assignment = $v.assignment;
+      super.static = $v.static;
+      super.name = $v.name;
+      super.type = $v.type;
+      super.modifier = $v.modifier;
       _$v = null;
     }
     return this;
@@ -204,14 +195,12 @@ class _$FieldBuilder extends FieldBuilder {
 
   @override
   void replace(Field other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$Field;
   }
 
   @override
-  void update(void Function(FieldBuilder) updates) {
+  void update(void Function(FieldBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -224,12 +213,15 @@ class _$FieldBuilder extends FieldBuilder {
               annotations: annotations.build(),
               docs: docs.build(),
               assignment: assignment,
-              static: static,
-              name: name,
+              static: BuiltValueNullFieldError.checkNotNull(
+                  static, 'Field', 'static'),
+              name:
+                  BuiltValueNullFieldError.checkNotNull(name, 'Field', 'name'),
               type: type,
-              modifier: modifier);
+              modifier: BuiltValueNullFieldError.checkNotNull(
+                  modifier, 'Field', 'modifier'));
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'annotations';
         annotations.build();

--- a/lib/src/specs/field.g.dart
+++ b/lib/src/specs/field.g.dart
@@ -117,13 +117,13 @@ class _$FieldBuilder extends FieldBuilder {
   }
 
   @override
-  Code get assignment {
+  Code? get assignment {
     _$this;
     return super.assignment;
   }
 
   @override
-  set assignment(Code assignment) {
+  set assignment(Code? assignment) {
     _$this;
     super.assignment = assignment;
   }
@@ -141,25 +141,25 @@ class _$FieldBuilder extends FieldBuilder {
   }
 
   @override
-  String get name {
+  String? get name {
     _$this;
     return super.name;
   }
 
   @override
-  set name(String name) {
+  set name(String? name) {
     _$this;
     super.name = name;
   }
 
   @override
-  Reference get type {
+  Reference? get type {
     _$this;
     return super.type;
   }
 
   @override
-  set type(Reference type) {
+  set type(Reference? type) {
     _$this;
     super.type = type;
   }

--- a/lib/src/specs/library.dart
+++ b/lib/src/specs/library.dart
@@ -23,7 +23,7 @@ abstract class Library implements Built<Library, LibraryBuilder>, Spec {
   @override
   R accept<R>(
     SpecVisitor<R> visitor, [
-    R context,
+    R? context,
   ]) =>
       visitor.visitLibrary(this, context);
 }

--- a/lib/src/specs/library.g.dart
+++ b/lib/src/specs/library.g.dart
@@ -12,16 +12,12 @@ class _$Library extends Library {
   @override
   final BuiltList<Spec> body;
 
-  factory _$Library([void Function(LibraryBuilder) updates]) =>
+  factory _$Library([void Function(LibraryBuilder)? updates]) =>
       (new LibraryBuilder()..update(updates)).build() as _$Library;
 
-  _$Library._({this.directives, this.body}) : super._() {
-    if (directives == null) {
-      throw new BuiltValueNullFieldError('Library', 'directives');
-    }
-    if (body == null) {
-      throw new BuiltValueNullFieldError('Library', 'body');
-    }
+  _$Library._({required this.directives, required this.body}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(directives, 'Library', 'directives');
+    BuiltValueNullFieldError.checkNotNull(body, 'Library', 'body');
   }
 
   @override
@@ -54,12 +50,12 @@ class _$Library extends Library {
 }
 
 class _$LibraryBuilder extends LibraryBuilder {
-  _$Library _$v;
+  _$Library? _$v;
 
   @override
   ListBuilder<Directive> get directives {
     _$this;
-    return super.directives ??= new ListBuilder<Directive>();
+    return super.directives;
   }
 
   @override
@@ -71,7 +67,7 @@ class _$LibraryBuilder extends LibraryBuilder {
   @override
   ListBuilder<Spec> get body {
     _$this;
-    return super.body ??= new ListBuilder<Spec>();
+    return super.body;
   }
 
   @override
@@ -83,9 +79,10 @@ class _$LibraryBuilder extends LibraryBuilder {
   _$LibraryBuilder() : super._();
 
   LibraryBuilder get _$this {
-    if (_$v != null) {
-      super.directives = _$v.directives?.toBuilder();
-      super.body = _$v.body?.toBuilder();
+    final $v = _$v;
+    if ($v != null) {
+      super.directives = $v.directives.toBuilder();
+      super.body = $v.body.toBuilder();
       _$v = null;
     }
     return this;
@@ -93,14 +90,12 @@ class _$LibraryBuilder extends LibraryBuilder {
 
   @override
   void replace(Library other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$Library;
   }
 
   @override
-  void update(void Function(LibraryBuilder) updates) {
+  void update(void Function(LibraryBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -111,7 +106,7 @@ class _$LibraryBuilder extends LibraryBuilder {
       _$result = _$v ??
           new _$Library._(directives: directives.build(), body: body.build());
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'directives';
         directives.build();

--- a/lib/src/specs/method.dart
+++ b/lib/src/specs/method.dart
@@ -101,6 +101,11 @@ abstract class MethodBuilder extends Object
   MethodBuilder._();
 
   @override
+  void update(void Function(MethodBuilder)? updates) {
+    updates?.call(this);
+  }
+
+  @override
   ListBuilder<Expression> annotations = ListBuilder<Expression>();
 
   @override
@@ -207,6 +212,11 @@ abstract class ParameterBuilder extends Object
   factory ParameterBuilder() = _$ParameterBuilder;
 
   ParameterBuilder._();
+
+  @override
+  void update(void Function(ParameterBuilder)? updates) {
+    updates?.call(this);
+  }
 
   /// If not `null`, a default assignment if the parameter is optional.
   Code? defaultTo;

--- a/lib/src/specs/method.dart
+++ b/lib/src/specs/method.dart
@@ -25,7 +25,7 @@ abstract class Method extends Object
     implements Built<Method, MethodBuilder>, Spec {
   factory Method([void Function(MethodBuilder) updates]) = _$Method;
 
-  factory Method.returnsVoid([void Function(MethodBuilder) updates]) =>
+  factory Method.returnsVoid([void Function(MethodBuilder)? updates]) =>
       Method((b) {
         if (updates != null) {
           updates(b);
@@ -51,8 +51,7 @@ abstract class Method extends Object
   BuiltList<Parameter> get requiredParameters;
 
   /// Body of the method.
-  @nullable
-  Code get body;
+  Code? get body;
 
   /// Whether the method should be prefixed with `external`.
   bool get external;
@@ -60,8 +59,7 @@ abstract class Method extends Object
   /// Whether this method is a simple lambda expression.
   ///
   /// May be `null` to be inferred based on the value of [body].
-  @nullable
-  bool get lambda;
+  bool? get lambda;
 
   /// Whether this method should be prefixed with `static`.
   ///
@@ -71,24 +69,20 @@ abstract class Method extends Object
   /// Name of the method or function.
   ///
   /// May be `null` when being used as a [closure].
-  @nullable
-  String get name;
+  String? get name;
 
   /// Whether this is a getter or setter.
-  @nullable
-  MethodType get type;
+  MethodType? get type;
 
   /// Whether this method is `async`, `async*`, or `sync*`.
-  @nullable
-  MethodModifier get modifier;
+  MethodModifier? get modifier;
 
-  @nullable
-  Reference get returns;
+  Reference? get returns;
 
   @override
   R accept<R>(
     SpecVisitor<R> visitor, [
-    R context,
+    R? context,
   ]) =>
       visitor.visitMethod(this, context);
 
@@ -122,7 +116,7 @@ abstract class MethodBuilder extends Object
   ListBuilder<Parameter> requiredParameters = ListBuilder<Parameter>();
 
   /// Body of the method.
-  Code body;
+  Code? body;
 
   /// Whether the method should be prefixed with `external`.
   bool external = false;
@@ -130,7 +124,7 @@ abstract class MethodBuilder extends Object
   /// Whether this method is a simple lambda expression.
   ///
   /// If not specified this is inferred from the [body].
-  bool lambda;
+  bool? lambda;
 
   /// Whether this method should be prefixed with `static`.
   ///
@@ -138,15 +132,15 @@ abstract class MethodBuilder extends Object
   bool static = false;
 
   /// Name of the method or function.
-  String name;
+  String? name;
 
   /// Whether this is a getter or setter.
-  MethodType type;
+  MethodType? type;
 
   /// Whether this method is `async`, `async*`, or `sync*`.
-  MethodModifier modifier;
+  MethodModifier? modifier;
 
-  Reference returns;
+  Reference? returns;
 }
 
 enum MethodType {
@@ -168,8 +162,7 @@ abstract class Parameter extends Object
   Parameter._();
 
   /// If not `null`, a default assignment if the parameter is optional.
-  @nullable
-  Code get defaultTo;
+  Code? get defaultTo;
 
   /// Name of the parameter.
   String get name;
@@ -192,8 +185,7 @@ abstract class Parameter extends Object
   BuiltList<Reference> get types;
 
   /// Type of the parameter;
-  @nullable
-  Reference get type;
+  Reference? get type;
 
   /// Whether this parameter should be annotated with the `required` keyword.
   ///
@@ -217,10 +209,10 @@ abstract class ParameterBuilder extends Object
   ParameterBuilder._();
 
   /// If not `null`, a default assignment if the parameter is optional.
-  Code defaultTo;
+  Code? defaultTo;
 
   /// Name of the parameter.
-  String name;
+  late final String name;
 
   /// Whether this parameter should be named, if optional.
   bool named = false;
@@ -240,7 +232,7 @@ abstract class ParameterBuilder extends Object
   ListBuilder<Reference> types = ListBuilder<Reference>();
 
   /// Type of the parameter;
-  Reference type;
+  Reference? type;
 
   /// Whether this parameter should be annotated with the `required` keyword.
   ///

--- a/lib/src/specs/method.g.dart
+++ b/lib/src/specs/method.g.dart
@@ -51,7 +51,17 @@ class _$Method extends Method {
       this.type,
       this.modifier,
       this.returns})
-      : super._();
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(annotations, 'Method', 'annotations');
+    BuiltValueNullFieldError.checkNotNull(docs, 'Method', 'docs');
+    BuiltValueNullFieldError.checkNotNull(types, 'Method', 'types');
+    BuiltValueNullFieldError.checkNotNull(
+        optionalParameters, 'Method', 'optionalParameters');
+    BuiltValueNullFieldError.checkNotNull(
+        requiredParameters, 'Method', 'requiredParameters');
+    BuiltValueNullFieldError.checkNotNull(external, 'Method', 'external');
+    BuiltValueNullFieldError.checkNotNull(static, 'Method', 'static');
+  }
 
   @override
   Method rebuild(void Function(MethodBuilder) updates) =>
@@ -117,14 +127,14 @@ class _$Method extends Method {
           ..add('types', types)
           ..add('optionalParameters', optionalParameters)
           ..add('requiredParameters', requiredParameters)
-          ..add('body', body ?? 'null')
+          ..add('body', body)
           ..add('external', external)
-          ..add('lambda', lambda ?? 'null')
+          ..add('lambda', lambda)
           ..add('static', static)
-          ..add('name', name ?? 'null')
-          ..add('type', type ?? 'null')
-          ..add('modifier', modifier ?? 'null')
-          ..add('returns', returns ?? 'null'))
+          ..add('name', name)
+          ..add('type', type)
+          ..add('modifier', modifier)
+          ..add('returns', returns))
         .toString();
   }
 }
@@ -193,9 +203,9 @@ class _$MethodBuilder extends MethodBuilder {
   }
 
   @override
-  Code get body {
+  Code? get body {
     _$this;
-    return super.body!;
+    return super.body;
   }
 
   @override
@@ -217,9 +227,9 @@ class _$MethodBuilder extends MethodBuilder {
   }
 
   @override
-  bool get lambda {
+  bool? get lambda {
     _$this;
-    return super.lambda!;
+    return super.lambda;
   }
 
   @override
@@ -241,9 +251,9 @@ class _$MethodBuilder extends MethodBuilder {
   }
 
   @override
-  String get name {
+  String? get name {
     _$this;
-    return super.name!;
+    return super.name;
   }
 
   @override
@@ -253,9 +263,9 @@ class _$MethodBuilder extends MethodBuilder {
   }
 
   @override
-  MethodType get type {
+  MethodType? get type {
     _$this;
-    return super.type!;
+    return super.type;
   }
 
   @override
@@ -265,9 +275,9 @@ class _$MethodBuilder extends MethodBuilder {
   }
 
   @override
-  MethodModifier get modifier {
+  MethodModifier? get modifier {
     _$this;
-    return super.modifier!;
+    return super.modifier;
   }
 
   @override
@@ -277,9 +287,9 @@ class _$MethodBuilder extends MethodBuilder {
   }
 
   @override
-  Reference get returns {
+  Reference? get returns {
     _$this;
-    return super.returns!;
+    return super.returns;
   }
 
   @override
@@ -291,30 +301,29 @@ class _$MethodBuilder extends MethodBuilder {
   _$MethodBuilder() : super._();
 
   MethodBuilder get _$this {
-    if (_$v != null) {
-      super.annotations = _$v!.annotations.toBuilder();
-      super.docs = _$v!.docs.toBuilder();
-      super.types = _$v!.types.toBuilder();
-      super.optionalParameters = _$v!.optionalParameters.toBuilder();
-      super.requiredParameters = _$v!.requiredParameters.toBuilder();
-      super.body = _$v!.body;
-      super.external = _$v!.external;
-      super.lambda = _$v!.lambda;
-      super.static = _$v!.static;
-      super.name = _$v!.name;
-      super.type = _$v!.type;
-      super.modifier = _$v!.modifier;
-      super.returns = _$v!.returns;
+    final $v = _$v;
+    if ($v != null) {
+      super.annotations = $v.annotations.toBuilder();
+      super.docs = $v.docs.toBuilder();
+      super.types = $v.types.toBuilder();
+      super.optionalParameters = $v.optionalParameters.toBuilder();
+      super.requiredParameters = $v.requiredParameters.toBuilder();
+      super.body = $v.body;
+      super.external = $v.external;
+      super.lambda = $v.lambda;
+      super.static = $v.static;
+      super.name = $v.name;
+      super.type = $v.type;
+      super.modifier = $v.modifier;
+      super.returns = $v.returns;
       _$v = null;
     }
     return this;
   }
 
   @override
-  void replace(Method? other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+  void replace(Method other) {
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$Method;
   }
 
@@ -335,9 +344,11 @@ class _$MethodBuilder extends MethodBuilder {
               optionalParameters: optionalParameters.build(),
               requiredParameters: requiredParameters.build(),
               body: body,
-              external: external,
+              external: BuiltValueNullFieldError.checkNotNull(
+                  external, 'Method', 'external'),
               lambda: lambda,
-              static: static,
+              static: BuiltValueNullFieldError.checkNotNull(
+                  static, 'Method', 'static'),
               name: name,
               type: type,
               modifier: modifier,
@@ -402,7 +413,17 @@ class _$Parameter extends Parameter {
       this.type,
       required this.required,
       required this.covariant})
-      : super._();
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(name, 'Parameter', 'name');
+    BuiltValueNullFieldError.checkNotNull(named, 'Parameter', 'named');
+    BuiltValueNullFieldError.checkNotNull(toThis, 'Parameter', 'toThis');
+    BuiltValueNullFieldError.checkNotNull(
+        annotations, 'Parameter', 'annotations');
+    BuiltValueNullFieldError.checkNotNull(docs, 'Parameter', 'docs');
+    BuiltValueNullFieldError.checkNotNull(types, 'Parameter', 'types');
+    BuiltValueNullFieldError.checkNotNull(required, 'Parameter', 'required');
+    BuiltValueNullFieldError.checkNotNull(covariant, 'Parameter', 'covariant');
+  }
 
   @override
   Parameter rebuild(void Function(ParameterBuilder) updates) =>
@@ -452,14 +473,14 @@ class _$Parameter extends Parameter {
   @override
   String toString() {
     return (newBuiltValueToStringHelper('Parameter')
-          ..add('defaultTo', defaultTo ?? 'null')
+          ..add('defaultTo', defaultTo)
           ..add('name', name)
           ..add('named', named)
           ..add('toThis', toThis)
           ..add('annotations', annotations)
           ..add('docs', docs)
           ..add('types', types)
-          ..add('type', type ?? 'null')
+          ..add('type', type)
           ..add('required', required)
           ..add('covariant', covariant))
         .toString();
@@ -592,27 +613,26 @@ class _$ParameterBuilder extends ParameterBuilder {
   _$ParameterBuilder() : super._();
 
   ParameterBuilder get _$this {
-    if (_$v != null) {
-      super.defaultTo = _$v!.defaultTo;
-      super.name = _$v!.name;
-      super.named = _$v!.named;
-      super.toThis = _$v!.toThis;
-      super.annotations = _$v!.annotations.toBuilder();
-      super.docs = _$v!.docs.toBuilder();
-      super.types = _$v!.types.toBuilder();
-      super.type = _$v!.type;
-      super.required = _$v!.required;
-      super.covariant = _$v!.covariant;
+    final $v = _$v;
+    if ($v != null) {
+      super.defaultTo = $v.defaultTo;
+      super.name = $v.name;
+      super.named = $v.named;
+      super.toThis = $v.toThis;
+      super.annotations = $v.annotations.toBuilder();
+      super.docs = $v.docs.toBuilder();
+      super.types = $v.types.toBuilder();
+      super.type = $v.type;
+      super.required = $v.required;
+      super.covariant = $v.covariant;
       _$v = null;
     }
     return this;
   }
 
   @override
-  void replace(Parameter? other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+  void replace(Parameter other) {
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$Parameter;
   }
 
@@ -628,15 +648,20 @@ class _$ParameterBuilder extends ParameterBuilder {
       _$result = _$v ??
           new _$Parameter._(
               defaultTo: defaultTo,
-              name: name,
-              named: named,
-              toThis: toThis,
+              name: BuiltValueNullFieldError.checkNotNull(
+                  name, 'Parameter', 'name'),
+              named: BuiltValueNullFieldError.checkNotNull(
+                  named, 'Parameter', 'named'),
+              toThis: BuiltValueNullFieldError.checkNotNull(
+                  toThis, 'Parameter', 'toThis'),
               annotations: annotations.build(),
               docs: docs.build(),
               types: types.build(),
               type: type,
-              required: required,
-              covariant: covariant);
+              required: BuiltValueNullFieldError.checkNotNull(
+                  required, 'Parameter', 'required'),
+              covariant: BuiltValueNullFieldError.checkNotNull(
+                  covariant, 'Parameter', 'covariant'));
     } catch (_) {
       late String _$failedField;
       try {

--- a/lib/src/specs/method.g.dart
+++ b/lib/src/specs/method.g.dart
@@ -18,62 +18,40 @@ class _$Method extends Method {
   @override
   final BuiltList<Parameter> requiredParameters;
   @override
-  final Code body;
+  final Code? body;
   @override
   final bool external;
   @override
-  final bool lambda;
+  final bool? lambda;
   @override
   final bool static;
   @override
-  final String name;
+  final String? name;
   @override
-  final MethodType type;
+  final MethodType? type;
   @override
-  final MethodModifier modifier;
+  final MethodModifier? modifier;
   @override
-  final Reference returns;
+  final Reference? returns;
 
-  factory _$Method([void Function(MethodBuilder) updates]) =>
+  factory _$Method([void Function(MethodBuilder)? updates]) =>
       (new MethodBuilder()..update(updates)).build() as _$Method;
 
   _$Method._(
-      {this.annotations,
-      this.docs,
-      this.types,
-      this.optionalParameters,
-      this.requiredParameters,
+      {required this.annotations,
+      required this.docs,
+      required this.types,
+      required this.optionalParameters,
+      required this.requiredParameters,
       this.body,
-      this.external,
+      required this.external,
       this.lambda,
-      this.static,
+      required this.static,
       this.name,
       this.type,
       this.modifier,
       this.returns})
-      : super._() {
-    if (annotations == null) {
-      throw new BuiltValueNullFieldError('Method', 'annotations');
-    }
-    if (docs == null) {
-      throw new BuiltValueNullFieldError('Method', 'docs');
-    }
-    if (types == null) {
-      throw new BuiltValueNullFieldError('Method', 'types');
-    }
-    if (optionalParameters == null) {
-      throw new BuiltValueNullFieldError('Method', 'optionalParameters');
-    }
-    if (requiredParameters == null) {
-      throw new BuiltValueNullFieldError('Method', 'requiredParameters');
-    }
-    if (external == null) {
-      throw new BuiltValueNullFieldError('Method', 'external');
-    }
-    if (static == null) {
-      throw new BuiltValueNullFieldError('Method', 'static');
-    }
-  }
+      : super._();
 
   @override
   Method rebuild(void Function(MethodBuilder) updates) =>
@@ -139,25 +117,25 @@ class _$Method extends Method {
           ..add('types', types)
           ..add('optionalParameters', optionalParameters)
           ..add('requiredParameters', requiredParameters)
-          ..add('body', body)
+          ..add('body', body ?? 'null')
           ..add('external', external)
-          ..add('lambda', lambda)
+          ..add('lambda', lambda ?? 'null')
           ..add('static', static)
-          ..add('name', name)
-          ..add('type', type)
-          ..add('modifier', modifier)
-          ..add('returns', returns))
+          ..add('name', name ?? 'null')
+          ..add('type', type ?? 'null')
+          ..add('modifier', modifier ?? 'null')
+          ..add('returns', returns ?? 'null'))
         .toString();
   }
 }
 
 class _$MethodBuilder extends MethodBuilder {
-  _$Method _$v;
+  _$Method? _$v;
 
   @override
   ListBuilder<Expression> get annotations {
     _$this;
-    return super.annotations ??= new ListBuilder<Expression>();
+    return super.annotations;
   }
 
   @override
@@ -169,7 +147,7 @@ class _$MethodBuilder extends MethodBuilder {
   @override
   ListBuilder<String> get docs {
     _$this;
-    return super.docs ??= new ListBuilder<String>();
+    return super.docs;
   }
 
   @override
@@ -181,7 +159,7 @@ class _$MethodBuilder extends MethodBuilder {
   @override
   ListBuilder<Reference> get types {
     _$this;
-    return super.types ??= new ListBuilder<Reference>();
+    return super.types;
   }
 
   @override
@@ -193,7 +171,7 @@ class _$MethodBuilder extends MethodBuilder {
   @override
   ListBuilder<Parameter> get optionalParameters {
     _$this;
-    return super.optionalParameters ??= new ListBuilder<Parameter>();
+    return super.optionalParameters;
   }
 
   @override
@@ -205,7 +183,7 @@ class _$MethodBuilder extends MethodBuilder {
   @override
   ListBuilder<Parameter> get requiredParameters {
     _$this;
-    return super.requiredParameters ??= new ListBuilder<Parameter>();
+    return super.requiredParameters;
   }
 
   @override
@@ -217,11 +195,11 @@ class _$MethodBuilder extends MethodBuilder {
   @override
   Code get body {
     _$this;
-    return super.body;
+    return super.body!;
   }
 
   @override
-  set body(Code body) {
+  set body(Code? body) {
     _$this;
     super.body = body;
   }
@@ -241,11 +219,11 @@ class _$MethodBuilder extends MethodBuilder {
   @override
   bool get lambda {
     _$this;
-    return super.lambda;
+    return super.lambda!;
   }
 
   @override
-  set lambda(bool lambda) {
+  set lambda(bool? lambda) {
     _$this;
     super.lambda = lambda;
   }
@@ -265,11 +243,11 @@ class _$MethodBuilder extends MethodBuilder {
   @override
   String get name {
     _$this;
-    return super.name;
+    return super.name!;
   }
 
   @override
-  set name(String name) {
+  set name(String? name) {
     _$this;
     super.name = name;
   }
@@ -277,11 +255,11 @@ class _$MethodBuilder extends MethodBuilder {
   @override
   MethodType get type {
     _$this;
-    return super.type;
+    return super.type!;
   }
 
   @override
-  set type(MethodType type) {
+  set type(MethodType? type) {
     _$this;
     super.type = type;
   }
@@ -289,11 +267,11 @@ class _$MethodBuilder extends MethodBuilder {
   @override
   MethodModifier get modifier {
     _$this;
-    return super.modifier;
+    return super.modifier!;
   }
 
   @override
-  set modifier(MethodModifier modifier) {
+  set modifier(MethodModifier? modifier) {
     _$this;
     super.modifier = modifier;
   }
@@ -301,11 +279,11 @@ class _$MethodBuilder extends MethodBuilder {
   @override
   Reference get returns {
     _$this;
-    return super.returns;
+    return super.returns!;
   }
 
   @override
-  set returns(Reference returns) {
+  set returns(Reference? returns) {
     _$this;
     super.returns = returns;
   }
@@ -314,26 +292,26 @@ class _$MethodBuilder extends MethodBuilder {
 
   MethodBuilder get _$this {
     if (_$v != null) {
-      super.annotations = _$v.annotations?.toBuilder();
-      super.docs = _$v.docs?.toBuilder();
-      super.types = _$v.types?.toBuilder();
-      super.optionalParameters = _$v.optionalParameters?.toBuilder();
-      super.requiredParameters = _$v.requiredParameters?.toBuilder();
-      super.body = _$v.body;
-      super.external = _$v.external;
-      super.lambda = _$v.lambda;
-      super.static = _$v.static;
-      super.name = _$v.name;
-      super.type = _$v.type;
-      super.modifier = _$v.modifier;
-      super.returns = _$v.returns;
+      super.annotations = _$v!.annotations.toBuilder();
+      super.docs = _$v!.docs.toBuilder();
+      super.types = _$v!.types.toBuilder();
+      super.optionalParameters = _$v!.optionalParameters.toBuilder();
+      super.requiredParameters = _$v!.requiredParameters.toBuilder();
+      super.body = _$v!.body;
+      super.external = _$v!.external;
+      super.lambda = _$v!.lambda;
+      super.static = _$v!.static;
+      super.name = _$v!.name;
+      super.type = _$v!.type;
+      super.modifier = _$v!.modifier;
+      super.returns = _$v!.returns;
       _$v = null;
     }
     return this;
   }
 
   @override
-  void replace(Method other) {
+  void replace(Method? other) {
     if (other == null) {
       throw new ArgumentError.notNull('other');
     }
@@ -341,7 +319,7 @@ class _$MethodBuilder extends MethodBuilder {
   }
 
   @override
-  void update(void Function(MethodBuilder) updates) {
+  void update(void Function(MethodBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -365,7 +343,7 @@ class _$MethodBuilder extends MethodBuilder {
               modifier: modifier,
               returns: returns);
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'annotations';
         annotations.build();
@@ -390,7 +368,7 @@ class _$MethodBuilder extends MethodBuilder {
 
 class _$Parameter extends Parameter {
   @override
-  final Code defaultTo;
+  final Code? defaultTo;
   @override
   final String name;
   @override
@@ -404,52 +382,27 @@ class _$Parameter extends Parameter {
   @override
   final BuiltList<Reference> types;
   @override
-  final Reference type;
+  final Reference? type;
   @override
   final bool required;
   @override
   final bool covariant;
 
-  factory _$Parameter([void Function(ParameterBuilder) updates]) =>
+  factory _$Parameter([void Function(ParameterBuilder)? updates]) =>
       (new ParameterBuilder()..update(updates)).build() as _$Parameter;
 
   _$Parameter._(
       {this.defaultTo,
-      this.name,
-      this.named,
-      this.toThis,
-      this.annotations,
-      this.docs,
-      this.types,
+      required this.name,
+      required this.named,
+      required this.toThis,
+      required this.annotations,
+      required this.docs,
+      required this.types,
       this.type,
-      this.required,
-      this.covariant})
-      : super._() {
-    if (name == null) {
-      throw new BuiltValueNullFieldError('Parameter', 'name');
-    }
-    if (named == null) {
-      throw new BuiltValueNullFieldError('Parameter', 'named');
-    }
-    if (toThis == null) {
-      throw new BuiltValueNullFieldError('Parameter', 'toThis');
-    }
-    if (annotations == null) {
-      throw new BuiltValueNullFieldError('Parameter', 'annotations');
-    }
-    if (docs == null) {
-      throw new BuiltValueNullFieldError('Parameter', 'docs');
-    }
-    if (types == null) {
-      throw new BuiltValueNullFieldError('Parameter', 'types');
-    }
-    if (required == null) {
-      throw new BuiltValueNullFieldError('Parameter', 'required');
-    }
-    if (covariant == null) {
-      throw new BuiltValueNullFieldError('Parameter', 'covariant');
-    }
-  }
+      required this.required,
+      required this.covariant})
+      : super._();
 
   @override
   Parameter rebuild(void Function(ParameterBuilder) updates) =>
@@ -499,14 +452,14 @@ class _$Parameter extends Parameter {
   @override
   String toString() {
     return (newBuiltValueToStringHelper('Parameter')
-          ..add('defaultTo', defaultTo)
+          ..add('defaultTo', defaultTo ?? 'null')
           ..add('name', name)
           ..add('named', named)
           ..add('toThis', toThis)
           ..add('annotations', annotations)
           ..add('docs', docs)
           ..add('types', types)
-          ..add('type', type)
+          ..add('type', type ?? 'null')
           ..add('required', required)
           ..add('covariant', covariant))
         .toString();
@@ -514,16 +467,16 @@ class _$Parameter extends Parameter {
 }
 
 class _$ParameterBuilder extends ParameterBuilder {
-  _$Parameter _$v;
+  _$Parameter? _$v;
 
   @override
-  Code get defaultTo {
+  Code? get defaultTo {
     _$this;
     return super.defaultTo;
   }
 
   @override
-  set defaultTo(Code defaultTo) {
+  set defaultTo(Code? defaultTo) {
     _$this;
     super.defaultTo = defaultTo;
   }
@@ -567,7 +520,7 @@ class _$ParameterBuilder extends ParameterBuilder {
   @override
   ListBuilder<Expression> get annotations {
     _$this;
-    return super.annotations ??= new ListBuilder<Expression>();
+    return super.annotations;
   }
 
   @override
@@ -579,7 +532,7 @@ class _$ParameterBuilder extends ParameterBuilder {
   @override
   ListBuilder<String> get docs {
     _$this;
-    return super.docs ??= new ListBuilder<String>();
+    return super.docs;
   }
 
   @override
@@ -591,7 +544,7 @@ class _$ParameterBuilder extends ParameterBuilder {
   @override
   ListBuilder<Reference> get types {
     _$this;
-    return super.types ??= new ListBuilder<Reference>();
+    return super.types;
   }
 
   @override
@@ -601,13 +554,13 @@ class _$ParameterBuilder extends ParameterBuilder {
   }
 
   @override
-  Reference get type {
+  Reference? get type {
     _$this;
     return super.type;
   }
 
   @override
-  set type(Reference type) {
+  set type(Reference? type) {
     _$this;
     super.type = type;
   }
@@ -640,23 +593,23 @@ class _$ParameterBuilder extends ParameterBuilder {
 
   ParameterBuilder get _$this {
     if (_$v != null) {
-      super.defaultTo = _$v.defaultTo;
-      super.name = _$v.name;
-      super.named = _$v.named;
-      super.toThis = _$v.toThis;
-      super.annotations = _$v.annotations?.toBuilder();
-      super.docs = _$v.docs?.toBuilder();
-      super.types = _$v.types?.toBuilder();
-      super.type = _$v.type;
-      super.required = _$v.required;
-      super.covariant = _$v.covariant;
+      super.defaultTo = _$v!.defaultTo;
+      super.name = _$v!.name;
+      super.named = _$v!.named;
+      super.toThis = _$v!.toThis;
+      super.annotations = _$v!.annotations.toBuilder();
+      super.docs = _$v!.docs.toBuilder();
+      super.types = _$v!.types.toBuilder();
+      super.type = _$v!.type;
+      super.required = _$v!.required;
+      super.covariant = _$v!.covariant;
       _$v = null;
     }
     return this;
   }
 
   @override
-  void replace(Parameter other) {
+  void replace(Parameter? other) {
     if (other == null) {
       throw new ArgumentError.notNull('other');
     }
@@ -664,7 +617,7 @@ class _$ParameterBuilder extends ParameterBuilder {
   }
 
   @override
-  void update(void Function(ParameterBuilder) updates) {
+  void update(void Function(ParameterBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -685,7 +638,7 @@ class _$ParameterBuilder extends ParameterBuilder {
               required: required,
               covariant: covariant);
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'annotations';
         annotations.build();

--- a/lib/src/specs/reference.dart
+++ b/lib/src/specs/reference.dart
@@ -14,7 +14,7 @@ import 'expression.dart';
 import 'type_reference.dart';
 
 /// Short-hand for `Reference(symbol, url)`.
-Reference refer(String symbol, [String url]) => Reference(symbol, url);
+Reference refer(String symbol, [String? url]) => Reference(symbol, url);
 
 /// A reference to [symbol], such as a class, or top-level method or field.
 ///
@@ -25,7 +25,7 @@ class Reference extends Expression implements Spec {
   /// Relative, `package:` or `dart:` URL of the library.
   ///
   /// May be omitted (`null`) in order to express "same library".
-  final String url;
+  final String? url;
 
   /// Name of the class, method, or field.
   final String symbol;
@@ -36,7 +36,7 @@ class Reference extends Expression implements Spec {
   @override
   R accept<R>(
     SpecVisitor<R> visitor, [
-    R context,
+    R? context,
   ]) =>
       visitor.visitReference(this, context);
 

--- a/lib/src/specs/type_function.dart
+++ b/lib/src/specs/type_function.dart
@@ -28,13 +28,12 @@ abstract class FunctionType extends Expression
   @override
   R accept<R>(
     SpecVisitor<R> visitor, [
-    R context,
+    R? context,
   ]) =>
       visitor.visitFunctionType(this, context);
 
   /// Return type.
-  @nullable
-  Reference get returnType;
+  Reference? get returnType;
 
   @override
   BuiltList<Reference> get types;
@@ -61,8 +60,7 @@ abstract class FunctionType extends Expression
   ///
   /// An emitter may ignore this if the output is not targeting a Dart language
   /// version that supports null safety.
-  @nullable
-  bool get isNullable;
+  bool? get isNullable;
 
   @override
   Expression newInstance(

--- a/lib/src/specs/type_function.dart
+++ b/lib/src/specs/type_function.dart
@@ -48,10 +48,11 @@ abstract class FunctionType extends Expression
   BuiltMap<String, Reference> get namedParameters;
 
   @override
-  String? get url;
+  String? get url => null;
 
   @override
-  String get symbol;
+  String get symbol => throw UnsupportedError(
+      'Getting the `symbol` of a function type is not supported');
 
   @override
   Reference get type => this;

--- a/lib/src/specs/type_function.dart
+++ b/lib/src/specs/type_function.dart
@@ -48,10 +48,10 @@ abstract class FunctionType extends Expression
   BuiltMap<String, Reference> get namedParameters;
 
   @override
-  String get url => null;
+  String? get url;
 
   @override
-  String get symbol => null;
+  String get symbol;
 
   @override
   Reference get type => this;
@@ -107,7 +107,7 @@ abstract class FunctionTypeBuilder extends Object
 
   FunctionTypeBuilder._();
 
-  Reference returnType;
+  Reference? returnType;
 
   @override
   ListBuilder<Reference> types = ListBuilder<Reference>();
@@ -119,5 +119,9 @@ abstract class FunctionTypeBuilder extends Object
   MapBuilder<String, Reference> namedParameters =
       MapBuilder<String, Reference>();
 
-  bool isNullable;
+  bool? isNullable;
+
+  String? url;
+
+  String? symbol;
 }

--- a/lib/src/specs/type_function.g.dart
+++ b/lib/src/specs/type_function.g.dart
@@ -18,8 +18,6 @@ class _$FunctionType extends FunctionType {
   @override
   final BuiltMap<String, Reference> namedParameters;
   @override
-  final String? url;
-  @override
   final bool? isNullable;
 
   factory _$FunctionType([void Function(FunctionTypeBuilder)? updates]) =>
@@ -31,7 +29,6 @@ class _$FunctionType extends FunctionType {
       required this.requiredParameters,
       required this.optionalParameters,
       required this.namedParameters,
-      this.url,
       this.isNullable})
       : super._() {
     BuiltValueNullFieldError.checkNotNull(types, 'FunctionType', 'types');
@@ -60,7 +57,6 @@ class _$FunctionType extends FunctionType {
         requiredParameters == other.requiredParameters &&
         optionalParameters == other.optionalParameters &&
         namedParameters == other.namedParameters &&
-        url == other.url &&
         isNullable == other.isNullable;
   }
 
@@ -69,12 +65,10 @@ class _$FunctionType extends FunctionType {
     return $jf($jc(
         $jc(
             $jc(
-                $jc(
-                    $jc($jc($jc(0, returnType.hashCode), types.hashCode),
-                        requiredParameters.hashCode),
-                    optionalParameters.hashCode),
-                namedParameters.hashCode),
-            url.hashCode),
+                $jc($jc($jc(0, returnType.hashCode), types.hashCode),
+                    requiredParameters.hashCode),
+                optionalParameters.hashCode),
+            namedParameters.hashCode),
         isNullable.hashCode));
   }
 
@@ -86,7 +80,6 @@ class _$FunctionType extends FunctionType {
           ..add('requiredParameters', requiredParameters)
           ..add('optionalParameters', optionalParameters)
           ..add('namedParameters', namedParameters)
-          ..add('url', url)
           ..add('isNullable', isNullable))
         .toString();
   }
@@ -156,18 +149,6 @@ class _$FunctionTypeBuilder extends FunctionTypeBuilder {
   }
 
   @override
-  String? get url {
-    _$this;
-    return super.url;
-  }
-
-  @override
-  set url(String? url) {
-    _$this;
-    super.url = url;
-  }
-
-  @override
   bool? get isNullable {
     _$this;
     return super.isNullable;
@@ -189,7 +170,6 @@ class _$FunctionTypeBuilder extends FunctionTypeBuilder {
       super.requiredParameters = $v.requiredParameters.toBuilder();
       super.optionalParameters = $v.optionalParameters.toBuilder();
       super.namedParameters = $v.namedParameters.toBuilder();
-      super.url = $v.url;
       super.isNullable = $v.isNullable;
       _$v = null;
     }
@@ -218,7 +198,6 @@ class _$FunctionTypeBuilder extends FunctionTypeBuilder {
               requiredParameters: requiredParameters.build(),
               optionalParameters: optionalParameters.build(),
               namedParameters: namedParameters.build(),
-              url: url,
               isNullable: isNullable);
     } catch (_) {
       late String _$failedField;

--- a/lib/src/specs/type_function.g.dart
+++ b/lib/src/specs/type_function.g.dart
@@ -8,7 +8,7 @@ part of 'type_function.dart';
 
 class _$FunctionType extends FunctionType {
   @override
-  final Reference returnType;
+  final Reference? returnType;
   @override
   final BuiltList<Reference> types;
   @override
@@ -18,31 +18,26 @@ class _$FunctionType extends FunctionType {
   @override
   final BuiltMap<String, Reference> namedParameters;
   @override
-  final bool isNullable;
+  final bool? isNullable;
 
-  factory _$FunctionType([void Function(FunctionTypeBuilder) updates]) =>
+  factory _$FunctionType([void Function(FunctionTypeBuilder)? updates]) =>
       (new FunctionTypeBuilder()..update(updates)).build() as _$FunctionType;
 
   _$FunctionType._(
       {this.returnType,
-      this.types,
-      this.requiredParameters,
-      this.optionalParameters,
-      this.namedParameters,
+      required this.types,
+      required this.requiredParameters,
+      required this.optionalParameters,
+      required this.namedParameters,
       this.isNullable})
       : super._() {
-    if (types == null) {
-      throw new BuiltValueNullFieldError('FunctionType', 'types');
-    }
-    if (requiredParameters == null) {
-      throw new BuiltValueNullFieldError('FunctionType', 'requiredParameters');
-    }
-    if (optionalParameters == null) {
-      throw new BuiltValueNullFieldError('FunctionType', 'optionalParameters');
-    }
-    if (namedParameters == null) {
-      throw new BuiltValueNullFieldError('FunctionType', 'namedParameters');
-    }
+    BuiltValueNullFieldError.checkNotNull(types, 'FunctionType', 'types');
+    BuiltValueNullFieldError.checkNotNull(
+        requiredParameters, 'FunctionType', 'requiredParameters');
+    BuiltValueNullFieldError.checkNotNull(
+        optionalParameters, 'FunctionType', 'optionalParameters');
+    BuiltValueNullFieldError.checkNotNull(
+        namedParameters, 'FunctionType', 'namedParameters');
   }
 
   @override
@@ -91,7 +86,7 @@ class _$FunctionType extends FunctionType {
 }
 
 class _$FunctionTypeBuilder extends FunctionTypeBuilder {
-  _$FunctionType _$v;
+  _$FunctionType? _$v;
 
   @override
   Reference get returnType {
@@ -108,7 +103,7 @@ class _$FunctionTypeBuilder extends FunctionTypeBuilder {
   @override
   ListBuilder<Reference> get types {
     _$this;
-    return super.types ??= new ListBuilder<Reference>();
+    return super.types;
   }
 
   @override
@@ -120,7 +115,7 @@ class _$FunctionTypeBuilder extends FunctionTypeBuilder {
   @override
   ListBuilder<Reference> get requiredParameters {
     _$this;
-    return super.requiredParameters ??= new ListBuilder<Reference>();
+    return super.requiredParameters;
   }
 
   @override
@@ -132,7 +127,7 @@ class _$FunctionTypeBuilder extends FunctionTypeBuilder {
   @override
   ListBuilder<Reference> get optionalParameters {
     _$this;
-    return super.optionalParameters ??= new ListBuilder<Reference>();
+    return super.optionalParameters;
   }
 
   @override
@@ -144,7 +139,7 @@ class _$FunctionTypeBuilder extends FunctionTypeBuilder {
   @override
   MapBuilder<String, Reference> get namedParameters {
     _$this;
-    return super.namedParameters ??= new MapBuilder<String, Reference>();
+    return super.namedParameters;
   }
 
   @override
@@ -168,13 +163,14 @@ class _$FunctionTypeBuilder extends FunctionTypeBuilder {
   _$FunctionTypeBuilder() : super._();
 
   FunctionTypeBuilder get _$this {
-    if (_$v != null) {
-      super.returnType = _$v.returnType;
-      super.types = _$v.types?.toBuilder();
-      super.requiredParameters = _$v.requiredParameters?.toBuilder();
-      super.optionalParameters = _$v.optionalParameters?.toBuilder();
-      super.namedParameters = _$v.namedParameters?.toBuilder();
-      super.isNullable = _$v.isNullable;
+    final $v = _$v;
+    if ($v != null) {
+      super.returnType = $v.returnType;
+      super.types = $v.types.toBuilder();
+      super.requiredParameters = $v.requiredParameters.toBuilder();
+      super.optionalParameters = $v.optionalParameters.toBuilder();
+      super.namedParameters = $v.namedParameters.toBuilder();
+      super.isNullable = $v.isNullable;
       _$v = null;
     }
     return this;
@@ -182,14 +178,12 @@ class _$FunctionTypeBuilder extends FunctionTypeBuilder {
 
   @override
   void replace(FunctionType other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FunctionType;
   }
 
   @override
-  void update(void Function(FunctionTypeBuilder) updates) {
+  void update(void Function(FunctionTypeBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -206,7 +200,7 @@ class _$FunctionTypeBuilder extends FunctionTypeBuilder {
               namedParameters: namedParameters.build(),
               isNullable: isNullable);
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'types';
         types.build();

--- a/lib/src/specs/type_function.g.dart
+++ b/lib/src/specs/type_function.g.dart
@@ -18,6 +18,10 @@ class _$FunctionType extends FunctionType {
   @override
   final BuiltMap<String, Reference> namedParameters;
   @override
+  final String? url;
+  @override
+  final String symbol;
+  @override
   final bool? isNullable;
 
   factory _$FunctionType([void Function(FunctionTypeBuilder)? updates]) =>
@@ -29,6 +33,8 @@ class _$FunctionType extends FunctionType {
       required this.requiredParameters,
       required this.optionalParameters,
       required this.namedParameters,
+      this.url,
+      required this.symbol,
       this.isNullable})
       : super._() {
     BuiltValueNullFieldError.checkNotNull(types, 'FunctionType', 'types');
@@ -38,6 +44,7 @@ class _$FunctionType extends FunctionType {
         optionalParameters, 'FunctionType', 'optionalParameters');
     BuiltValueNullFieldError.checkNotNull(
         namedParameters, 'FunctionType', 'namedParameters');
+    BuiltValueNullFieldError.checkNotNull(symbol, 'FunctionType', 'symbol');
   }
 
   @override
@@ -57,6 +64,8 @@ class _$FunctionType extends FunctionType {
         requiredParameters == other.requiredParameters &&
         optionalParameters == other.optionalParameters &&
         namedParameters == other.namedParameters &&
+        url == other.url &&
+        symbol == other.symbol &&
         isNullable == other.isNullable;
   }
 
@@ -65,10 +74,14 @@ class _$FunctionType extends FunctionType {
     return $jf($jc(
         $jc(
             $jc(
-                $jc($jc($jc(0, returnType.hashCode), types.hashCode),
-                    requiredParameters.hashCode),
-                optionalParameters.hashCode),
-            namedParameters.hashCode),
+                $jc(
+                    $jc(
+                        $jc($jc($jc(0, returnType.hashCode), types.hashCode),
+                            requiredParameters.hashCode),
+                        optionalParameters.hashCode),
+                    namedParameters.hashCode),
+                url.hashCode),
+            symbol.hashCode),
         isNullable.hashCode));
   }
 
@@ -80,6 +93,8 @@ class _$FunctionType extends FunctionType {
           ..add('requiredParameters', requiredParameters)
           ..add('optionalParameters', optionalParameters)
           ..add('namedParameters', namedParameters)
+          ..add('url', url)
+          ..add('symbol', symbol)
           ..add('isNullable', isNullable))
         .toString();
   }
@@ -89,13 +104,13 @@ class _$FunctionTypeBuilder extends FunctionTypeBuilder {
   _$FunctionType? _$v;
 
   @override
-  Reference get returnType {
+  Reference? get returnType {
     _$this;
     return super.returnType;
   }
 
   @override
-  set returnType(Reference returnType) {
+  set returnType(Reference? returnType) {
     _$this;
     super.returnType = returnType;
   }
@@ -149,13 +164,37 @@ class _$FunctionTypeBuilder extends FunctionTypeBuilder {
   }
 
   @override
-  bool get isNullable {
+  String? get url {
+    _$this;
+    return super.url;
+  }
+
+  @override
+  set url(String? url) {
+    _$this;
+    super.url = url;
+  }
+
+  @override
+  String? get symbol {
+    _$this;
+    return super.symbol;
+  }
+
+  @override
+  set symbol(String? symbol) {
+    _$this;
+    super.symbol = symbol;
+  }
+
+  @override
+  bool? get isNullable {
     _$this;
     return super.isNullable;
   }
 
   @override
-  set isNullable(bool isNullable) {
+  set isNullable(bool? isNullable) {
     _$this;
     super.isNullable = isNullable;
   }
@@ -170,6 +209,8 @@ class _$FunctionTypeBuilder extends FunctionTypeBuilder {
       super.requiredParameters = $v.requiredParameters.toBuilder();
       super.optionalParameters = $v.optionalParameters.toBuilder();
       super.namedParameters = $v.namedParameters.toBuilder();
+      super.url = $v.url;
+      super.symbol = $v.symbol;
       super.isNullable = $v.isNullable;
       _$v = null;
     }
@@ -198,6 +239,9 @@ class _$FunctionTypeBuilder extends FunctionTypeBuilder {
               requiredParameters: requiredParameters.build(),
               optionalParameters: optionalParameters.build(),
               namedParameters: namedParameters.build(),
+              url: url,
+              symbol: BuiltValueNullFieldError.checkNotNull(
+                  symbol, 'FunctionType', 'symbol'),
               isNullable: isNullable);
     } catch (_) {
       late String _$failedField;

--- a/lib/src/specs/type_function.g.dart
+++ b/lib/src/specs/type_function.g.dart
@@ -20,8 +20,6 @@ class _$FunctionType extends FunctionType {
   @override
   final String? url;
   @override
-  final String symbol;
-  @override
   final bool? isNullable;
 
   factory _$FunctionType([void Function(FunctionTypeBuilder)? updates]) =>
@@ -34,7 +32,6 @@ class _$FunctionType extends FunctionType {
       required this.optionalParameters,
       required this.namedParameters,
       this.url,
-      required this.symbol,
       this.isNullable})
       : super._() {
     BuiltValueNullFieldError.checkNotNull(types, 'FunctionType', 'types');
@@ -44,7 +41,6 @@ class _$FunctionType extends FunctionType {
         optionalParameters, 'FunctionType', 'optionalParameters');
     BuiltValueNullFieldError.checkNotNull(
         namedParameters, 'FunctionType', 'namedParameters');
-    BuiltValueNullFieldError.checkNotNull(symbol, 'FunctionType', 'symbol');
   }
 
   @override
@@ -65,7 +61,6 @@ class _$FunctionType extends FunctionType {
         optionalParameters == other.optionalParameters &&
         namedParameters == other.namedParameters &&
         url == other.url &&
-        symbol == other.symbol &&
         isNullable == other.isNullable;
   }
 
@@ -75,13 +70,11 @@ class _$FunctionType extends FunctionType {
         $jc(
             $jc(
                 $jc(
-                    $jc(
-                        $jc($jc($jc(0, returnType.hashCode), types.hashCode),
-                            requiredParameters.hashCode),
-                        optionalParameters.hashCode),
-                    namedParameters.hashCode),
-                url.hashCode),
-            symbol.hashCode),
+                    $jc($jc($jc(0, returnType.hashCode), types.hashCode),
+                        requiredParameters.hashCode),
+                    optionalParameters.hashCode),
+                namedParameters.hashCode),
+            url.hashCode),
         isNullable.hashCode));
   }
 
@@ -94,7 +87,6 @@ class _$FunctionType extends FunctionType {
           ..add('optionalParameters', optionalParameters)
           ..add('namedParameters', namedParameters)
           ..add('url', url)
-          ..add('symbol', symbol)
           ..add('isNullable', isNullable))
         .toString();
   }
@@ -176,18 +168,6 @@ class _$FunctionTypeBuilder extends FunctionTypeBuilder {
   }
 
   @override
-  String? get symbol {
-    _$this;
-    return super.symbol;
-  }
-
-  @override
-  set symbol(String? symbol) {
-    _$this;
-    super.symbol = symbol;
-  }
-
-  @override
   bool? get isNullable {
     _$this;
     return super.isNullable;
@@ -210,7 +190,6 @@ class _$FunctionTypeBuilder extends FunctionTypeBuilder {
       super.optionalParameters = $v.optionalParameters.toBuilder();
       super.namedParameters = $v.namedParameters.toBuilder();
       super.url = $v.url;
-      super.symbol = $v.symbol;
       super.isNullable = $v.isNullable;
       _$v = null;
     }
@@ -240,8 +219,6 @@ class _$FunctionTypeBuilder extends FunctionTypeBuilder {
               optionalParameters: optionalParameters.build(),
               namedParameters: namedParameters.build(),
               url: url,
-              symbol: BuiltValueNullFieldError.checkNotNull(
-                  symbol, 'FunctionType', 'symbol'),
               isNullable: isNullable);
     } catch (_) {
       late String _$failedField;

--- a/lib/src/specs/type_reference.dart
+++ b/lib/src/specs/type_reference.dart
@@ -46,7 +46,7 @@ abstract class TypeReference extends Expression
   @override
   R accept<R>(
     SpecVisitor<R> visitor, [
-    R context,
+    R? context,
   ]) =>
       visitor.visitType(this, context);
 
@@ -120,12 +120,12 @@ abstract class TypeReferenceBuilder extends Object
 
   TypeReferenceBuilder._();
 
-  String symbol;
+  String? symbol;
 
-  String url;
+  String? url;
 
   /// Optional bound generic.
-  Reference bound;
+  Reference? bound;
 
   @override
   ListBuilder<Reference> types = ListBuilder<Reference>();
@@ -134,5 +134,5 @@ abstract class TypeReferenceBuilder extends Object
   ///
   /// An emitter may ignore this if the output is not targeting a Dart language
   /// version that supports null safety.
-  bool isNullable;
+  bool? isNullable;
 }

--- a/lib/src/specs/type_reference.dart
+++ b/lib/src/specs/type_reference.dart
@@ -29,12 +29,10 @@ abstract class TypeReference extends Expression
   String get symbol;
 
   @override
-  @nullable
-  String get url;
+  String? get url;
 
   /// Optional bound generic.
-  @nullable
-  Reference get bound;
+  Reference? get bound;
 
   @override
   BuiltList<Reference> get types;
@@ -43,8 +41,7 @@ abstract class TypeReference extends Expression
   ///
   /// An emitter may ignore this if the output is not targeting a Dart language
   /// version that supports null safety.
-  @nullable
-  bool get isNullable;
+  bool? get isNullable;
 
   @override
   R accept<R>(

--- a/lib/src/specs/type_reference.g.dart
+++ b/lib/src/specs/type_reference.g.dart
@@ -10,26 +10,26 @@ class _$TypeReference extends TypeReference {
   @override
   final String symbol;
   @override
-  final String url;
+  final String? url;
   @override
-  final Reference bound;
+  final Reference? bound;
   @override
   final BuiltList<Reference> types;
   @override
-  final bool isNullable;
+  final bool? isNullable;
 
-  factory _$TypeReference([void Function(TypeReferenceBuilder) updates]) =>
+  factory _$TypeReference([void Function(TypeReferenceBuilder)? updates]) =>
       (new TypeReferenceBuilder()..update(updates)).build() as _$TypeReference;
 
   _$TypeReference._(
-      {this.symbol, this.url, this.bound, this.types, this.isNullable})
+      {required this.symbol,
+      this.url,
+      this.bound,
+      required this.types,
+      this.isNullable})
       : super._() {
-    if (symbol == null) {
-      throw new BuiltValueNullFieldError('TypeReference', 'symbol');
-    }
-    if (types == null) {
-      throw new BuiltValueNullFieldError('TypeReference', 'types');
-    }
+    BuiltValueNullFieldError.checkNotNull(symbol, 'TypeReference', 'symbol');
+    BuiltValueNullFieldError.checkNotNull(types, 'TypeReference', 'types');
   }
 
   @override
@@ -72,7 +72,7 @@ class _$TypeReference extends TypeReference {
 }
 
 class _$TypeReferenceBuilder extends TypeReferenceBuilder {
-  _$TypeReference _$v;
+  _$TypeReference? _$v;
 
   @override
   String get symbol {
@@ -113,7 +113,7 @@ class _$TypeReferenceBuilder extends TypeReferenceBuilder {
   @override
   ListBuilder<Reference> get types {
     _$this;
-    return super.types ??= new ListBuilder<Reference>();
+    return super.types;
   }
 
   @override
@@ -137,12 +137,13 @@ class _$TypeReferenceBuilder extends TypeReferenceBuilder {
   _$TypeReferenceBuilder() : super._();
 
   TypeReferenceBuilder get _$this {
-    if (_$v != null) {
-      super.symbol = _$v.symbol;
-      super.url = _$v.url;
-      super.bound = _$v.bound;
-      super.types = _$v.types?.toBuilder();
-      super.isNullable = _$v.isNullable;
+    final $v = _$v;
+    if ($v != null) {
+      super.symbol = $v.symbol;
+      super.url = $v.url;
+      super.bound = $v.bound;
+      super.types = $v.types.toBuilder();
+      super.isNullable = $v.isNullable;
       _$v = null;
     }
     return this;
@@ -150,14 +151,12 @@ class _$TypeReferenceBuilder extends TypeReferenceBuilder {
 
   @override
   void replace(TypeReference other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$TypeReference;
   }
 
   @override
-  void update(void Function(TypeReferenceBuilder) updates) {
+  void update(void Function(TypeReferenceBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -167,13 +166,14 @@ class _$TypeReferenceBuilder extends TypeReferenceBuilder {
     try {
       _$result = _$v ??
           new _$TypeReference._(
-              symbol: symbol,
+              symbol: BuiltValueNullFieldError.checkNotNull(
+                  symbol, 'TypeReference', 'symbol'),
               url: url,
               bound: bound,
               types: types.build(),
               isNullable: isNullable);
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'types';
         types.build();

--- a/lib/src/specs/type_reference.g.dart
+++ b/lib/src/specs/type_reference.g.dart
@@ -75,37 +75,37 @@ class _$TypeReferenceBuilder extends TypeReferenceBuilder {
   _$TypeReference? _$v;
 
   @override
-  String get symbol {
+  String? get symbol {
     _$this;
     return super.symbol;
   }
 
   @override
-  set symbol(String symbol) {
+  set symbol(String? symbol) {
     _$this;
     super.symbol = symbol;
   }
 
   @override
-  String get url {
+  String? get url {
     _$this;
     return super.url;
   }
 
   @override
-  set url(String url) {
+  set url(String? url) {
     _$this;
     super.url = url;
   }
 
   @override
-  Reference get bound {
+  Reference? get bound {
     _$this;
     return super.bound;
   }
 
   @override
-  set bound(Reference bound) {
+  set bound(Reference? bound) {
     _$this;
     super.bound = bound;
   }
@@ -123,13 +123,13 @@ class _$TypeReferenceBuilder extends TypeReferenceBuilder {
   }
 
   @override
-  bool get isNullable {
+  bool? get isNullable {
     _$this;
     return super.isNullable;
   }
 
   @override
-  set isNullable(bool isNullable) {
+  set isNullable(bool? isNullable) {
     _$this;
     super.isNullable = isNullable;
   }

--- a/lib/src/visitors.dart
+++ b/lib/src/visitors.dart
@@ -22,31 +22,31 @@ import 'specs/type_reference.dart';
 abstract class SpecVisitor<T> {
   const SpecVisitor._();
 
-  T visitAnnotation(Expression spec, [T context]);
+  T visitAnnotation(Expression spec, [T? context]);
 
-  T visitClass(Class spec, [T context]);
+  T visitClass(Class spec, [T? context]);
 
-  T visitExtension(Extension spec, [T context]);
+  T visitExtension(Extension spec, [T? context]);
 
-  T visitEnum(Enum spec, [T context]);
+  T visitEnum(Enum spec, [T? context]);
 
-  T visitConstructor(Constructor spec, String clazz, [T context]);
+  T visitConstructor(Constructor spec, String clazz, [T? context]);
 
-  T visitDirective(Directive spec, [T context]);
+  T visitDirective(Directive spec, [T? context]);
 
-  T visitField(Field spec, [T context]);
+  T visitField(Field spec, [T? context]);
 
-  T visitLibrary(Library spec, [T context]);
+  T visitLibrary(Library spec, [T? context]);
 
-  T visitFunctionType(FunctionType spec, [T context]);
+  T visitFunctionType(FunctionType spec, [T? context]);
 
-  T visitMethod(Method spec, [T context]);
+  T visitMethod(Method spec, [T? context]);
 
-  T visitReference(Reference spec, [T context]);
+  T visitReference(Reference spec, [T? context]);
 
-  T visitSpec(Spec spec, [T context]);
+  T visitSpec(Spec spec, [T? context]);
 
-  T visitType(TypeReference spec, [T context]);
+  T visitType(TypeReference spec, [T? context]);
 
-  T visitTypeParameters(Iterable<Reference> specs, [T context]);
+  T visitTypeParameters(Iterable<Reference> specs, [T? context]);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,25 +1,29 @@
 name: code_builder
-version: 3.7.0
+version: 4.0.0
 
 description: >-
   A fluent, builder-based library for generating valid Dart code
 homepage: https://github.com/dart-lang/code_builder
 
 environment:
-  sdk: '>=2.7.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  built_collection: '>=3.0.0 <6.0.0'
-  built_value: '>=7.0.0 <9.0.0'
-  collection: ^1.14.0
-  matcher: ^0.12.0
-  meta: ^1.0.5
+  built_collection: ^5.0.0
+  built_value: ^8.0.0
+  collection: ^1.15.0
+  matcher: ^0.12.10
+  meta: ^1.3.0
 
 dev_dependencies:
-  build: ^1.0.0
-  build_runner: ^1.1.0
-  built_value_generator: ^7.0.0
-  dart_style: ^1.0.0
-  pedantic: ^1.0.0
-  source_gen: ^0.9.0
-  test: ^1.3.0
+  build: ^2.0.0
+  build_runner: ^1.12.2
+  built_value_generator: ^8.0.0
+  dart_style: ^2.0.0
+  pedantic: ^1.10.0
+  source_gen: ^1.0.0
+  test: ^1.16.0
+
+dependency_overrides:
+  # Due to dependency cycle
+  build_runner: ^1.12.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: code_builder
-version: 4.0.0
+version: 4.0.0-dev
 
 description: >-
   A fluent, builder-based library for generating valid Dart code

--- a/test/specs/type_reference_test.dart
+++ b/test/specs/type_reference_test.dart
@@ -22,7 +22,7 @@ void main() {
   });
 
   group('in a Null Safety library', () {
-    DartEmitter emitter;
+    late DartEmitter emitter;
 
     setUp(() => emitter = DartEmitter.scoped(useNullSafetySyntax: true));
 

--- a/tool/src/builder.dart
+++ b/tool/src/builder.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+//
+// @dart=2.9
 
 import 'package:build/build.dart';
 import 'package:built_value_generator/built_value_generator.dart';


### PR DESCRIPTION
One weird thing here, the `FunctionType` class implements `Reference` which has a non-nullable `symbol` field, but it was overriding it with a getter that returns `null`. I changed that to instead throw an `UnsupportedError` which is a bit funky but makes it statically safe and does make the tests happy. Open to suggestions on that.