### PR TITLE
Null safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.8.0-nullsafety01
+
+* First null safety version. Alpha Version!!! Please report any inconsistencies that you have!
+* Add support for late and abstract fields
+* Made extension `on` clause required as Dart definition.
+
 ## 3.7.0
 
 * Add support for converting a Method to a generic closure, with
@@ -185,7 +191,7 @@ void main() {
 ```
 
 * Added inference support for `Method.lambda` and `Constructor.lambda`. If not
-  explicitly provided and the body of the function originated from an
+  explicitly provided, and the body of the function originated from an
   `Expression` then `lambda` is inferred to be true. This is not a breaking
   change yet, as it requires an explicit `null` value. In `3.0.0` this will be
   the default:
@@ -210,12 +216,12 @@ void main() {
 * Methods taking `positionalArguments` accept `Iterable<Expression>`
 * **BUG FIX**: Parameters can take a `FunctionType` as a `type`.
   `Reference.type` now returns a `Reference`. Note that this change is
-  technically breaking but should not impacts most clients.
+  technically breaking but should not impact most clients.
 
 ## 2.2.0
 
 * Imports are prefixed with `_i1` rather than `_1` which satisfies the lint
-  `lowercase_with_underscores`. While not a strictly breaking change you may
+  `lowercase_with_underscores`. While not a strictly breaking change, you may
   have to fix/regenerate golden file-like tests. We added documentation that
   the specific prefix is not considered stable.
 
@@ -245,7 +251,7 @@ void main() {
 
 * `literalList` accepts an `Iterable` argument.
 
-* Fixed an NPE when a method had a return type of a `FunctionType`:
+* Fixed an NPE when a method had a return type of `FunctionType`:
 
 ```dart
 void main() {

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,6 +1,7 @@
 include: package:pedantic/analysis_options.yaml
 
 analyzer:
+  exclude: [CHANGELOG.md]
   strong-mode:
     implicit-casts: false
     implicit-dynamic: false

--- a/lib/src/allocator.dart
+++ b/lib/src/allocator.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.12
 
 import 'specs/directive.dart';
 import 'specs/reference.dart';
@@ -51,7 +52,7 @@ class _Allocator implements Allocator {
   @override
   String allocate(Reference reference) {
     if (reference.url != null) {
-      _imports.add(reference.url);
+      _imports.add(reference.url!);
     }
     return reference.symbol;
   }
@@ -82,7 +83,7 @@ class _PrefixedAllocator implements Allocator {
     if (reference.url == null || _doNotPrefix.contains(reference.url)) {
       return symbol;
     }
-    return '_i${_imports.putIfAbsent(reference.url, _nextKey)}.$symbol';
+    return '_i${_imports.putIfAbsent(reference.url!, _nextKey)}.$symbol';
   }
 
   int _nextKey() => _keys++;

--- a/lib/src/base.dart
+++ b/lib/src/base.dart
@@ -1,11 +1,12 @@
 // Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.12
 
 import 'visitors.dart';
 
 abstract class Spec {
-  R accept<R>(SpecVisitor<R> visitor, [R context]);
+  R accept<R>(SpecVisitor<R> visitor, [R? context]);
 }
 
 /// Returns a generic [Spec] that is lazily generated when visited.
@@ -17,6 +18,6 @@ class _LazySpec implements Spec {
   const _LazySpec(this.generate);
 
   @override
-  R accept<R>(SpecVisitor<R> visitor, [R context]) =>
+  R accept<R>(SpecVisitor<R> visitor, [R? context]) =>
       generate().accept(visitor, context);
 }

--- a/lib/src/matchers.dart
+++ b/lib/src/matchers.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.12
 
 import 'package:matcher/matcher.dart';
 
@@ -18,7 +19,7 @@ String _dart(Spec spec, DartEmitter emitter) =>
 /// be overridden with [emitter].
 Matcher equalsDart(
   String source, [
-  DartEmitter emitter,
+  DartEmitter? emitter,
 ]) =>
     EqualsDart._(EqualsDart._format(source), emitter ?? DartEmitter());
 

--- a/lib/src/mixins/annotations.dart
+++ b/lib/src/mixins/annotations.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.12
 
 import 'package:built_collection/built_collection.dart';
 
@@ -15,5 +16,5 @@ abstract class HasAnnotations {
 /// Compliment to the [HasAnnotations] mixin for metadata [annotations].
 abstract class HasAnnotationsBuilder {
   /// Annotations as metadata on the node.
-  ListBuilder<Expression> annotations;
+  abstract ListBuilder<Expression> annotations;
 }

--- a/lib/src/mixins/dartdoc.dart
+++ b/lib/src/mixins/dartdoc.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.12
 
 import 'package:built_collection/built_collection.dart';
 
@@ -11,5 +12,5 @@ abstract class HasDartDocs {
 
 abstract class HasDartDocsBuilder {
   /// Dart docs.
-  ListBuilder<String> docs;
+  abstract ListBuilder<String> docs;
 }

--- a/lib/src/mixins/generics.dart
+++ b/lib/src/mixins/generics.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.12
 
 import 'package:built_collection/built_collection.dart';
 
@@ -13,5 +14,5 @@ abstract class HasGenerics {
 
 abstract class HasGenericsBuilder {
   /// Generic type parameters.
-  ListBuilder<Reference> types;
+  abstract ListBuilder<Reference> types;
 }

--- a/lib/src/specs/class.dart
+++ b/lib/src/specs/class.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.12
 
 import 'package:built_value/built_value.dart';
 import 'package:built_collection/built_collection.dart';
@@ -36,8 +37,7 @@ abstract class Class extends Object
   @override
   BuiltList<String> get docs;
 
-  @nullable
-  Reference get extend;
+  Reference? get extend;
 
   BuiltList<Reference> get implements;
 
@@ -56,7 +56,7 @@ abstract class Class extends Object
   @override
   R accept<R>(
     SpecVisitor<R> visitor, [
-    R context,
+    R? context,
   ]) =>
       visitor.visitClass(this, context);
 }
@@ -77,7 +77,7 @@ abstract class ClassBuilder extends Object
   @override
   ListBuilder<String> docs = ListBuilder<String>();
 
-  Reference extend;
+  Reference? extend;
 
   ListBuilder<Reference> implements = ListBuilder<Reference>();
   ListBuilder<Reference> mixins = ListBuilder<Reference>();
@@ -90,5 +90,5 @@ abstract class ClassBuilder extends Object
   ListBuilder<Field> fields = ListBuilder<Field>();
 
   /// Name of the class.
-  String name;
+  late String name;
 }

--- a/lib/src/specs/class.g.dart
+++ b/lib/src/specs/class.g.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// @dart=2.12
 
 part of 'class.dart';
 
@@ -14,7 +15,7 @@ class _$Class extends Class {
   @override
   final BuiltList<String> docs;
   @override
-  final Reference extend;
+  final Reference? extend;
   @override
   final BuiltList<Reference> implements;
   @override
@@ -30,52 +31,33 @@ class _$Class extends Class {
   @override
   final String name;
 
-  factory _$Class([void Function(ClassBuilder) updates]) =>
+  factory _$Class([void Function(ClassBuilder)? updates]) =>
       (new ClassBuilder()..update(updates)).build() as _$Class;
 
   _$Class._(
-      {this.abstract,
-      this.annotations,
-      this.docs,
+      {required this.abstract,
+      required this.annotations,
+      required this.docs,
       this.extend,
-      this.implements,
-      this.mixins,
-      this.types,
-      this.constructors,
-      this.methods,
-      this.fields,
-      this.name})
+      required this.implements,
+      required this.mixins,
+      required this.types,
+      required this.constructors,
+      required this.methods,
+      required this.fields,
+      required this.name})
       : super._() {
-    if (abstract == null) {
-      throw new BuiltValueNullFieldError('Class', 'abstract');
-    }
-    if (annotations == null) {
-      throw new BuiltValueNullFieldError('Class', 'annotations');
-    }
-    if (docs == null) {
-      throw new BuiltValueNullFieldError('Class', 'docs');
-    }
-    if (implements == null) {
-      throw new BuiltValueNullFieldError('Class', 'implements');
-    }
-    if (mixins == null) {
-      throw new BuiltValueNullFieldError('Class', 'mixins');
-    }
-    if (types == null) {
-      throw new BuiltValueNullFieldError('Class', 'types');
-    }
-    if (constructors == null) {
-      throw new BuiltValueNullFieldError('Class', 'constructors');
-    }
-    if (methods == null) {
-      throw new BuiltValueNullFieldError('Class', 'methods');
-    }
-    if (fields == null) {
-      throw new BuiltValueNullFieldError('Class', 'fields');
-    }
-    if (name == null) {
-      throw new BuiltValueNullFieldError('Class', 'name');
-    }
+    BuiltValueNullFieldError.checkNotNull(abstract, 'Class', 'abstract');
+    BuiltValueNullFieldError.checkNotNull(annotations, 'Class', 'annotations');
+    BuiltValueNullFieldError.checkNotNull(docs, 'Class', 'docs');
+    BuiltValueNullFieldError.checkNotNull(implements, 'Class', 'implements');
+    BuiltValueNullFieldError.checkNotNull(mixins, 'Class', 'mixins');
+    BuiltValueNullFieldError.checkNotNull(types, 'Class', 'types');
+    BuiltValueNullFieldError.checkNotNull(
+        constructors, 'Class', 'constructors');
+    BuiltValueNullFieldError.checkNotNull(methods, 'Class', 'methods');
+    BuiltValueNullFieldError.checkNotNull(fields, 'Class', 'fields');
+    BuiltValueNullFieldError.checkNotNull(name, 'Class', 'name');
   }
 
   @override
@@ -145,7 +127,7 @@ class _$Class extends Class {
 }
 
 class _$ClassBuilder extends ClassBuilder {
-  _$Class _$v;
+  _$Class? _$v;
 
   @override
   bool get abstract {
@@ -162,7 +144,7 @@ class _$ClassBuilder extends ClassBuilder {
   @override
   ListBuilder<Expression> get annotations {
     _$this;
-    return super.annotations ??= new ListBuilder<Expression>();
+    return super.annotations;
   }
 
   @override
@@ -174,7 +156,7 @@ class _$ClassBuilder extends ClassBuilder {
   @override
   ListBuilder<String> get docs {
     _$this;
-    return super.docs ??= new ListBuilder<String>();
+    return super.docs;
   }
 
   @override
@@ -184,13 +166,13 @@ class _$ClassBuilder extends ClassBuilder {
   }
 
   @override
-  Reference get extend {
+  Reference? get extend {
     _$this;
     return super.extend;
   }
 
   @override
-  set extend(Reference extend) {
+  set extend(Reference? extend) {
     _$this;
     super.extend = extend;
   }
@@ -198,7 +180,7 @@ class _$ClassBuilder extends ClassBuilder {
   @override
   ListBuilder<Reference> get implements {
     _$this;
-    return super.implements ??= new ListBuilder<Reference>();
+    return super.implements;
   }
 
   @override
@@ -210,7 +192,7 @@ class _$ClassBuilder extends ClassBuilder {
   @override
   ListBuilder<Reference> get mixins {
     _$this;
-    return super.mixins ??= new ListBuilder<Reference>();
+    return super.mixins;
   }
 
   @override
@@ -222,7 +204,7 @@ class _$ClassBuilder extends ClassBuilder {
   @override
   ListBuilder<Reference> get types {
     _$this;
-    return super.types ??= new ListBuilder<Reference>();
+    return super.types;
   }
 
   @override
@@ -234,7 +216,7 @@ class _$ClassBuilder extends ClassBuilder {
   @override
   ListBuilder<Constructor> get constructors {
     _$this;
-    return super.constructors ??= new ListBuilder<Constructor>();
+    return super.constructors;
   }
 
   @override
@@ -246,7 +228,7 @@ class _$ClassBuilder extends ClassBuilder {
   @override
   ListBuilder<Method> get methods {
     _$this;
-    return super.methods ??= new ListBuilder<Method>();
+    return super.methods;
   }
 
   @override
@@ -258,7 +240,7 @@ class _$ClassBuilder extends ClassBuilder {
   @override
   ListBuilder<Field> get fields {
     _$this;
-    return super.fields ??= new ListBuilder<Field>();
+    return super.fields;
   }
 
   @override
@@ -282,18 +264,19 @@ class _$ClassBuilder extends ClassBuilder {
   _$ClassBuilder() : super._();
 
   ClassBuilder get _$this {
-    if (_$v != null) {
-      super.abstract = _$v.abstract;
-      super.annotations = _$v.annotations?.toBuilder();
-      super.docs = _$v.docs?.toBuilder();
-      super.extend = _$v.extend;
-      super.implements = _$v.implements?.toBuilder();
-      super.mixins = _$v.mixins?.toBuilder();
-      super.types = _$v.types?.toBuilder();
-      super.constructors = _$v.constructors?.toBuilder();
-      super.methods = _$v.methods?.toBuilder();
-      super.fields = _$v.fields?.toBuilder();
-      super.name = _$v.name;
+    final $v = _$v;
+    if ($v != null) {
+      super.abstract = $v.abstract;
+      super.annotations = $v.annotations.toBuilder();
+      super.docs = $v.docs.toBuilder();
+      super.extend = $v.extend;
+      super.implements = $v.implements.toBuilder();
+      super.mixins = $v.mixins.toBuilder();
+      super.types = $v.types.toBuilder();
+      super.constructors = $v.constructors.toBuilder();
+      super.methods = $v.methods.toBuilder();
+      super.fields = $v.fields.toBuilder();
+      super.name = $v.name;
       _$v = null;
     }
     return this;
@@ -301,14 +284,12 @@ class _$ClassBuilder extends ClassBuilder {
 
   @override
   void replace(Class other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$Class;
   }
 
   @override
-  void update(void Function(ClassBuilder) updates) {
+  void update(void Function(ClassBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -318,7 +299,8 @@ class _$ClassBuilder extends ClassBuilder {
     try {
       _$result = _$v ??
           new _$Class._(
-              abstract: abstract,
+              abstract: BuiltValueNullFieldError.checkNotNull(
+                  abstract, 'Class', 'abstract'),
               annotations: annotations.build(),
               docs: docs.build(),
               extend: extend,
@@ -328,9 +310,10 @@ class _$ClassBuilder extends ClassBuilder {
               constructors: constructors.build(),
               methods: methods.build(),
               fields: fields.build(),
-              name: name);
+              name:
+                  BuiltValueNullFieldError.checkNotNull(name, 'Class', 'name'));
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'annotations';
         annotations.build();

--- a/lib/src/specs/code.dart
+++ b/lib/src/specs/code.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.12
 
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
@@ -41,7 +42,7 @@ abstract class Code implements Spec {
   ) = ScopedCode._;
 
   @override
-  R accept<R>(covariant CodeVisitor<R> visitor, [R context]);
+  R accept<R>(covariant CodeVisitor<R> visitor, [R? context]);
 }
 
 /// Represents blocks of statements of Dart code.
@@ -54,7 +55,7 @@ abstract class Block implements Built<Block, BlockBuilder>, Code, Spec {
   Block._();
 
   @override
-  R accept<R>(covariant CodeVisitor<R> visitor, [R context]) =>
+  R accept<R>(covariant CodeVisitor<R> visitor, [R? context]) =>
       visitor.visitBlock(this, context);
 
   BuiltList<Code> get statements;
@@ -79,11 +80,11 @@ abstract class BlockBuilder implements Builder<Block, BlockBuilder> {
 ///
 /// **INTERNAL ONLY**.
 abstract class CodeVisitor<T> implements SpecVisitor<T> {
-  T visitBlock(Block code, [T context]);
+  T visitBlock(Block code, [T? context]);
 
-  T visitStaticCode(StaticCode code, [T context]);
+  T visitStaticCode(StaticCode code, [T? context]);
 
-  T visitScopedCode(ScopedCode code, [T context]);
+  T visitScopedCode(ScopedCode code, [T? context]);
 }
 
 /// Knowledge of how to write valid Dart code from [CodeVisitor].
@@ -92,7 +93,7 @@ abstract class CodeEmitter implements CodeVisitor<StringSink> {
   Allocator get allocator;
 
   @override
-  StringSink visitBlock(Block block, [StringSink output]) {
+  StringSink visitBlock(Block block, [StringSink? output]) {
     output ??= StringBuffer();
     return visitAll<Code>(block.statements, output, (statement) {
       statement.accept(this, output);
@@ -100,13 +101,13 @@ abstract class CodeEmitter implements CodeVisitor<StringSink> {
   }
 
   @override
-  StringSink visitStaticCode(StaticCode code, [StringSink output]) {
+  StringSink visitStaticCode(StaticCode code, [StringSink? output]) {
     output ??= StringBuffer();
     return output..write(code.code);
   }
 
   @override
-  StringSink visitScopedCode(ScopedCode code, [StringSink output]) {
+  StringSink visitScopedCode(ScopedCode code, [StringSink? output]) {
     output ??= StringBuffer();
     return output..write(code.code(allocator.allocate));
   }
@@ -119,7 +120,7 @@ class LazyCode implements Code {
   const LazyCode._(this.generate);
 
   @override
-  R accept<R>(CodeVisitor<R> visitor, [R context]) =>
+  R accept<R>(CodeVisitor<R> visitor, [R? context]) =>
       generate(visitor).accept(visitor, context);
 }
 
@@ -132,7 +133,7 @@ class _LazyCode implements Code {
   const _LazyCode(this.generate);
 
   @override
-  R accept<R>(CodeVisitor<R> visitor, [R context]) =>
+  R accept<R>(CodeVisitor<R> visitor, [R? context]) =>
       generate().accept(visitor, context);
 }
 
@@ -143,7 +144,7 @@ class StaticCode implements Code {
   const StaticCode._(this.code);
 
   @override
-  R accept<R>(CodeVisitor<R> visitor, [R context]) =>
+  R accept<R>(CodeVisitor<R> visitor, [R? context]) =>
       visitor.visitStaticCode(this, context);
 
   @override
@@ -157,7 +158,7 @@ class ScopedCode implements Code {
   const ScopedCode._(this.code);
 
   @override
-  R accept<R>(CodeVisitor<R> visitor, [R context]) =>
+  R accept<R>(CodeVisitor<R> visitor, [R? context]) =>
       visitor.visitScopedCode(this, context);
 
   @override

--- a/lib/src/specs/code.g.dart
+++ b/lib/src/specs/code.g.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// @dart=2.12
 
 part of 'code.dart';
 
@@ -10,13 +11,11 @@ class _$Block extends Block {
   @override
   final BuiltList<Code> statements;
 
-  factory _$Block([void Function(BlockBuilder) updates]) =>
+  factory _$Block([void Function(BlockBuilder)? updates]) =>
       (new BlockBuilder()..update(updates)).build() as _$Block;
 
-  _$Block._({this.statements}) : super._() {
-    if (statements == null) {
-      throw new BuiltValueNullFieldError('Block', 'statements');
-    }
+  _$Block._({required this.statements}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(statements, 'Block', 'statements');
   }
 
   @override
@@ -45,12 +44,12 @@ class _$Block extends Block {
 }
 
 class _$BlockBuilder extends BlockBuilder {
-  _$Block _$v;
+  _$Block? _$v;
 
   @override
   ListBuilder<Code> get statements {
     _$this;
-    return super.statements ??= new ListBuilder<Code>();
+    return super.statements;
   }
 
   @override
@@ -62,8 +61,9 @@ class _$BlockBuilder extends BlockBuilder {
   _$BlockBuilder() : super._();
 
   BlockBuilder get _$this {
-    if (_$v != null) {
-      super.statements = _$v.statements?.toBuilder();
+    final $v = _$v;
+    if ($v != null) {
+      super.statements = $v.statements.toBuilder();
       _$v = null;
     }
     return this;
@@ -71,14 +71,12 @@ class _$BlockBuilder extends BlockBuilder {
 
   @override
   void replace(Block other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$Block;
   }
 
   @override
-  void update(void Function(BlockBuilder) updates) {
+  void update(void Function(BlockBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -88,7 +86,7 @@ class _$BlockBuilder extends BlockBuilder {
     try {
       _$result = _$v ?? new _$Block._(statements: statements.build());
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'statements';
         statements.build();

--- a/lib/src/specs/constructor.dart
+++ b/lib/src/specs/constructor.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.12
 
 import 'package:built_value/built_value.dart';
 import 'package:built_collection/built_collection.dart';
@@ -40,8 +41,7 @@ abstract class Constructor extends Object
   BuiltList<Code> get initializers;
 
   /// Body of the method.
-  @nullable
-  Code get body;
+  Code? get body;
 
   /// Whether the constructor should be prefixed with `external`.
   bool get external;
@@ -53,16 +53,13 @@ abstract class Constructor extends Object
   bool get factory;
 
   /// Whether this constructor is a simple lambda expression.
-  @nullable
-  bool get lambda;
+  bool? get lambda;
 
   /// Name of the constructor - optional.
-  @nullable
-  String get name;
+  String? get name;
 
   /// If non-null, redirect to this constructor.
-  @nullable
-  Reference get redirect;
+  Reference? get redirect;
 }
 
 abstract class ConstructorBuilder extends Object
@@ -88,7 +85,7 @@ abstract class ConstructorBuilder extends Object
   ListBuilder<Code> initializers = ListBuilder<Code>();
 
   /// Body of the constructor.
-  Code body;
+  Code? body;
 
   /// Whether the constructor should be prefixed with `const`.
   bool constant = false;
@@ -100,12 +97,12 @@ abstract class ConstructorBuilder extends Object
   bool factory = false;
 
   /// Whether this constructor is a simple lambda expression.
-  bool lambda;
+  bool? lambda;
 
   /// Name of the constructor - optional.
-  String name;
+  String? name;
 
   /// If non-null, redirect to this constructor.
-  @nullable
-  Reference redirect;
+
+  Reference? redirect;
 }

--- a/lib/src/specs/constructor.g.dart
+++ b/lib/src/specs/constructor.g.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// @dart=2.12
 
 part of 'constructor.dart';
 
@@ -18,7 +19,7 @@ class _$Constructor extends Constructor {
   @override
   final BuiltList<Code> initializers;
   @override
-  final Code body;
+  final Code? body;
   @override
   final bool external;
   @override
@@ -26,53 +27,41 @@ class _$Constructor extends Constructor {
   @override
   final bool factory;
   @override
-  final bool lambda;
+  final bool? lambda;
   @override
-  final String name;
+  final String? name;
   @override
-  final Reference redirect;
+  final Reference? redirect;
 
-  factory _$Constructor([void Function(ConstructorBuilder) updates]) =>
+  factory _$Constructor([void Function(ConstructorBuilder)? updates]) =>
       (new ConstructorBuilder()..update(updates)).build() as _$Constructor;
 
   _$Constructor._(
-      {this.annotations,
-      this.docs,
-      this.optionalParameters,
-      this.requiredParameters,
-      this.initializers,
+      {required this.annotations,
+      required this.docs,
+      required this.optionalParameters,
+      required this.requiredParameters,
+      required this.initializers,
       this.body,
-      this.external,
-      this.constant,
-      this.factory,
+      required this.external,
+      required this.constant,
+      required this.factory,
       this.lambda,
       this.name,
       this.redirect})
       : super._() {
-    if (annotations == null) {
-      throw new BuiltValueNullFieldError('Constructor', 'annotations');
-    }
-    if (docs == null) {
-      throw new BuiltValueNullFieldError('Constructor', 'docs');
-    }
-    if (optionalParameters == null) {
-      throw new BuiltValueNullFieldError('Constructor', 'optionalParameters');
-    }
-    if (requiredParameters == null) {
-      throw new BuiltValueNullFieldError('Constructor', 'requiredParameters');
-    }
-    if (initializers == null) {
-      throw new BuiltValueNullFieldError('Constructor', 'initializers');
-    }
-    if (external == null) {
-      throw new BuiltValueNullFieldError('Constructor', 'external');
-    }
-    if (constant == null) {
-      throw new BuiltValueNullFieldError('Constructor', 'constant');
-    }
-    if (factory == null) {
-      throw new BuiltValueNullFieldError('Constructor', 'factory');
-    }
+    BuiltValueNullFieldError.checkNotNull(
+        annotations, 'Constructor', 'annotations');
+    BuiltValueNullFieldError.checkNotNull(docs, 'Constructor', 'docs');
+    BuiltValueNullFieldError.checkNotNull(
+        optionalParameters, 'Constructor', 'optionalParameters');
+    BuiltValueNullFieldError.checkNotNull(
+        requiredParameters, 'Constructor', 'requiredParameters');
+    BuiltValueNullFieldError.checkNotNull(
+        initializers, 'Constructor', 'initializers');
+    BuiltValueNullFieldError.checkNotNull(external, 'Constructor', 'external');
+    BuiltValueNullFieldError.checkNotNull(constant, 'Constructor', 'constant');
+    BuiltValueNullFieldError.checkNotNull(factory, 'Constructor', 'factory');
   }
 
   @override
@@ -146,12 +135,12 @@ class _$Constructor extends Constructor {
 }
 
 class _$ConstructorBuilder extends ConstructorBuilder {
-  _$Constructor _$v;
+  _$Constructor? _$v;
 
   @override
   ListBuilder<Expression> get annotations {
     _$this;
-    return super.annotations ??= new ListBuilder<Expression>();
+    return super.annotations;
   }
 
   @override
@@ -163,7 +152,7 @@ class _$ConstructorBuilder extends ConstructorBuilder {
   @override
   ListBuilder<String> get docs {
     _$this;
-    return super.docs ??= new ListBuilder<String>();
+    return super.docs;
   }
 
   @override
@@ -175,7 +164,7 @@ class _$ConstructorBuilder extends ConstructorBuilder {
   @override
   ListBuilder<Parameter> get optionalParameters {
     _$this;
-    return super.optionalParameters ??= new ListBuilder<Parameter>();
+    return super.optionalParameters;
   }
 
   @override
@@ -187,7 +176,7 @@ class _$ConstructorBuilder extends ConstructorBuilder {
   @override
   ListBuilder<Parameter> get requiredParameters {
     _$this;
-    return super.requiredParameters ??= new ListBuilder<Parameter>();
+    return super.requiredParameters;
   }
 
   @override
@@ -199,7 +188,7 @@ class _$ConstructorBuilder extends ConstructorBuilder {
   @override
   ListBuilder<Code> get initializers {
     _$this;
-    return super.initializers ??= new ListBuilder<Code>();
+    return super.initializers;
   }
 
   @override
@@ -209,13 +198,13 @@ class _$ConstructorBuilder extends ConstructorBuilder {
   }
 
   @override
-  Code get body {
+  Code? get body {
     _$this;
     return super.body;
   }
 
   @override
-  set body(Code body) {
+  set body(Code? body) {
     _$this;
     super.body = body;
   }
@@ -257,37 +246,37 @@ class _$ConstructorBuilder extends ConstructorBuilder {
   }
 
   @override
-  bool get lambda {
+  bool? get lambda {
     _$this;
     return super.lambda;
   }
 
   @override
-  set lambda(bool lambda) {
+  set lambda(bool? lambda) {
     _$this;
     super.lambda = lambda;
   }
 
   @override
-  String get name {
+  String? get name {
     _$this;
     return super.name;
   }
 
   @override
-  set name(String name) {
+  set name(String? name) {
     _$this;
     super.name = name;
   }
 
   @override
-  Reference get redirect {
+  Reference? get redirect {
     _$this;
     return super.redirect;
   }
 
   @override
-  set redirect(Reference redirect) {
+  set redirect(Reference? redirect) {
     _$this;
     super.redirect = redirect;
   }
@@ -295,19 +284,20 @@ class _$ConstructorBuilder extends ConstructorBuilder {
   _$ConstructorBuilder() : super._();
 
   ConstructorBuilder get _$this {
-    if (_$v != null) {
-      super.annotations = _$v.annotations?.toBuilder();
-      super.docs = _$v.docs?.toBuilder();
-      super.optionalParameters = _$v.optionalParameters?.toBuilder();
-      super.requiredParameters = _$v.requiredParameters?.toBuilder();
-      super.initializers = _$v.initializers?.toBuilder();
-      super.body = _$v.body;
-      super.external = _$v.external;
-      super.constant = _$v.constant;
-      super.factory = _$v.factory;
-      super.lambda = _$v.lambda;
-      super.name = _$v.name;
-      super.redirect = _$v.redirect;
+    final $v = _$v;
+    if ($v != null) {
+      super.annotations = $v.annotations.toBuilder();
+      super.docs = $v.docs.toBuilder();
+      super.optionalParameters = $v.optionalParameters.toBuilder();
+      super.requiredParameters = $v.requiredParameters.toBuilder();
+      super.initializers = $v.initializers.toBuilder();
+      super.body = $v.body;
+      super.external = $v.external;
+      super.constant = $v.constant;
+      super.factory = $v.factory;
+      super.lambda = $v.lambda;
+      super.name = $v.name;
+      super.redirect = $v.redirect;
       _$v = null;
     }
     return this;
@@ -315,14 +305,12 @@ class _$ConstructorBuilder extends ConstructorBuilder {
 
   @override
   void replace(Constructor other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$Constructor;
   }
 
   @override
-  void update(void Function(ConstructorBuilder) updates) {
+  void update(void Function(ConstructorBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -338,14 +326,17 @@ class _$ConstructorBuilder extends ConstructorBuilder {
               requiredParameters: requiredParameters.build(),
               initializers: initializers.build(),
               body: body,
-              external: external,
-              constant: constant,
-              factory: factory,
+              external: BuiltValueNullFieldError.checkNotNull(
+                  external, 'Constructor', 'external'),
+              constant: BuiltValueNullFieldError.checkNotNull(
+                  constant, 'Constructor', 'constant'),
+              factory: BuiltValueNullFieldError.checkNotNull(
+                  factory, 'Constructor', 'factory'),
               lambda: lambda,
               name: name,
               redirect: redirect);
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'annotations';
         annotations.build();

--- a/lib/src/specs/directive.dart
+++ b/lib/src/specs/directive.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.12
 
 import 'package:built_value/built_value.dart';
 import 'package:collection/collection.dart';
@@ -18,7 +19,7 @@ abstract class Directive
 
   factory Directive.import(
     String url, {
-    String as,
+    String? as,
     List<String> show = const [],
     List<String> hide = const [],
   }) =>
@@ -64,8 +65,7 @@ abstract class Directive
 
   Directive._();
 
-  @nullable
-  String get as;
+  String? get as;
 
   String get url;
 
@@ -80,7 +80,7 @@ abstract class Directive
   @override
   R accept<R>(
     SpecVisitor<R> visitor, [
-    R context,
+    R? context,
   ]) =>
       visitor.visitDirective(this, context);
 
@@ -96,15 +96,15 @@ abstract class DirectiveBuilder
 
   bool deferred = false;
 
-  String as;
+  String? as;
 
-  String url;
+  late String url;
 
   List<String> show = <String>[];
 
   List<String> hide = <String>[];
 
-  DirectiveType type;
+  late DirectiveType type;
 }
 
 enum DirectiveType {

--- a/lib/src/specs/directive.g.dart
+++ b/lib/src/specs/directive.g.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// @dart=2.12
 
 part of 'directive.dart';
 
@@ -8,7 +9,7 @@ part of 'directive.dart';
 
 class _$Directive extends Directive {
   @override
-  final String as;
+  final String? as;
   @override
   final String url;
   @override
@@ -20,27 +21,22 @@ class _$Directive extends Directive {
   @override
   final bool deferred;
 
-  factory _$Directive([void Function(DirectiveBuilder) updates]) =>
+  factory _$Directive([void Function(DirectiveBuilder)? updates]) =>
       (new DirectiveBuilder()..update(updates)).build() as _$Directive;
 
   _$Directive._(
-      {this.as, this.url, this.type, this.show, this.hide, this.deferred})
+      {this.as,
+      required this.url,
+      required this.type,
+      required this.show,
+      required this.hide,
+      required this.deferred})
       : super._() {
-    if (url == null) {
-      throw new BuiltValueNullFieldError('Directive', 'url');
-    }
-    if (type == null) {
-      throw new BuiltValueNullFieldError('Directive', 'type');
-    }
-    if (show == null) {
-      throw new BuiltValueNullFieldError('Directive', 'show');
-    }
-    if (hide == null) {
-      throw new BuiltValueNullFieldError('Directive', 'hide');
-    }
-    if (deferred == null) {
-      throw new BuiltValueNullFieldError('Directive', 'deferred');
-    }
+    BuiltValueNullFieldError.checkNotNull(url, 'Directive', 'url');
+    BuiltValueNullFieldError.checkNotNull(type, 'Directive', 'type');
+    BuiltValueNullFieldError.checkNotNull(show, 'Directive', 'show');
+    BuiltValueNullFieldError.checkNotNull(hide, 'Directive', 'hide');
+    BuiltValueNullFieldError.checkNotNull(deferred, 'Directive', 'deferred');
   }
 
   @override
@@ -86,16 +82,16 @@ class _$Directive extends Directive {
 }
 
 class _$DirectiveBuilder extends DirectiveBuilder {
-  _$Directive _$v;
+  _$Directive? _$v;
 
   @override
-  String get as {
+  String? get as {
     _$this;
     return super.as;
   }
 
   @override
-  set as(String as) {
+  set as(String? as) {
     _$this;
     super.as = as;
   }
@@ -163,13 +159,14 @@ class _$DirectiveBuilder extends DirectiveBuilder {
   _$DirectiveBuilder() : super._();
 
   DirectiveBuilder get _$this {
-    if (_$v != null) {
-      super.as = _$v.as;
-      super.url = _$v.url;
-      super.type = _$v.type;
-      super.show = _$v.show;
-      super.hide = _$v.hide;
-      super.deferred = _$v.deferred;
+    final $v = _$v;
+    if ($v != null) {
+      super.as = $v.as;
+      super.url = $v.url;
+      super.type = $v.type;
+      super.show = $v.show;
+      super.hide = $v.hide;
+      super.deferred = $v.deferred;
       _$v = null;
     }
     return this;
@@ -177,14 +174,12 @@ class _$DirectiveBuilder extends DirectiveBuilder {
 
   @override
   void replace(Directive other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$Directive;
   }
 
   @override
-  void update(void Function(DirectiveBuilder) updates) {
+  void update(void Function(DirectiveBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -193,11 +188,15 @@ class _$DirectiveBuilder extends DirectiveBuilder {
     final _$result = _$v ??
         new _$Directive._(
             as: as,
-            url: url,
-            type: type,
-            show: show,
-            hide: hide,
-            deferred: deferred);
+            url: BuiltValueNullFieldError.checkNotNull(url, 'Directive', 'url'),
+            type: BuiltValueNullFieldError.checkNotNull(
+                type, 'Directive', 'type'),
+            show: BuiltValueNullFieldError.checkNotNull(
+                show, 'Directive', 'show'),
+            hide: BuiltValueNullFieldError.checkNotNull(
+                hide, 'Directive', 'hide'),
+            deferred: BuiltValueNullFieldError.checkNotNull(
+                deferred, 'Directive', 'deferred'));
     replace(_$result);
     return _$result;
   }

--- a/lib/src/specs/enum.dart
+++ b/lib/src/specs/enum.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.12
 
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
@@ -34,7 +35,7 @@ abstract class Enum extends Object
   @override
   R accept<R>(
     SpecVisitor<R> visitor, [
-    R context,
+    R? context,
   ]) =>
       visitor.visitEnum(this, context);
 }
@@ -46,7 +47,7 @@ abstract class EnumBuilder extends Object
 
   EnumBuilder._();
 
-  String name;
+  late String name;
 
   ListBuilder<EnumValue> values = ListBuilder<EnumValue>();
 
@@ -81,7 +82,7 @@ abstract class EnumValueBuilder extends Object
 
   EnumValueBuilder._();
 
-  String name;
+  late String name;
 
   @override
   ListBuilder<Expression> annotations = ListBuilder<Expression>();

--- a/lib/src/specs/enum.g.dart
+++ b/lib/src/specs/enum.g.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// @dart=2.12
 
 part of 'enum.dart';
 
@@ -16,22 +17,19 @@ class _$Enum extends Enum {
   @override
   final BuiltList<String> docs;
 
-  factory _$Enum([void Function(EnumBuilder) updates]) =>
+  factory _$Enum([void Function(EnumBuilder)? updates]) =>
       (new EnumBuilder()..update(updates)).build() as _$Enum;
 
-  _$Enum._({this.name, this.values, this.annotations, this.docs}) : super._() {
-    if (name == null) {
-      throw new BuiltValueNullFieldError('Enum', 'name');
-    }
-    if (values == null) {
-      throw new BuiltValueNullFieldError('Enum', 'values');
-    }
-    if (annotations == null) {
-      throw new BuiltValueNullFieldError('Enum', 'annotations');
-    }
-    if (docs == null) {
-      throw new BuiltValueNullFieldError('Enum', 'docs');
-    }
+  _$Enum._(
+      {required this.name,
+      required this.values,
+      required this.annotations,
+      required this.docs})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(name, 'Enum', 'name');
+    BuiltValueNullFieldError.checkNotNull(values, 'Enum', 'values');
+    BuiltValueNullFieldError.checkNotNull(annotations, 'Enum', 'annotations');
+    BuiltValueNullFieldError.checkNotNull(docs, 'Enum', 'docs');
   }
 
   @override
@@ -70,7 +68,7 @@ class _$Enum extends Enum {
 }
 
 class _$EnumBuilder extends EnumBuilder {
-  _$Enum _$v;
+  _$Enum? _$v;
 
   @override
   String get name {
@@ -87,7 +85,7 @@ class _$EnumBuilder extends EnumBuilder {
   @override
   ListBuilder<EnumValue> get values {
     _$this;
-    return super.values ??= new ListBuilder<EnumValue>();
+    return super.values;
   }
 
   @override
@@ -99,7 +97,7 @@ class _$EnumBuilder extends EnumBuilder {
   @override
   ListBuilder<Expression> get annotations {
     _$this;
-    return super.annotations ??= new ListBuilder<Expression>();
+    return super.annotations;
   }
 
   @override
@@ -111,7 +109,7 @@ class _$EnumBuilder extends EnumBuilder {
   @override
   ListBuilder<String> get docs {
     _$this;
-    return super.docs ??= new ListBuilder<String>();
+    return super.docs;
   }
 
   @override
@@ -123,11 +121,12 @@ class _$EnumBuilder extends EnumBuilder {
   _$EnumBuilder() : super._();
 
   EnumBuilder get _$this {
-    if (_$v != null) {
-      super.name = _$v.name;
-      super.values = _$v.values?.toBuilder();
-      super.annotations = _$v.annotations?.toBuilder();
-      super.docs = _$v.docs?.toBuilder();
+    final $v = _$v;
+    if ($v != null) {
+      super.name = $v.name;
+      super.values = $v.values.toBuilder();
+      super.annotations = $v.annotations.toBuilder();
+      super.docs = $v.docs.toBuilder();
       _$v = null;
     }
     return this;
@@ -135,14 +134,12 @@ class _$EnumBuilder extends EnumBuilder {
 
   @override
   void replace(Enum other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$Enum;
   }
 
   @override
-  void update(void Function(EnumBuilder) updates) {
+  void update(void Function(EnumBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -152,12 +149,12 @@ class _$EnumBuilder extends EnumBuilder {
     try {
       _$result = _$v ??
           new _$Enum._(
-              name: name,
+              name: BuiltValueNullFieldError.checkNotNull(name, 'Enum', 'name'),
               values: values.build(),
               annotations: annotations.build(),
               docs: docs.build());
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'values';
         values.build();
@@ -184,19 +181,16 @@ class _$EnumValue extends EnumValue {
   @override
   final BuiltList<String> docs;
 
-  factory _$EnumValue([void Function(EnumValueBuilder) updates]) =>
+  factory _$EnumValue([void Function(EnumValueBuilder)? updates]) =>
       (new EnumValueBuilder()..update(updates)).build() as _$EnumValue;
 
-  _$EnumValue._({this.name, this.annotations, this.docs}) : super._() {
-    if (name == null) {
-      throw new BuiltValueNullFieldError('EnumValue', 'name');
-    }
-    if (annotations == null) {
-      throw new BuiltValueNullFieldError('EnumValue', 'annotations');
-    }
-    if (docs == null) {
-      throw new BuiltValueNullFieldError('EnumValue', 'docs');
-    }
+  _$EnumValue._(
+      {required this.name, required this.annotations, required this.docs})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(name, 'EnumValue', 'name');
+    BuiltValueNullFieldError.checkNotNull(
+        annotations, 'EnumValue', 'annotations');
+    BuiltValueNullFieldError.checkNotNull(docs, 'EnumValue', 'docs');
   }
 
   @override
@@ -232,7 +226,7 @@ class _$EnumValue extends EnumValue {
 }
 
 class _$EnumValueBuilder extends EnumValueBuilder {
-  _$EnumValue _$v;
+  _$EnumValue? _$v;
 
   @override
   String get name {
@@ -249,7 +243,7 @@ class _$EnumValueBuilder extends EnumValueBuilder {
   @override
   ListBuilder<Expression> get annotations {
     _$this;
-    return super.annotations ??= new ListBuilder<Expression>();
+    return super.annotations;
   }
 
   @override
@@ -261,7 +255,7 @@ class _$EnumValueBuilder extends EnumValueBuilder {
   @override
   ListBuilder<String> get docs {
     _$this;
-    return super.docs ??= new ListBuilder<String>();
+    return super.docs;
   }
 
   @override
@@ -273,10 +267,11 @@ class _$EnumValueBuilder extends EnumValueBuilder {
   _$EnumValueBuilder() : super._();
 
   EnumValueBuilder get _$this {
-    if (_$v != null) {
-      super.name = _$v.name;
-      super.annotations = _$v.annotations?.toBuilder();
-      super.docs = _$v.docs?.toBuilder();
+    final $v = _$v;
+    if ($v != null) {
+      super.name = $v.name;
+      super.annotations = $v.annotations.toBuilder();
+      super.docs = $v.docs.toBuilder();
       _$v = null;
     }
     return this;
@@ -284,14 +279,12 @@ class _$EnumValueBuilder extends EnumValueBuilder {
 
   @override
   void replace(EnumValue other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$EnumValue;
   }
 
   @override
-  void update(void Function(EnumValueBuilder) updates) {
+  void update(void Function(EnumValueBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -301,9 +294,12 @@ class _$EnumValueBuilder extends EnumValueBuilder {
     try {
       _$result = _$v ??
           new _$EnumValue._(
-              name: name, annotations: annotations.build(), docs: docs.build());
+              name: BuiltValueNullFieldError.checkNotNull(
+                  name, 'EnumValue', 'name'),
+              annotations: annotations.build(),
+              docs: docs.build());
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'annotations';
         annotations.build();

--- a/lib/src/specs/expression/binary.dart
+++ b/lib/src/specs/expression/binary.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.12
 
 part of code_builder.src.specs.expression;
 
@@ -21,6 +22,6 @@ class BinaryExpression extends Expression {
   });
 
   @override
-  R accept<R>(ExpressionVisitor<R> visitor, [R context]) =>
+  R accept<R>(ExpressionVisitor<R> visitor, [R? context]) =>
       visitor.visitBinaryExpression(this, context);
 }

--- a/lib/src/specs/expression/closure.dart
+++ b/lib/src/specs/expression/closure.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.12
 
 part of code_builder.src.specs.expression;
 
@@ -27,6 +28,6 @@ class ClosureExpression extends Expression {
   const ClosureExpression._(this.method);
 
   @override
-  R accept<R>(ExpressionVisitor<R> visitor, [R context]) =>
+  R accept<R>(ExpressionVisitor<R> visitor, [R? context]) =>
       visitor.visitClosureExpression(this, context);
 }

--- a/lib/src/specs/expression/code.dart
+++ b/lib/src/specs/expression/code.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.12
 
 part of code_builder.src.specs.expression;
 
@@ -13,6 +14,6 @@ class CodeExpression extends Expression {
   const CodeExpression(this.code);
 
   @override
-  R accept<R>(ExpressionVisitor<R> visitor, [R context]) =>
+  R accept<R>(ExpressionVisitor<R> visitor, [R? context]) =>
       visitor.visitCodeExpression(this, context);
 }

--- a/lib/src/specs/expression/invoke.dart
+++ b/lib/src/specs/expression/invoke.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.12
 
 part of code_builder.src.specs.expression;
 
@@ -10,12 +11,14 @@ class InvokeExpression extends Expression {
   final Expression target;
 
   /// Optional; type of invocation.
-  final InvokeExpressionType type;
+  final InvokeExpressionType? type;
 
   final List<Expression> positionalArguments;
   final Map<String, Expression> namedArguments;
-  final List<Reference> typeArguments;
-  final String name;
+  // Tested for null so it must be optional
+  final List<Reference>? typeArguments; 
+  // Tested for null so it must be optional
+  final String? name;
 
   const InvokeExpression._(
     this.target,
@@ -42,7 +45,7 @@ class InvokeExpression extends Expression {
   ]) : type = InvokeExpressionType.constInstance;
 
   @override
-  R accept<R>(ExpressionVisitor<R> visitor, [R context]) =>
+  R accept<R>(ExpressionVisitor<R> visitor, [R? context]) =>
       visitor.visitInvokeExpression(this, context);
 
   @override

--- a/lib/src/specs/expression/literal.dart
+++ b/lib/src/specs/expression/literal.dart
@@ -1,13 +1,14 @@
 // Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.12
 
 part of code_builder.src.specs.expression;
 
 /// Converts a runtime Dart [literal] value into an [Expression].
 ///
 /// Unsupported inputs invoke the [onError] callback.
-Expression literal(Object literal, {Expression Function(Object) onError}) {
+Expression literal(Object? literal, {Expression Function(Object)? onError}) {
   if (literal is bool) {
     return literalBool(literal);
   }
@@ -66,34 +67,36 @@ Expression literalString(String value, {bool raw = false}) {
 }
 
 /// Creates a literal list expression from [values].
-LiteralListExpression literalList(Iterable<Object> values, [Reference type]) =>
+LiteralListExpression literalList(Iterable<Object?> values,
+        [Reference? type]) =>
     LiteralListExpression._(false, values.toList(), type);
 
 /// Creates a literal `const` list expression from [values].
-LiteralListExpression literalConstList(List<Object> values, [Reference type]) =>
+LiteralListExpression literalConstList(List<Object?> values,
+        [Reference? type]) =>
     LiteralListExpression._(true, values, type);
 
 /// Creates a literal set expression from [values].
-LiteralSetExpression literalSet(Iterable<Object> values, [Reference type]) =>
+LiteralSetExpression literalSet(Iterable<Object?> values, [Reference? type]) =>
     LiteralSetExpression._(false, values.toSet(), type);
 
 /// Creates a literal `const` set expression from [values].
-LiteralSetExpression literalConstSet(Set<Object> values, [Reference type]) =>
+LiteralSetExpression literalConstSet(Set<Object?> values, [Reference? type]) =>
     LiteralSetExpression._(true, values, type);
 
 /// Create a literal map expression from [values].
 LiteralMapExpression literalMap(
-  Map<Object, Object> values, [
-  Reference keyType,
-  Reference valueType,
+  Map<Object?, Object?> values, [
+  Reference? keyType,
+  Reference? valueType,
 ]) =>
     LiteralMapExpression._(false, values, keyType, valueType);
 
 /// Create a literal `const` map expression from [values].
 LiteralMapExpression literalConstMap(
-  Map<Object, Object> values, [
-  Reference keyType,
-  Reference valueType,
+  Map<Object?, Object?> values, [
+  Reference? keyType,
+  Reference? valueType,
 ]) =>
     LiteralMapExpression._(true, values, keyType, valueType);
 
@@ -113,7 +116,7 @@ class LiteralExpression extends Expression {
   const LiteralExpression._(this.literal);
 
   @override
-  R accept<R>(ExpressionVisitor<R> visitor, [R context]) =>
+  R accept<R>(ExpressionVisitor<R> visitor, [R? context]) =>
       visitor.visitLiteralExpression(this, context);
 
   @override
@@ -122,13 +125,13 @@ class LiteralExpression extends Expression {
 
 class LiteralListExpression extends Expression {
   final bool isConst;
-  final List<Object> values;
-  final Reference type;
+  final List<Object?> values;
+  final Reference? type;
 
   const LiteralListExpression._(this.isConst, this.values, this.type);
 
   @override
-  R accept<R>(ExpressionVisitor<R> visitor, [R context]) =>
+  R accept<R>(ExpressionVisitor<R> visitor, [R? context]) =>
       visitor.visitLiteralListExpression(this, context);
 
   @override
@@ -137,13 +140,13 @@ class LiteralListExpression extends Expression {
 
 class LiteralSetExpression extends Expression {
   final bool isConst;
-  final Set<Object> values;
-  final Reference type;
+  final Set<Object?> values;
+  final Reference? type;
 
   const LiteralSetExpression._(this.isConst, this.values, this.type);
 
   @override
-  R accept<R>(ExpressionVisitor<R> visitor, [R context]) =>
+  R accept<R>(ExpressionVisitor<R> visitor, [R? context]) =>
       visitor.visitLiteralSetExpression(this, context);
 
   @override
@@ -152,9 +155,9 @@ class LiteralSetExpression extends Expression {
 
 class LiteralMapExpression extends Expression {
   final bool isConst;
-  final Map<Object, Object> values;
-  final Reference keyType;
-  final Reference valueType;
+  final Map<Object?, Object?> values;
+  final Reference? keyType;
+  final Reference? valueType;
 
   const LiteralMapExpression._(
     this.isConst,
@@ -164,7 +167,7 @@ class LiteralMapExpression extends Expression {
   );
 
   @override
-  R accept<R>(ExpressionVisitor<R> visitor, [R context]) =>
+  R accept<R>(ExpressionVisitor<R> visitor, [R? context]) =>
       visitor.visitLiteralMapExpression(this, context);
 
   @override

--- a/lib/src/specs/extension.dart
+++ b/lib/src/specs/extension.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.12
 
 import 'package:built_value/built_value.dart';
 import 'package:built_collection/built_collection.dart';
@@ -33,7 +34,7 @@ abstract class Extension extends Object
   @override
   BuiltList<String> get docs;
 
-  @nullable
+  // On reference class of an extension is not nullable, just the name
   Reference get on;
 
   @override
@@ -43,13 +44,12 @@ abstract class Extension extends Object
   BuiltList<Field> get fields;
 
   /// Name of the extension - optional.
-  @nullable
-  String get name;
+  String? get name;
 
   @override
   R accept<R>(
     SpecVisitor<R> visitor, [
-    R context,
+    R? context,
   ]) =>
       visitor.visitExtension(this, context);
 }
@@ -67,7 +67,7 @@ abstract class ExtensionBuilder extends Object
   @override
   ListBuilder<String> docs = ListBuilder<String>();
 
-  Reference on;
+  late Reference on;
 
   @override
   ListBuilder<Reference> types = ListBuilder<Reference>();
@@ -76,5 +76,5 @@ abstract class ExtensionBuilder extends Object
   ListBuilder<Field> fields = ListBuilder<Field>();
 
   /// Name of the extension - optional.
-  String name;
+  String? name;
 }

--- a/lib/src/specs/extension.g.dart
+++ b/lib/src/specs/extension.g.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// @dart=2.12
 
 part of 'extension.dart';
 
@@ -20,35 +21,27 @@ class _$Extension extends Extension {
   @override
   final BuiltList<Field> fields;
   @override
-  final String name;
+  final String? name;
 
-  factory _$Extension([void Function(ExtensionBuilder) updates]) =>
+  factory _$Extension([void Function(ExtensionBuilder)? updates]) =>
       (new ExtensionBuilder()..update(updates)).build() as _$Extension;
 
   _$Extension._(
-      {this.annotations,
-      this.docs,
-      this.on,
-      this.types,
-      this.methods,
-      this.fields,
+      {required this.annotations,
+      required this.docs,
+      required this.on,
+      required this.types,
+      required this.methods,
+      required this.fields,
       this.name})
       : super._() {
-    if (annotations == null) {
-      throw new BuiltValueNullFieldError('Extension', 'annotations');
-    }
-    if (docs == null) {
-      throw new BuiltValueNullFieldError('Extension', 'docs');
-    }
-    if (types == null) {
-      throw new BuiltValueNullFieldError('Extension', 'types');
-    }
-    if (methods == null) {
-      throw new BuiltValueNullFieldError('Extension', 'methods');
-    }
-    if (fields == null) {
-      throw new BuiltValueNullFieldError('Extension', 'fields');
-    }
+    BuiltValueNullFieldError.checkNotNull(
+        annotations, 'Extension', 'annotations');
+    BuiltValueNullFieldError.checkNotNull(docs, 'Extension', 'docs');
+    BuiltValueNullFieldError.checkNotNull(on, 'Extension', 'on');
+    BuiltValueNullFieldError.checkNotNull(types, 'Extension', 'types');
+    BuiltValueNullFieldError.checkNotNull(methods, 'Extension', 'methods');
+    BuiltValueNullFieldError.checkNotNull(fields, 'Extension', 'fields');
   }
 
   @override
@@ -100,12 +93,12 @@ class _$Extension extends Extension {
 }
 
 class _$ExtensionBuilder extends ExtensionBuilder {
-  _$Extension _$v;
+  _$Extension? _$v;
 
   @override
   ListBuilder<Expression> get annotations {
     _$this;
-    return super.annotations ??= new ListBuilder<Expression>();
+    return super.annotations;
   }
 
   @override
@@ -117,7 +110,7 @@ class _$ExtensionBuilder extends ExtensionBuilder {
   @override
   ListBuilder<String> get docs {
     _$this;
-    return super.docs ??= new ListBuilder<String>();
+    return super.docs;
   }
 
   @override
@@ -141,7 +134,7 @@ class _$ExtensionBuilder extends ExtensionBuilder {
   @override
   ListBuilder<Reference> get types {
     _$this;
-    return super.types ??= new ListBuilder<Reference>();
+    return super.types;
   }
 
   @override
@@ -153,7 +146,7 @@ class _$ExtensionBuilder extends ExtensionBuilder {
   @override
   ListBuilder<Method> get methods {
     _$this;
-    return super.methods ??= new ListBuilder<Method>();
+    return super.methods;
   }
 
   @override
@@ -165,7 +158,7 @@ class _$ExtensionBuilder extends ExtensionBuilder {
   @override
   ListBuilder<Field> get fields {
     _$this;
-    return super.fields ??= new ListBuilder<Field>();
+    return super.fields;
   }
 
   @override
@@ -175,13 +168,13 @@ class _$ExtensionBuilder extends ExtensionBuilder {
   }
 
   @override
-  String get name {
+  String? get name {
     _$this;
     return super.name;
   }
 
   @override
-  set name(String name) {
+  set name(String? name) {
     _$this;
     super.name = name;
   }
@@ -189,14 +182,15 @@ class _$ExtensionBuilder extends ExtensionBuilder {
   _$ExtensionBuilder() : super._();
 
   ExtensionBuilder get _$this {
-    if (_$v != null) {
-      super.annotations = _$v.annotations?.toBuilder();
-      super.docs = _$v.docs?.toBuilder();
-      super.on = _$v.on;
-      super.types = _$v.types?.toBuilder();
-      super.methods = _$v.methods?.toBuilder();
-      super.fields = _$v.fields?.toBuilder();
-      super.name = _$v.name;
+    final $v = _$v;
+    if ($v != null) {
+      super.annotations = $v.annotations.toBuilder();
+      super.docs = $v.docs.toBuilder();
+      super.on = $v.on;
+      super.types = $v.types.toBuilder();
+      super.methods = $v.methods.toBuilder();
+      super.fields = $v.fields.toBuilder();
+      super.name = $v.name;
       _$v = null;
     }
     return this;
@@ -204,14 +198,12 @@ class _$ExtensionBuilder extends ExtensionBuilder {
 
   @override
   void replace(Extension other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$Extension;
   }
 
   @override
-  void update(void Function(ExtensionBuilder) updates) {
+  void update(void Function(ExtensionBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -223,13 +215,13 @@ class _$ExtensionBuilder extends ExtensionBuilder {
           new _$Extension._(
               annotations: annotations.build(),
               docs: docs.build(),
-              on: on,
+              on: BuiltValueNullFieldError.checkNotNull(on, 'Extension', 'on'),
               types: types.build(),
               methods: methods.build(),
               fields: fields.build(),
               name: name);
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'annotations';
         annotations.build();

--- a/lib/src/specs/field.dart
+++ b/lib/src/specs/field.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.12
 
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
@@ -31,26 +32,34 @@ abstract class Field extends Object
   BuiltList<String> get docs;
 
   /// Field assignment, if any.
-  @nullable
-  Code get assignment;
+  Code? get assignment;
 
   /// Whether this field should be prefixed with `static`.
   ///
   /// This is only valid within classes.
   bool get static;
 
+  /// Whether this field should be prefixed with `abstract`.
+  ///
+  /// This is only valid within abstract classes.
+  bool get abstract;
+
+  /// Whether this field should be prefixed with `late`.
+  ///
+  /// This is only valid wit classes.
+  bool get late;
+
   /// Name of the field.
   String get name;
 
-  @nullable
-  Reference get type;
+  Reference? get type;
 
   FieldModifier get modifier;
 
   @override
   R accept<R>(
     SpecVisitor<R> visitor, [
-    R context,
+    R? context,
   ]) =>
       visitor.visitField(this, context);
 }
@@ -66,7 +75,14 @@ abstract class FieldBuilder extends Object
     implements Builder<Field, FieldBuilder> {
   factory FieldBuilder() = _$FieldBuilder;
 
-  FieldBuilder._();
+  FieldBuilder._() {
+    if (abstract && late) {
+      throw StateError('Fields can be abstract or late. Not both.');
+    }
+    if (abstract && static) {
+      throw StateError('Abstract fields can not be static');
+    }
+  }
 
   @override
   ListBuilder<Expression> annotations = ListBuilder<Expression>();
@@ -75,17 +91,27 @@ abstract class FieldBuilder extends Object
   ListBuilder<String> docs = ListBuilder<String>();
 
   /// Field assignment, if any.
-  Code assignment;
+  Code? assignment;
 
   /// Whether this field should be prefixed with `static`.
   ///
   /// This is only valid within classes.
   bool static = false;
 
-  /// Name of the field.
-  String name;
+  /// Whether this field should be prefixed with `abstract`.
+  ///
+  /// This is only valid within abstract classes.
+  bool abstract = false;
 
-  Reference type;
+  /// Whether this field should be prefixed with `late`.
+  ///
+  /// This is only valid wit classes.
+  bool late = false;
+
+  /// Name of the field.
+  late String name;
+
+  Reference? type;
 
   FieldModifier modifier = FieldModifier.var$;
 }

--- a/lib/src/specs/field.g.dart
+++ b/lib/src/specs/field.g.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// @dart=2.12
 
 part of 'field.dart';
 
@@ -12,43 +13,41 @@ class _$Field extends Field {
   @override
   final BuiltList<String> docs;
   @override
-  final Code assignment;
+  final Code? assignment;
   @override
   final bool static;
   @override
+  final bool abstract;
+  @override
+  final bool late;
+  @override
   final String name;
   @override
-  final Reference type;
+  final Reference? type;
   @override
   final FieldModifier modifier;
 
-  factory _$Field([void Function(FieldBuilder) updates]) =>
+  factory _$Field([void Function(FieldBuilder)? updates]) =>
       (new FieldBuilder()..update(updates)).build() as _$Field;
 
   _$Field._(
-      {this.annotations,
-      this.docs,
+      {required this.annotations,
+      required this.docs,
       this.assignment,
-      this.static,
-      this.name,
+      required this.static,
+      required this.abstract,
+      required this.late,
+      required this.name,
       this.type,
-      this.modifier})
+      required this.modifier})
       : super._() {
-    if (annotations == null) {
-      throw new BuiltValueNullFieldError('Field', 'annotations');
-    }
-    if (docs == null) {
-      throw new BuiltValueNullFieldError('Field', 'docs');
-    }
-    if (static == null) {
-      throw new BuiltValueNullFieldError('Field', 'static');
-    }
-    if (name == null) {
-      throw new BuiltValueNullFieldError('Field', 'name');
-    }
-    if (modifier == null) {
-      throw new BuiltValueNullFieldError('Field', 'modifier');
-    }
+    BuiltValueNullFieldError.checkNotNull(annotations, 'Field', 'annotations');
+    BuiltValueNullFieldError.checkNotNull(docs, 'Field', 'docs');
+    BuiltValueNullFieldError.checkNotNull(static, 'Field', 'static');
+    BuiltValueNullFieldError.checkNotNull(abstract, 'Field', 'abstract');
+    BuiltValueNullFieldError.checkNotNull(late, 'Field', 'late');
+    BuiltValueNullFieldError.checkNotNull(name, 'Field', 'name');
+    BuiltValueNullFieldError.checkNotNull(modifier, 'Field', 'modifier');
   }
 
   @override
@@ -66,6 +65,8 @@ class _$Field extends Field {
         docs == other.docs &&
         assignment == other.assignment &&
         static == other.static &&
+        abstract == other.abstract &&
+        late == other.late &&
         name == other.name &&
         type == other.type &&
         modifier == other.modifier;
@@ -77,9 +78,15 @@ class _$Field extends Field {
         $jc(
             $jc(
                 $jc(
-                    $jc($jc($jc(0, annotations.hashCode), docs.hashCode),
-                        assignment.hashCode),
-                    static.hashCode),
+                    $jc(
+                        $jc(
+                            $jc(
+                                $jc($jc(0, annotations.hashCode),
+                                    docs.hashCode),
+                                assignment.hashCode),
+                            static.hashCode),
+                        abstract.hashCode),
+                    late.hashCode),
                 name.hashCode),
             type.hashCode),
         modifier.hashCode));
@@ -92,6 +99,8 @@ class _$Field extends Field {
           ..add('docs', docs)
           ..add('assignment', assignment)
           ..add('static', static)
+          ..add('abstract', abstract)
+          ..add('late', late)
           ..add('name', name)
           ..add('type', type)
           ..add('modifier', modifier))
@@ -100,12 +109,12 @@ class _$Field extends Field {
 }
 
 class _$FieldBuilder extends FieldBuilder {
-  _$Field _$v;
+  _$Field? _$v;
 
   @override
   ListBuilder<Expression> get annotations {
     _$this;
-    return super.annotations ??= new ListBuilder<Expression>();
+    return super.annotations;
   }
 
   @override
@@ -117,7 +126,7 @@ class _$FieldBuilder extends FieldBuilder {
   @override
   ListBuilder<String> get docs {
     _$this;
-    return super.docs ??= new ListBuilder<String>();
+    return super.docs;
   }
 
   @override
@@ -127,13 +136,13 @@ class _$FieldBuilder extends FieldBuilder {
   }
 
   @override
-  Code get assignment {
+  Code? get assignment {
     _$this;
     return super.assignment;
   }
 
   @override
-  set assignment(Code assignment) {
+  set assignment(Code? assignment) {
     _$this;
     super.assignment = assignment;
   }
@@ -151,6 +160,30 @@ class _$FieldBuilder extends FieldBuilder {
   }
 
   @override
+  bool get abstract {
+    _$this;
+    return super.abstract;
+  }
+
+  @override
+  set abstract(bool abstract) {
+    _$this;
+    super.abstract = abstract;
+  }
+
+  @override
+  bool get late {
+    _$this;
+    return super.late;
+  }
+
+  @override
+  set late(bool late) {
+    _$this;
+    super.late = late;
+  }
+
+  @override
   String get name {
     _$this;
     return super.name;
@@ -163,13 +196,13 @@ class _$FieldBuilder extends FieldBuilder {
   }
 
   @override
-  Reference get type {
+  Reference? get type {
     _$this;
     return super.type;
   }
 
   @override
-  set type(Reference type) {
+  set type(Reference? type) {
     _$this;
     super.type = type;
   }
@@ -189,14 +222,17 @@ class _$FieldBuilder extends FieldBuilder {
   _$FieldBuilder() : super._();
 
   FieldBuilder get _$this {
-    if (_$v != null) {
-      super.annotations = _$v.annotations?.toBuilder();
-      super.docs = _$v.docs?.toBuilder();
-      super.assignment = _$v.assignment;
-      super.static = _$v.static;
-      super.name = _$v.name;
-      super.type = _$v.type;
-      super.modifier = _$v.modifier;
+    final $v = _$v;
+    if ($v != null) {
+      super.annotations = $v.annotations.toBuilder();
+      super.docs = $v.docs.toBuilder();
+      super.assignment = $v.assignment;
+      super.static = $v.static;
+      super.abstract = $v.abstract;
+      super.late = $v.late;
+      super.name = $v.name;
+      super.type = $v.type;
+      super.modifier = $v.modifier;
       _$v = null;
     }
     return this;
@@ -204,14 +240,12 @@ class _$FieldBuilder extends FieldBuilder {
 
   @override
   void replace(Field other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$Field;
   }
 
   @override
-  void update(void Function(FieldBuilder) updates) {
+  void update(void Function(FieldBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -224,12 +258,19 @@ class _$FieldBuilder extends FieldBuilder {
               annotations: annotations.build(),
               docs: docs.build(),
               assignment: assignment,
-              static: static,
-              name: name,
+              static: BuiltValueNullFieldError.checkNotNull(
+                  static, 'Field', 'static'),
+              abstract: BuiltValueNullFieldError.checkNotNull(
+                  abstract, 'Field', 'abstract'),
+              late:
+                  BuiltValueNullFieldError.checkNotNull(late, 'Field', 'late'),
+              name:
+                  BuiltValueNullFieldError.checkNotNull(name, 'Field', 'name'),
               type: type,
-              modifier: modifier);
+              modifier: BuiltValueNullFieldError.checkNotNull(
+                  modifier, 'Field', 'modifier'));
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'annotations';
         annotations.build();

--- a/lib/src/specs/library.dart
+++ b/lib/src/specs/library.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.12
 
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
@@ -23,7 +24,7 @@ abstract class Library implements Built<Library, LibraryBuilder>, Spec {
   @override
   R accept<R>(
     SpecVisitor<R> visitor, [
-    R context,
+    R? context,
   ]) =>
       visitor.visitLibrary(this, context);
 }

--- a/lib/src/specs/library.g.dart
+++ b/lib/src/specs/library.g.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// @dart=2.12
 
 part of 'library.dart';
 
@@ -12,16 +13,12 @@ class _$Library extends Library {
   @override
   final BuiltList<Spec> body;
 
-  factory _$Library([void Function(LibraryBuilder) updates]) =>
+  factory _$Library([void Function(LibraryBuilder)? updates]) =>
       (new LibraryBuilder()..update(updates)).build() as _$Library;
 
-  _$Library._({this.directives, this.body}) : super._() {
-    if (directives == null) {
-      throw new BuiltValueNullFieldError('Library', 'directives');
-    }
-    if (body == null) {
-      throw new BuiltValueNullFieldError('Library', 'body');
-    }
+  _$Library._({required this.directives, required this.body}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(directives, 'Library', 'directives');
+    BuiltValueNullFieldError.checkNotNull(body, 'Library', 'body');
   }
 
   @override
@@ -54,12 +51,12 @@ class _$Library extends Library {
 }
 
 class _$LibraryBuilder extends LibraryBuilder {
-  _$Library _$v;
+  _$Library? _$v;
 
   @override
   ListBuilder<Directive> get directives {
     _$this;
-    return super.directives ??= new ListBuilder<Directive>();
+    return super.directives;
   }
 
   @override
@@ -71,7 +68,7 @@ class _$LibraryBuilder extends LibraryBuilder {
   @override
   ListBuilder<Spec> get body {
     _$this;
-    return super.body ??= new ListBuilder<Spec>();
+    return super.body;
   }
 
   @override
@@ -83,9 +80,10 @@ class _$LibraryBuilder extends LibraryBuilder {
   _$LibraryBuilder() : super._();
 
   LibraryBuilder get _$this {
-    if (_$v != null) {
-      super.directives = _$v.directives?.toBuilder();
-      super.body = _$v.body?.toBuilder();
+    final $v = _$v;
+    if ($v != null) {
+      super.directives = $v.directives.toBuilder();
+      super.body = $v.body.toBuilder();
       _$v = null;
     }
     return this;
@@ -93,14 +91,12 @@ class _$LibraryBuilder extends LibraryBuilder {
 
   @override
   void replace(Library other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$Library;
   }
 
   @override
-  void update(void Function(LibraryBuilder) updates) {
+  void update(void Function(LibraryBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -111,7 +107,7 @@ class _$LibraryBuilder extends LibraryBuilder {
       _$result = _$v ??
           new _$Library._(directives: directives.build(), body: body.build());
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'directives';
         directives.build();

--- a/lib/src/specs/method.dart
+++ b/lib/src/specs/method.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.12
 
 import 'package:built_value/built_value.dart';
 import 'package:built_collection/built_collection.dart';
@@ -25,7 +26,7 @@ abstract class Method extends Object
     implements Built<Method, MethodBuilder>, Spec {
   factory Method([void Function(MethodBuilder) updates]) = _$Method;
 
-  factory Method.returnsVoid([void Function(MethodBuilder) updates]) =>
+  factory Method.returnsVoid([void Function(MethodBuilder)? updates]) =>
       Method((b) {
         if (updates != null) {
           updates(b);
@@ -51,8 +52,7 @@ abstract class Method extends Object
   BuiltList<Parameter> get requiredParameters;
 
   /// Body of the method.
-  @nullable
-  Code get body;
+  Code? get body;
 
   /// Whether the method should be prefixed with `external`.
   bool get external;
@@ -60,8 +60,7 @@ abstract class Method extends Object
   /// Whether this method is a simple lambda expression.
   ///
   /// May be `null` to be inferred based on the value of [body].
-  @nullable
-  bool get lambda;
+  bool? get lambda;
 
   /// Whether this method should be prefixed with `static`.
   ///
@@ -71,24 +70,20 @@ abstract class Method extends Object
   /// Name of the method or function.
   ///
   /// May be `null` when being used as a [closure].
-  @nullable
-  String get name;
+  String? get name;
 
   /// Whether this is a getter or setter.
-  @nullable
-  MethodType get type;
+  MethodType? get type;
 
   /// Whether this method is `async`, `async*`, or `sync*`.
-  @nullable
-  MethodModifier get modifier;
+  MethodModifier? get modifier;
 
-  @nullable
-  Reference get returns;
+  Reference? get returns;
 
   @override
   R accept<R>(
     SpecVisitor<R> visitor, [
-    R context,
+    R? context,
   ]) =>
       visitor.visitMethod(this, context);
 
@@ -122,7 +117,7 @@ abstract class MethodBuilder extends Object
   ListBuilder<Parameter> requiredParameters = ListBuilder<Parameter>();
 
   /// Body of the method.
-  Code body;
+  Code? body;
 
   /// Whether the method should be prefixed with `external`.
   bool external = false;
@@ -130,7 +125,7 @@ abstract class MethodBuilder extends Object
   /// Whether this method is a simple lambda expression.
   ///
   /// If not specified this is inferred from the [body].
-  bool lambda;
+  bool? lambda;
 
   /// Whether this method should be prefixed with `static`.
   ///
@@ -138,15 +133,15 @@ abstract class MethodBuilder extends Object
   bool static = false;
 
   /// Name of the method or function.
-  String name;
+  String? name;
 
   /// Whether this is a getter or setter.
-  MethodType type;
+  MethodType? type;
 
   /// Whether this method is `async`, `async*`, or `sync*`.
-  MethodModifier modifier;
+  MethodModifier? modifier;
 
-  Reference returns;
+  Reference? returns;
 }
 
 enum MethodType {
@@ -168,8 +163,7 @@ abstract class Parameter extends Object
   Parameter._();
 
   /// If not `null`, a default assignment if the parameter is optional.
-  @nullable
-  Code get defaultTo;
+  Code? get defaultTo;
 
   /// Name of the parameter.
   String get name;
@@ -192,8 +186,7 @@ abstract class Parameter extends Object
   BuiltList<Reference> get types;
 
   /// Type of the parameter;
-  @nullable
-  Reference get type;
+  Reference? get type;
 
   /// Whether this parameter should be annotated with the `required` keyword.
   ///
@@ -217,10 +210,10 @@ abstract class ParameterBuilder extends Object
   ParameterBuilder._();
 
   /// If not `null`, a default assignment if the parameter is optional.
-  Code defaultTo;
+  Code? defaultTo;
 
   /// Name of the parameter.
-  String name;
+  late String name;
 
   /// Whether this parameter should be named, if optional.
   bool named = false;
@@ -240,7 +233,7 @@ abstract class ParameterBuilder extends Object
   ListBuilder<Reference> types = ListBuilder<Reference>();
 
   /// Type of the parameter;
-  Reference type;
+  Reference? type;
 
   /// Whether this parameter should be annotated with the `required` keyword.
   ///

--- a/lib/src/specs/method.g.dart
+++ b/lib/src/specs/method.g.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// @dart=2.12
 
 part of 'method.dart';
 
@@ -18,61 +19,49 @@ class _$Method extends Method {
   @override
   final BuiltList<Parameter> requiredParameters;
   @override
-  final Code body;
+  final Code? body;
   @override
   final bool external;
   @override
-  final bool lambda;
+  final bool? lambda;
   @override
   final bool static;
   @override
-  final String name;
+  final String? name;
   @override
-  final MethodType type;
+  final MethodType? type;
   @override
-  final MethodModifier modifier;
+  final MethodModifier? modifier;
   @override
-  final Reference returns;
+  final Reference? returns;
 
-  factory _$Method([void Function(MethodBuilder) updates]) =>
+  factory _$Method([void Function(MethodBuilder)? updates]) =>
       (new MethodBuilder()..update(updates)).build() as _$Method;
 
   _$Method._(
-      {this.annotations,
-      this.docs,
-      this.types,
-      this.optionalParameters,
-      this.requiredParameters,
+      {required this.annotations,
+      required this.docs,
+      required this.types,
+      required this.optionalParameters,
+      required this.requiredParameters,
       this.body,
-      this.external,
+      required this.external,
       this.lambda,
-      this.static,
+      required this.static,
       this.name,
       this.type,
       this.modifier,
       this.returns})
       : super._() {
-    if (annotations == null) {
-      throw new BuiltValueNullFieldError('Method', 'annotations');
-    }
-    if (docs == null) {
-      throw new BuiltValueNullFieldError('Method', 'docs');
-    }
-    if (types == null) {
-      throw new BuiltValueNullFieldError('Method', 'types');
-    }
-    if (optionalParameters == null) {
-      throw new BuiltValueNullFieldError('Method', 'optionalParameters');
-    }
-    if (requiredParameters == null) {
-      throw new BuiltValueNullFieldError('Method', 'requiredParameters');
-    }
-    if (external == null) {
-      throw new BuiltValueNullFieldError('Method', 'external');
-    }
-    if (static == null) {
-      throw new BuiltValueNullFieldError('Method', 'static');
-    }
+    BuiltValueNullFieldError.checkNotNull(annotations, 'Method', 'annotations');
+    BuiltValueNullFieldError.checkNotNull(docs, 'Method', 'docs');
+    BuiltValueNullFieldError.checkNotNull(types, 'Method', 'types');
+    BuiltValueNullFieldError.checkNotNull(
+        optionalParameters, 'Method', 'optionalParameters');
+    BuiltValueNullFieldError.checkNotNull(
+        requiredParameters, 'Method', 'requiredParameters');
+    BuiltValueNullFieldError.checkNotNull(external, 'Method', 'external');
+    BuiltValueNullFieldError.checkNotNull(static, 'Method', 'static');
   }
 
   @override
@@ -152,12 +141,12 @@ class _$Method extends Method {
 }
 
 class _$MethodBuilder extends MethodBuilder {
-  _$Method _$v;
+  _$Method? _$v;
 
   @override
   ListBuilder<Expression> get annotations {
     _$this;
-    return super.annotations ??= new ListBuilder<Expression>();
+    return super.annotations;
   }
 
   @override
@@ -169,7 +158,7 @@ class _$MethodBuilder extends MethodBuilder {
   @override
   ListBuilder<String> get docs {
     _$this;
-    return super.docs ??= new ListBuilder<String>();
+    return super.docs;
   }
 
   @override
@@ -181,7 +170,7 @@ class _$MethodBuilder extends MethodBuilder {
   @override
   ListBuilder<Reference> get types {
     _$this;
-    return super.types ??= new ListBuilder<Reference>();
+    return super.types;
   }
 
   @override
@@ -193,7 +182,7 @@ class _$MethodBuilder extends MethodBuilder {
   @override
   ListBuilder<Parameter> get optionalParameters {
     _$this;
-    return super.optionalParameters ??= new ListBuilder<Parameter>();
+    return super.optionalParameters;
   }
 
   @override
@@ -205,7 +194,7 @@ class _$MethodBuilder extends MethodBuilder {
   @override
   ListBuilder<Parameter> get requiredParameters {
     _$this;
-    return super.requiredParameters ??= new ListBuilder<Parameter>();
+    return super.requiredParameters;
   }
 
   @override
@@ -215,13 +204,13 @@ class _$MethodBuilder extends MethodBuilder {
   }
 
   @override
-  Code get body {
+  Code? get body {
     _$this;
     return super.body;
   }
 
   @override
-  set body(Code body) {
+  set body(Code? body) {
     _$this;
     super.body = body;
   }
@@ -239,13 +228,13 @@ class _$MethodBuilder extends MethodBuilder {
   }
 
   @override
-  bool get lambda {
+  bool? get lambda {
     _$this;
     return super.lambda;
   }
 
   @override
-  set lambda(bool lambda) {
+  set lambda(bool? lambda) {
     _$this;
     super.lambda = lambda;
   }
@@ -263,49 +252,49 @@ class _$MethodBuilder extends MethodBuilder {
   }
 
   @override
-  String get name {
+  String? get name {
     _$this;
     return super.name;
   }
 
   @override
-  set name(String name) {
+  set name(String? name) {
     _$this;
     super.name = name;
   }
 
   @override
-  MethodType get type {
+  MethodType? get type {
     _$this;
     return super.type;
   }
 
   @override
-  set type(MethodType type) {
+  set type(MethodType? type) {
     _$this;
     super.type = type;
   }
 
   @override
-  MethodModifier get modifier {
+  MethodModifier? get modifier {
     _$this;
     return super.modifier;
   }
 
   @override
-  set modifier(MethodModifier modifier) {
+  set modifier(MethodModifier? modifier) {
     _$this;
     super.modifier = modifier;
   }
 
   @override
-  Reference get returns {
+  Reference? get returns {
     _$this;
     return super.returns;
   }
 
   @override
-  set returns(Reference returns) {
+  set returns(Reference? returns) {
     _$this;
     super.returns = returns;
   }
@@ -313,20 +302,21 @@ class _$MethodBuilder extends MethodBuilder {
   _$MethodBuilder() : super._();
 
   MethodBuilder get _$this {
-    if (_$v != null) {
-      super.annotations = _$v.annotations?.toBuilder();
-      super.docs = _$v.docs?.toBuilder();
-      super.types = _$v.types?.toBuilder();
-      super.optionalParameters = _$v.optionalParameters?.toBuilder();
-      super.requiredParameters = _$v.requiredParameters?.toBuilder();
-      super.body = _$v.body;
-      super.external = _$v.external;
-      super.lambda = _$v.lambda;
-      super.static = _$v.static;
-      super.name = _$v.name;
-      super.type = _$v.type;
-      super.modifier = _$v.modifier;
-      super.returns = _$v.returns;
+    final $v = _$v;
+    if ($v != null) {
+      super.annotations = $v.annotations.toBuilder();
+      super.docs = $v.docs.toBuilder();
+      super.types = $v.types.toBuilder();
+      super.optionalParameters = $v.optionalParameters.toBuilder();
+      super.requiredParameters = $v.requiredParameters.toBuilder();
+      super.body = $v.body;
+      super.external = $v.external;
+      super.lambda = $v.lambda;
+      super.static = $v.static;
+      super.name = $v.name;
+      super.type = $v.type;
+      super.modifier = $v.modifier;
+      super.returns = $v.returns;
       _$v = null;
     }
     return this;
@@ -334,14 +324,12 @@ class _$MethodBuilder extends MethodBuilder {
 
   @override
   void replace(Method other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$Method;
   }
 
   @override
-  void update(void Function(MethodBuilder) updates) {
+  void update(void Function(MethodBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -357,15 +345,17 @@ class _$MethodBuilder extends MethodBuilder {
               optionalParameters: optionalParameters.build(),
               requiredParameters: requiredParameters.build(),
               body: body,
-              external: external,
+              external: BuiltValueNullFieldError.checkNotNull(
+                  external, 'Method', 'external'),
               lambda: lambda,
-              static: static,
+              static: BuiltValueNullFieldError.checkNotNull(
+                  static, 'Method', 'static'),
               name: name,
               type: type,
               modifier: modifier,
               returns: returns);
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'annotations';
         annotations.build();
@@ -390,7 +380,7 @@ class _$MethodBuilder extends MethodBuilder {
 
 class _$Parameter extends Parameter {
   @override
-  final Code defaultTo;
+  final Code? defaultTo;
   @override
   final String name;
   @override
@@ -404,51 +394,36 @@ class _$Parameter extends Parameter {
   @override
   final BuiltList<Reference> types;
   @override
-  final Reference type;
+  final Reference? type;
   @override
   final bool required;
   @override
   final bool covariant;
 
-  factory _$Parameter([void Function(ParameterBuilder) updates]) =>
+  factory _$Parameter([void Function(ParameterBuilder)? updates]) =>
       (new ParameterBuilder()..update(updates)).build() as _$Parameter;
 
   _$Parameter._(
       {this.defaultTo,
-      this.name,
-      this.named,
-      this.toThis,
-      this.annotations,
-      this.docs,
-      this.types,
+      required this.name,
+      required this.named,
+      required this.toThis,
+      required this.annotations,
+      required this.docs,
+      required this.types,
       this.type,
-      this.required,
-      this.covariant})
+      required this.required,
+      required this.covariant})
       : super._() {
-    if (name == null) {
-      throw new BuiltValueNullFieldError('Parameter', 'name');
-    }
-    if (named == null) {
-      throw new BuiltValueNullFieldError('Parameter', 'named');
-    }
-    if (toThis == null) {
-      throw new BuiltValueNullFieldError('Parameter', 'toThis');
-    }
-    if (annotations == null) {
-      throw new BuiltValueNullFieldError('Parameter', 'annotations');
-    }
-    if (docs == null) {
-      throw new BuiltValueNullFieldError('Parameter', 'docs');
-    }
-    if (types == null) {
-      throw new BuiltValueNullFieldError('Parameter', 'types');
-    }
-    if (required == null) {
-      throw new BuiltValueNullFieldError('Parameter', 'required');
-    }
-    if (covariant == null) {
-      throw new BuiltValueNullFieldError('Parameter', 'covariant');
-    }
+    BuiltValueNullFieldError.checkNotNull(name, 'Parameter', 'name');
+    BuiltValueNullFieldError.checkNotNull(named, 'Parameter', 'named');
+    BuiltValueNullFieldError.checkNotNull(toThis, 'Parameter', 'toThis');
+    BuiltValueNullFieldError.checkNotNull(
+        annotations, 'Parameter', 'annotations');
+    BuiltValueNullFieldError.checkNotNull(docs, 'Parameter', 'docs');
+    BuiltValueNullFieldError.checkNotNull(types, 'Parameter', 'types');
+    BuiltValueNullFieldError.checkNotNull(required, 'Parameter', 'required');
+    BuiltValueNullFieldError.checkNotNull(covariant, 'Parameter', 'covariant');
   }
 
   @override
@@ -514,16 +489,16 @@ class _$Parameter extends Parameter {
 }
 
 class _$ParameterBuilder extends ParameterBuilder {
-  _$Parameter _$v;
+  _$Parameter? _$v;
 
   @override
-  Code get defaultTo {
+  Code? get defaultTo {
     _$this;
     return super.defaultTo;
   }
 
   @override
-  set defaultTo(Code defaultTo) {
+  set defaultTo(Code? defaultTo) {
     _$this;
     super.defaultTo = defaultTo;
   }
@@ -567,7 +542,7 @@ class _$ParameterBuilder extends ParameterBuilder {
   @override
   ListBuilder<Expression> get annotations {
     _$this;
-    return super.annotations ??= new ListBuilder<Expression>();
+    return super.annotations;
   }
 
   @override
@@ -579,7 +554,7 @@ class _$ParameterBuilder extends ParameterBuilder {
   @override
   ListBuilder<String> get docs {
     _$this;
-    return super.docs ??= new ListBuilder<String>();
+    return super.docs;
   }
 
   @override
@@ -591,7 +566,7 @@ class _$ParameterBuilder extends ParameterBuilder {
   @override
   ListBuilder<Reference> get types {
     _$this;
-    return super.types ??= new ListBuilder<Reference>();
+    return super.types;
   }
 
   @override
@@ -601,13 +576,13 @@ class _$ParameterBuilder extends ParameterBuilder {
   }
 
   @override
-  Reference get type {
+  Reference? get type {
     _$this;
     return super.type;
   }
 
   @override
-  set type(Reference type) {
+  set type(Reference? type) {
     _$this;
     super.type = type;
   }
@@ -639,17 +614,18 @@ class _$ParameterBuilder extends ParameterBuilder {
   _$ParameterBuilder() : super._();
 
   ParameterBuilder get _$this {
-    if (_$v != null) {
-      super.defaultTo = _$v.defaultTo;
-      super.name = _$v.name;
-      super.named = _$v.named;
-      super.toThis = _$v.toThis;
-      super.annotations = _$v.annotations?.toBuilder();
-      super.docs = _$v.docs?.toBuilder();
-      super.types = _$v.types?.toBuilder();
-      super.type = _$v.type;
-      super.required = _$v.required;
-      super.covariant = _$v.covariant;
+    final $v = _$v;
+    if ($v != null) {
+      super.defaultTo = $v.defaultTo;
+      super.name = $v.name;
+      super.named = $v.named;
+      super.toThis = $v.toThis;
+      super.annotations = $v.annotations.toBuilder();
+      super.docs = $v.docs.toBuilder();
+      super.types = $v.types.toBuilder();
+      super.type = $v.type;
+      super.required = $v.required;
+      super.covariant = $v.covariant;
       _$v = null;
     }
     return this;
@@ -657,14 +633,12 @@ class _$ParameterBuilder extends ParameterBuilder {
 
   @override
   void replace(Parameter other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$Parameter;
   }
 
   @override
-  void update(void Function(ParameterBuilder) updates) {
+  void update(void Function(ParameterBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -675,17 +649,22 @@ class _$ParameterBuilder extends ParameterBuilder {
       _$result = _$v ??
           new _$Parameter._(
               defaultTo: defaultTo,
-              name: name,
-              named: named,
-              toThis: toThis,
+              name: BuiltValueNullFieldError.checkNotNull(
+                  name, 'Parameter', 'name'),
+              named: BuiltValueNullFieldError.checkNotNull(
+                  named, 'Parameter', 'named'),
+              toThis: BuiltValueNullFieldError.checkNotNull(
+                  toThis, 'Parameter', 'toThis'),
               annotations: annotations.build(),
               docs: docs.build(),
               types: types.build(),
               type: type,
-              required: required,
-              covariant: covariant);
+              required: BuiltValueNullFieldError.checkNotNull(
+                  required, 'Parameter', 'required'),
+              covariant: BuiltValueNullFieldError.checkNotNull(
+                  covariant, 'Parameter', 'covariant'));
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'annotations';
         annotations.build();

--- a/lib/src/specs/reference.dart
+++ b/lib/src/specs/reference.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.12
 
 library code_builder.src.specs.reference;
 
@@ -14,7 +15,7 @@ import 'expression.dart';
 import 'type_reference.dart';
 
 /// Short-hand for `Reference(symbol, url)`.
-Reference refer(String symbol, [String url]) => Reference(symbol, url);
+Reference refer(String symbol, [String? url]) => Reference(symbol, url);
 
 /// A reference to [symbol], such as a class, or top-level method or field.
 ///
@@ -25,7 +26,7 @@ class Reference extends Expression implements Spec {
   /// Relative, `package:` or `dart:` URL of the library.
   ///
   /// May be omitted (`null`) in order to express "same library".
-  final String url;
+  final String? url;
 
   /// Name of the class, method, or field.
   final String symbol;
@@ -36,7 +37,7 @@ class Reference extends Expression implements Spec {
   @override
   R accept<R>(
     SpecVisitor<R> visitor, [
-    R context,
+    R? context,
   ]) =>
       visitor.visitReference(this, context);
 

--- a/lib/src/specs/type_function.dart
+++ b/lib/src/specs/type_function.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.12
 
 import 'package:built_value/built_value.dart';
 import 'package:built_collection/built_collection.dart';
@@ -28,13 +29,12 @@ abstract class FunctionType extends Expression
   @override
   R accept<R>(
     SpecVisitor<R> visitor, [
-    R context,
+    R? context,
   ]) =>
       visitor.visitFunctionType(this, context);
 
   /// Return type.
-  @nullable
-  Reference get returnType;
+  Reference? get returnType;
 
   @override
   BuiltList<Reference> get types;
@@ -49,10 +49,10 @@ abstract class FunctionType extends Expression
   BuiltMap<String, Reference> get namedParameters;
 
   @override
-  String get url => null;
+  String? get url => null;
 
   @override
-  String get symbol => null;
+  String get symbol => '';
 
   @override
   Reference get type => this;
@@ -61,8 +61,7 @@ abstract class FunctionType extends Expression
   ///
   /// An emitter may ignore this if the output is not targeting a Dart language
   /// version that supports null safety.
-  @nullable
-  bool get isNullable;
+  bool? get isNullable;
 
   @override
   Expression newInstance(
@@ -109,7 +108,7 @@ abstract class FunctionTypeBuilder extends Object
 
   FunctionTypeBuilder._();
 
-  Reference returnType;
+  Reference? returnType;
 
   @override
   ListBuilder<Reference> types = ListBuilder<Reference>();
@@ -121,5 +120,5 @@ abstract class FunctionTypeBuilder extends Object
   MapBuilder<String, Reference> namedParameters =
       MapBuilder<String, Reference>();
 
-  bool isNullable;
+  bool? isNullable;
 }

--- a/lib/src/specs/type_function.g.dart
+++ b/lib/src/specs/type_function.g.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// @dart=2.12
 
 part of 'type_function.dart';
 
@@ -8,7 +9,7 @@ part of 'type_function.dart';
 
 class _$FunctionType extends FunctionType {
   @override
-  final Reference returnType;
+  final Reference? returnType;
   @override
   final BuiltList<Reference> types;
   @override
@@ -18,31 +19,26 @@ class _$FunctionType extends FunctionType {
   @override
   final BuiltMap<String, Reference> namedParameters;
   @override
-  final bool isNullable;
+  final bool? isNullable;
 
-  factory _$FunctionType([void Function(FunctionTypeBuilder) updates]) =>
+  factory _$FunctionType([void Function(FunctionTypeBuilder)? updates]) =>
       (new FunctionTypeBuilder()..update(updates)).build() as _$FunctionType;
 
   _$FunctionType._(
       {this.returnType,
-      this.types,
-      this.requiredParameters,
-      this.optionalParameters,
-      this.namedParameters,
+      required this.types,
+      required this.requiredParameters,
+      required this.optionalParameters,
+      required this.namedParameters,
       this.isNullable})
       : super._() {
-    if (types == null) {
-      throw new BuiltValueNullFieldError('FunctionType', 'types');
-    }
-    if (requiredParameters == null) {
-      throw new BuiltValueNullFieldError('FunctionType', 'requiredParameters');
-    }
-    if (optionalParameters == null) {
-      throw new BuiltValueNullFieldError('FunctionType', 'optionalParameters');
-    }
-    if (namedParameters == null) {
-      throw new BuiltValueNullFieldError('FunctionType', 'namedParameters');
-    }
+    BuiltValueNullFieldError.checkNotNull(types, 'FunctionType', 'types');
+    BuiltValueNullFieldError.checkNotNull(
+        requiredParameters, 'FunctionType', 'requiredParameters');
+    BuiltValueNullFieldError.checkNotNull(
+        optionalParameters, 'FunctionType', 'optionalParameters');
+    BuiltValueNullFieldError.checkNotNull(
+        namedParameters, 'FunctionType', 'namedParameters');
   }
 
   @override
@@ -91,16 +87,16 @@ class _$FunctionType extends FunctionType {
 }
 
 class _$FunctionTypeBuilder extends FunctionTypeBuilder {
-  _$FunctionType _$v;
+  _$FunctionType? _$v;
 
   @override
-  Reference get returnType {
+  Reference? get returnType {
     _$this;
     return super.returnType;
   }
 
   @override
-  set returnType(Reference returnType) {
+  set returnType(Reference? returnType) {
     _$this;
     super.returnType = returnType;
   }
@@ -108,7 +104,7 @@ class _$FunctionTypeBuilder extends FunctionTypeBuilder {
   @override
   ListBuilder<Reference> get types {
     _$this;
-    return super.types ??= new ListBuilder<Reference>();
+    return super.types;
   }
 
   @override
@@ -120,7 +116,7 @@ class _$FunctionTypeBuilder extends FunctionTypeBuilder {
   @override
   ListBuilder<Reference> get requiredParameters {
     _$this;
-    return super.requiredParameters ??= new ListBuilder<Reference>();
+    return super.requiredParameters;
   }
 
   @override
@@ -132,7 +128,7 @@ class _$FunctionTypeBuilder extends FunctionTypeBuilder {
   @override
   ListBuilder<Reference> get optionalParameters {
     _$this;
-    return super.optionalParameters ??= new ListBuilder<Reference>();
+    return super.optionalParameters;
   }
 
   @override
@@ -144,7 +140,7 @@ class _$FunctionTypeBuilder extends FunctionTypeBuilder {
   @override
   MapBuilder<String, Reference> get namedParameters {
     _$this;
-    return super.namedParameters ??= new MapBuilder<String, Reference>();
+    return super.namedParameters;
   }
 
   @override
@@ -154,13 +150,13 @@ class _$FunctionTypeBuilder extends FunctionTypeBuilder {
   }
 
   @override
-  bool get isNullable {
+  bool? get isNullable {
     _$this;
     return super.isNullable;
   }
 
   @override
-  set isNullable(bool isNullable) {
+  set isNullable(bool? isNullable) {
     _$this;
     super.isNullable = isNullable;
   }
@@ -168,13 +164,14 @@ class _$FunctionTypeBuilder extends FunctionTypeBuilder {
   _$FunctionTypeBuilder() : super._();
 
   FunctionTypeBuilder get _$this {
-    if (_$v != null) {
-      super.returnType = _$v.returnType;
-      super.types = _$v.types?.toBuilder();
-      super.requiredParameters = _$v.requiredParameters?.toBuilder();
-      super.optionalParameters = _$v.optionalParameters?.toBuilder();
-      super.namedParameters = _$v.namedParameters?.toBuilder();
-      super.isNullable = _$v.isNullable;
+    final $v = _$v;
+    if ($v != null) {
+      super.returnType = $v.returnType;
+      super.types = $v.types.toBuilder();
+      super.requiredParameters = $v.requiredParameters.toBuilder();
+      super.optionalParameters = $v.optionalParameters.toBuilder();
+      super.namedParameters = $v.namedParameters.toBuilder();
+      super.isNullable = $v.isNullable;
       _$v = null;
     }
     return this;
@@ -182,14 +179,12 @@ class _$FunctionTypeBuilder extends FunctionTypeBuilder {
 
   @override
   void replace(FunctionType other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$FunctionType;
   }
 
   @override
-  void update(void Function(FunctionTypeBuilder) updates) {
+  void update(void Function(FunctionTypeBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -206,7 +201,7 @@ class _$FunctionTypeBuilder extends FunctionTypeBuilder {
               namedParameters: namedParameters.build(),
               isNullable: isNullable);
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'types';
         types.build();

--- a/lib/src/specs/type_reference.dart
+++ b/lib/src/specs/type_reference.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.12
 
 import 'package:built_value/built_value.dart';
 import 'package:built_collection/built_collection.dart';
@@ -29,12 +30,10 @@ abstract class TypeReference extends Expression
   String get symbol;
 
   @override
-  @nullable
-  String get url;
+  String? get url;
 
   /// Optional bound generic.
-  @nullable
-  Reference get bound;
+  Reference? get bound;
 
   @override
   BuiltList<Reference> get types;
@@ -43,13 +42,12 @@ abstract class TypeReference extends Expression
   ///
   /// An emitter may ignore this if the output is not targeting a Dart language
   /// version that supports null safety.
-  @nullable
-  bool get isNullable;
+  bool? get isNullable;
 
   @override
   R accept<R>(
     SpecVisitor<R> visitor, [
-    R context,
+    R? context,
   ]) =>
       visitor.visitType(this, context);
 
@@ -123,12 +121,12 @@ abstract class TypeReferenceBuilder extends Object
 
   TypeReferenceBuilder._();
 
-  String symbol;
+  late String symbol;
 
-  String url;
+  String? url;
 
   /// Optional bound generic.
-  Reference bound;
+  Reference? bound;
 
   @override
   ListBuilder<Reference> types = ListBuilder<Reference>();
@@ -137,5 +135,5 @@ abstract class TypeReferenceBuilder extends Object
   ///
   /// An emitter may ignore this if the output is not targeting a Dart language
   /// version that supports null safety.
-  bool isNullable;
+  bool? isNullable;
 }

--- a/lib/src/specs/type_reference.g.dart
+++ b/lib/src/specs/type_reference.g.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// @dart=2.12
 
 part of 'type_reference.dart';
 
@@ -10,26 +11,26 @@ class _$TypeReference extends TypeReference {
   @override
   final String symbol;
   @override
-  final String url;
+  final String? url;
   @override
-  final Reference bound;
+  final Reference? bound;
   @override
   final BuiltList<Reference> types;
   @override
-  final bool isNullable;
+  final bool? isNullable;
 
-  factory _$TypeReference([void Function(TypeReferenceBuilder) updates]) =>
+  factory _$TypeReference([void Function(TypeReferenceBuilder)? updates]) =>
       (new TypeReferenceBuilder()..update(updates)).build() as _$TypeReference;
 
   _$TypeReference._(
-      {this.symbol, this.url, this.bound, this.types, this.isNullable})
+      {required this.symbol,
+      this.url,
+      this.bound,
+      required this.types,
+      this.isNullable})
       : super._() {
-    if (symbol == null) {
-      throw new BuiltValueNullFieldError('TypeReference', 'symbol');
-    }
-    if (types == null) {
-      throw new BuiltValueNullFieldError('TypeReference', 'types');
-    }
+    BuiltValueNullFieldError.checkNotNull(symbol, 'TypeReference', 'symbol');
+    BuiltValueNullFieldError.checkNotNull(types, 'TypeReference', 'types');
   }
 
   @override
@@ -72,7 +73,7 @@ class _$TypeReference extends TypeReference {
 }
 
 class _$TypeReferenceBuilder extends TypeReferenceBuilder {
-  _$TypeReference _$v;
+  _$TypeReference? _$v;
 
   @override
   String get symbol {
@@ -87,25 +88,25 @@ class _$TypeReferenceBuilder extends TypeReferenceBuilder {
   }
 
   @override
-  String get url {
+  String? get url {
     _$this;
     return super.url;
   }
 
   @override
-  set url(String url) {
+  set url(String? url) {
     _$this;
     super.url = url;
   }
 
   @override
-  Reference get bound {
+  Reference? get bound {
     _$this;
     return super.bound;
   }
 
   @override
-  set bound(Reference bound) {
+  set bound(Reference? bound) {
     _$this;
     super.bound = bound;
   }
@@ -113,7 +114,7 @@ class _$TypeReferenceBuilder extends TypeReferenceBuilder {
   @override
   ListBuilder<Reference> get types {
     _$this;
-    return super.types ??= new ListBuilder<Reference>();
+    return super.types;
   }
 
   @override
@@ -123,13 +124,13 @@ class _$TypeReferenceBuilder extends TypeReferenceBuilder {
   }
 
   @override
-  bool get isNullable {
+  bool? get isNullable {
     _$this;
     return super.isNullable;
   }
 
   @override
-  set isNullable(bool isNullable) {
+  set isNullable(bool? isNullable) {
     _$this;
     super.isNullable = isNullable;
   }
@@ -137,12 +138,13 @@ class _$TypeReferenceBuilder extends TypeReferenceBuilder {
   _$TypeReferenceBuilder() : super._();
 
   TypeReferenceBuilder get _$this {
-    if (_$v != null) {
-      super.symbol = _$v.symbol;
-      super.url = _$v.url;
-      super.bound = _$v.bound;
-      super.types = _$v.types?.toBuilder();
-      super.isNullable = _$v.isNullable;
+    final $v = _$v;
+    if ($v != null) {
+      super.symbol = $v.symbol;
+      super.url = $v.url;
+      super.bound = $v.bound;
+      super.types = $v.types.toBuilder();
+      super.isNullable = $v.isNullable;
       _$v = null;
     }
     return this;
@@ -150,14 +152,12 @@ class _$TypeReferenceBuilder extends TypeReferenceBuilder {
 
   @override
   void replace(TypeReference other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$TypeReference;
   }
 
   @override
-  void update(void Function(TypeReferenceBuilder) updates) {
+  void update(void Function(TypeReferenceBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -167,13 +167,14 @@ class _$TypeReferenceBuilder extends TypeReferenceBuilder {
     try {
       _$result = _$v ??
           new _$TypeReference._(
-              symbol: symbol,
+              symbol: BuiltValueNullFieldError.checkNotNull(
+                  symbol, 'TypeReference', 'symbol'),
               url: url,
               bound: bound,
               types: types.build(),
               isNullable: isNullable);
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'types';
         types.build();

--- a/lib/src/visitors.dart
+++ b/lib/src/visitors.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.12
 
 import 'package:meta/meta.dart';
 
@@ -22,31 +23,31 @@ import 'specs/type_reference.dart';
 abstract class SpecVisitor<T> {
   const SpecVisitor._();
 
-  T visitAnnotation(Expression spec, [T context]);
+  T visitAnnotation(Expression spec, [T? context]);
 
-  T visitClass(Class spec, [T context]);
+  T visitClass(Class spec, [T? context]);
 
-  T visitExtension(Extension spec, [T context]);
+  T visitExtension(Extension spec, [T? context]);
 
-  T visitEnum(Enum spec, [T context]);
+  T visitEnum(Enum spec, [T? context]);
 
-  T visitConstructor(Constructor spec, String clazz, [T context]);
+  T visitConstructor(Constructor spec, String clazz, [T? context]);
 
-  T visitDirective(Directive spec, [T context]);
+  T visitDirective(Directive spec, [T? context]);
 
-  T visitField(Field spec, [T context]);
+  T visitField(Field spec, [T? context]);
 
-  T visitLibrary(Library spec, [T context]);
+  T visitLibrary(Library spec, [T? context]);
 
-  T visitFunctionType(FunctionType spec, [T context]);
+  T visitFunctionType(FunctionType spec, [T? context]);
 
-  T visitMethod(Method spec, [T context]);
+  T visitMethod(Method spec, [T? context]);
 
-  T visitReference(Reference spec, [T context]);
+  T visitReference(Reference spec, [T? context]);
 
-  T visitSpec(Spec spec, [T context]);
+  T visitSpec(Spec spec, [T? context]);
 
-  T visitType(TypeReference spec, [T context]);
+  T visitType(TypeReference spec, [T? context]);
 
-  T visitTypeParameters(Iterable<Reference> specs, [T context]);
+  T visitTypeParameters(Iterable<Reference> specs, [T? context]);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,25 +1,27 @@
 name: code_builder
-version: 3.7.0
+version: 3.8.0-nullsafety01
+  # Maybe the correct version should be 4.0.0 but it will block build_runner 
+  # because of the code_builder version constraints.
 
 description: >-
   A fluent, builder-based library for generating valid Dart code
 homepage: https://github.com/dart-lang/code_builder
 
 environment:
-  sdk: '>=2.7.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  built_collection: '>=3.0.0 <6.0.0'
-  built_value: '>=7.0.0 <9.0.0'
-  collection: ^1.14.0
-  matcher: ^0.12.0
-  meta: ^1.0.5
+  built_collection: '>=5.0.0 <6.0.0'
+  built_value: '>=8.0.4 <9.0.0'
+  collection: ^1.15.0
+  matcher: ^0.12.10
+  meta: ^1.3.0
 
 dev_dependencies:
-  build: ^1.0.0
-  build_runner: ^1.1.0
-  built_value_generator: ^7.0.0
-  dart_style: ^1.0.0
-  pedantic: ^1.0.0
-  source_gen: ^0.9.0
-  test: ^1.3.0
+  build: ^2.0.0
+  build_runner: ^1.12.2
+  built_value_generator: ^8.0.4
+  dart_style: ^2.0.0
+  pedantic: ^1.11.0
+  source_gen: ^1.0.0
+  test: ^1.16.8

--- a/test/specs/type_reference_test.dart
+++ b/test/specs/type_reference_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.12
 
 import 'package:code_builder/code_builder.dart';
 import 'package:test/test.dart';
@@ -22,7 +23,7 @@ void main() {
   });
 
   group('in a Null Safety library', () {
-    DartEmitter emitter;
+    late DartEmitter emitter;
 
     setUp(() => emitter = DartEmitter.scoped(useNullSafetySyntax: true));
 


### PR DESCRIPTION
Sorry to be late! This was my null safety migration.
Maybe you can still use some of the code like the new features for fields (late and abstract)
All the code looks just like the same. But how could you generate the built values without put //@dart=2.12 in all sources?
Well. Hope I put it faster next time but (I was testing it)...