### PR TITLE
change the DartEmitter constructor to use named parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 4.0.0-dev
 
 * Migrate to null safety.
+* Changed the DartEmittor constructor to use named optional parameters.
 
 ## 3.7.0
 

--- a/lib/src/emitter.dart
+++ b/lib/src/emitter.dart
@@ -71,9 +71,9 @@ class DartEmitter extends Object
   ///
   /// May specify an [Allocator] to use for symbols, otherwise uses a no-op.
   DartEmitter(
-      [this.allocator = Allocator.none,
+      {this.allocator = Allocator.none,
       bool? orderDirectives = false,
-      bool? useNullSafetySyntax = false])
+      bool? useNullSafetySyntax = false})
       : orderDirectives = orderDirectives ?? false,
         _useNullSafetySyntax = useNullSafetySyntax ?? false;
 
@@ -81,7 +81,9 @@ class DartEmitter extends Object
   factory DartEmitter.scoped(
           {bool orderDirectives = false, bool useNullSafetySyntax = false}) =>
       DartEmitter(
-          Allocator.simplePrefixing(), orderDirectives, useNullSafetySyntax);
+          allocator: Allocator.simplePrefixing(),
+          orderDirectives: orderDirectives,
+          useNullSafetySyntax: useNullSafetySyntax);
 
   static bool _isLambdaBody(Code? code) =>
       code is ToCodeExpression && !code.isStatement;

--- a/lib/src/emitter.dart
+++ b/lib/src/emitter.dart
@@ -72,10 +72,9 @@ class DartEmitter extends Object
   /// May specify an [Allocator] to use for symbols, otherwise uses a no-op.
   DartEmitter(
       {this.allocator = Allocator.none,
-      bool? orderDirectives = false,
-      bool? useNullSafetySyntax = false})
-      : orderDirectives = orderDirectives ?? false,
-        _useNullSafetySyntax = useNullSafetySyntax ?? false;
+      this.orderDirectives = false,
+      bool useNullSafetySyntax = false})
+      : _useNullSafetySyntax = useNullSafetySyntax;
 
   /// Creates a new instance of [DartEmitter] with simple automatic imports.
   factory DartEmitter.scoped(

--- a/test/e2e/injection_test.dart
+++ b/test/e2e/injection_test.dart
@@ -61,7 +61,7 @@ void main() {
           @override
           _i3.Thing getThing() => _i3.Thing(_module.get1(), _module.get2());
         }
-      ''', DartEmitter(Allocator.simplePrefixing())),
+      ''', DartEmitter(allocator: Allocator.simplePrefixing())),
     );
   });
 }

--- a/test/specs/code/expression_test.dart
+++ b/test/specs/code/expression_test.dart
@@ -136,7 +136,8 @@ void main() {
   test('should emit a scoped type as an expression', () {
     expect(
       refer('Foo', 'package:foo/foo.dart'),
-      equalsDart('_i1.Foo', DartEmitter(Allocator.simplePrefixing())),
+      equalsDart(
+          '_i1.Foo', DartEmitter(allocator: Allocator.simplePrefixing())),
     );
   });
 

--- a/test/specs/library_test.dart
+++ b/test/specs/library_test.dart
@@ -91,7 +91,7 @@ void main() {
           import 'dart:collection';
           
           final test = LinkedHashMap();
-        ''', DartEmitter(Allocator())),
+        ''', DartEmitter(allocator: Allocator())),
       );
     });
 
@@ -106,7 +106,7 @@ void main() {
           import 'dart:collection' as _i1;
           
           final test = _i1.LinkedHashMap();
-        ''', DartEmitter(Allocator.simplePrefixing())),
+        ''', DartEmitter(allocator: Allocator.simplePrefixing())),
       );
     });
 


### PR DESCRIPTION
Fixes https://github.com/dart-lang/code_builder/issues/299

Going with a one-shot approach to keep the same constructor name, it looks feasible to migrate all at once internally and we have a breaking change for NNBD anyways. 