### PR TITLE
Make Reference.symbol nullable

### DIFF
--- a/lib/src/allocator.dart
+++ b/lib/src/allocator.dart
@@ -54,7 +54,7 @@ class _Allocator implements Allocator {
     if (url != null) {
       _imports.add(url);
     }
-    return reference.symbol;
+    return reference.symbol!;
   }
 
   @override
@@ -65,7 +65,7 @@ class _NullAllocator implements Allocator {
   const _NullAllocator();
 
   @override
-  String allocate(Reference reference) => reference.symbol;
+  String allocate(Reference reference) => reference.symbol!;
 
   @override
   Iterable<Directive> get imports => const [];
@@ -82,7 +82,7 @@ class _PrefixedAllocator implements Allocator {
     final symbol = reference.symbol;
     final url = reference.url;
     if (url == null || _doNotPrefix.contains(url)) {
-      return symbol;
+      return symbol!;
     }
     return '_i${_imports.putIfAbsent(url, _nextKey)}.$symbol';
   }

--- a/lib/src/specs/code.dart
+++ b/lib/src/specs/code.dart
@@ -161,5 +161,5 @@ class ScopedCode implements Code {
       visitor.visitScopedCode(this, context);
 
   @override
-  String toString() => code((ref) => ref.symbol);
+  String toString() => code((ref) => ref.symbol!);
 }

--- a/lib/src/specs/reference.dart
+++ b/lib/src/specs/reference.dart
@@ -29,7 +29,7 @@ class Reference extends Expression implements Spec {
 
   /// Name of the class, method, or field.
   ///
-  /// May be `null` for references without symbols, for isntance a function type
+  /// May be `null` for references without symbols, for instance a function type
   /// has no symbol.
   final String? symbol;
 

--- a/lib/src/specs/reference.dart
+++ b/lib/src/specs/reference.dart
@@ -28,7 +28,10 @@ class Reference extends Expression implements Spec {
   final String? url;
 
   /// Name of the class, method, or field.
-  final String symbol;
+  ///
+  /// May be `null` for references without symbols, for isntance a function type
+  /// has no symbol.
+  final String? symbol;
 
   /// Create a reference to [symbol] in [url].
   const Reference(this.symbol, [this.url]);

--- a/lib/src/specs/type_function.dart
+++ b/lib/src/specs/type_function.dart
@@ -51,8 +51,7 @@ abstract class FunctionType extends Expression
   String? get url => null;
 
   @override
-  String get symbol => throw UnsupportedError(
-      'Getting the `symbol` of a function type is not supported');
+  String? get symbol => null;
 
   @override
   Reference get type => this;


### PR DESCRIPTION
The throwing `symbol` getter in `FunctionType` makes it difficult to
perform certain sensible operations, like checking whether a given
reference is to a specific known type.

Rather than impose `is` checks on the call sites who want to read the
`symbol`, make it explicit that not all references have symbols. This
does impose some `!` operators where we use references. This is not any
less safe since an exception would happen either way and we are already
relying on a `FunctionType` not flowing to those call sites.