### PR TITLE
Add a parenthesized expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Migrate to null safety.
 * Changed the DartEmittor constructor to use named optional parameters.
+* Add `ParenthesizedExpression` and
+  `ExpressionVisitor.visitParenthesizedExpression.`
 
 ## 3.7.0
 

--- a/lib/src/specs/expression.dart
+++ b/lib/src/specs/expression.dart
@@ -19,6 +19,7 @@ part 'expression/closure.dart';
 part 'expression/code.dart';
 part 'expression/invoke.dart';
 part 'expression/literal.dart';
+part 'expression/parenthesized.dart';
 
 /// Represents a [code] block that wraps an [Expression].
 
@@ -55,15 +56,12 @@ abstract class Expression implements Spec {
       BinaryExpression._(_empty, expression, '!', addSpace: false);
 
   /// Returns the result of `this` `as` [other].
-  Expression asA(Expression other) => CodeExpression(Block.of([
-        const Code('('),
-        BinaryExpression._(
-          expression,
-          other,
-          'as',
-        ).code,
-        const Code(')')
-      ]));
+  Expression asA(Expression other) =>
+      ParenthesizedExpression._(BinaryExpression._(
+        expression,
+        other,
+        'as',
+      ));
 
   /// Returns accessing the index operator (`[]`) on `this`.
   Expression index(Expression index) => BinaryExpression._(
@@ -333,6 +331,8 @@ abstract class ExpressionVisitor<T> implements SpecVisitor<T> {
   T visitLiteralListExpression(LiteralListExpression expression, [T? context]);
   T visitLiteralSetExpression(LiteralSetExpression expression, [T? context]);
   T visitLiteralMapExpression(LiteralMapExpression expression, [T? context]);
+  T visitParenthesizedExpression(ParenthesizedExpression expression,
+      [T? context]);
 }
 
 /// Knowledge of how to write valid Dart code from [ExpressionVisitor].
@@ -502,6 +502,18 @@ abstract class ExpressionEmitter implements ExpressionVisitor<StringSink> {
       });
       return out..write('}');
     });
+  }
+
+  @override
+  StringSink visitParenthesizedExpression(
+    ParenthesizedExpression expression, [
+    StringSink? output,
+  ]) {
+    output ??= StringBuffer();
+    output.write('(');
+    expression.inner.accept(this, output);
+    output.write(')');
+    return output;
   }
 
   /// Executes [visit] within a context which may alter the output if [isConst]

--- a/lib/src/specs/expression/parenthesized.dart
+++ b/lib/src/specs/expression/parenthesized.dart
@@ -1,0 +1,16 @@
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+part of code_builder.src.specs.expression;
+
+/// An [Expression] wrapped with parenthesis.
+class ParenthesizedExpression extends Expression {
+  final Expression inner;
+
+  const ParenthesizedExpression._(this.inner);
+
+  @override
+  R accept<R>(ExpressionVisitor<R> visitor, [R? context]) =>
+      visitor.visitParenthesizedExpression(this, context);
+}

--- a/test/specs/code/expression_test.dart
+++ b/test/specs/code/expression_test.dart
@@ -476,7 +476,7 @@ void main() {
   test('should emit an explicit cast', () {
     expect(
       refer('foo').asA(refer('String')).property('length'),
-      equalsDart('( foo as String ).length'),
+      equalsDart('(foo as String).length'),
     );
   });
 

--- a/test/specs/method_test.dart
+++ b/test/specs/method_test.dart
@@ -67,6 +67,18 @@ void main() {
     );
   });
 
+  test('should create a lambda method if the value is cast', () {
+    expect(
+      Method((b) => b
+        ..name = 'returnsCastedValue'
+        ..returns = refer('Foo')
+        ..body = refer('bar').asA(refer('Foo')).code),
+      equalsDart(r'''
+        Foo returnsCastedValue() => (bar as Foo)
+      '''),
+    );
+  });
+
   test('should create a normal method implicitly', () {
     expect(
       Method.returnsVoid((b) => b


### PR DESCRIPTION
Fixes #305

Add a `ParenthesizedExpression` with special handling for the output
instead of using a `Block` to avoid influencing the behavior of other
calls that vary based on whether an argument is an expression or a
block.