### PR TITLE
Fix scoped emitter example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ void main() {
           ..name = 'doOther'
           ..returns = refer('Other', 'package:b/b.dart')),
       ]));
-  final emitter = DartEmitter(Allocator.simplePrefixing());
+  final emitter = DartEmitter.scoped();
   print(DartFormatter().format('${library.accept(emitter)}'));
 }
 ```


### PR DESCRIPTION
The current example of creating a scoped example is incorrect.

This change fixes the example to use the correct constructor.