### PR TITLE
Add annotations to libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add support for `Expression.nullChecked` to add a null assertion operator.
 * Add support for creating `mixin`s.
 * Add `Expression.nullSafeSpread` for the null aware spread operator `...?`.
+* A `Library` can now be annotated.
 
 ## 4.0.0
 

--- a/lib/src/emitter.dart
+++ b/lib/src/emitter.dart
@@ -389,6 +389,13 @@ class DartEmitter extends Object
       }
     }
 
+    if (spec.name != null) {
+      spec.annotations.forEach((a) => visitAnnotation(a, output));
+      output.write('library ${spec.name!};');
+    } else if (spec.annotations.isNotEmpty) {
+      throw StateError('a library name is required for annotations');
+    }
+
     final directives = <Directive>[...allocator.imports, ...spec.directives];
 
     if (orderDirectives) {

--- a/lib/src/specs/library.dart
+++ b/lib/src/specs/library.dart
@@ -7,18 +7,30 @@ import 'package:built_value/built_value.dart';
 import 'package:meta/meta.dart';
 
 import '../base.dart';
+import '../mixins/annotations.dart';
 import '../visitors.dart';
 import 'directive.dart';
+import 'expression.dart';
 
 part 'library.g.dart';
 
 @immutable
-abstract class Library implements Built<Library, LibraryBuilder>, Spec {
+abstract class Library
+    with HasAnnotations
+    implements Built<Library, LibraryBuilder>, Spec {
   factory Library([void Function(LibraryBuilder) updates]) = _$Library;
   Library._();
 
+  @override
+  BuiltList<Expression> get annotations;
+
   BuiltList<Directive> get directives;
   BuiltList<Spec> get body;
+
+  /// Name of the library.
+  ///
+  /// May be `null` when no [annotations] are specified.
+  String? get name;
 
   @override
   R accept<R>(
@@ -28,10 +40,17 @@ abstract class Library implements Built<Library, LibraryBuilder>, Spec {
       visitor.visitLibrary(this, context);
 }
 
-abstract class LibraryBuilder implements Builder<Library, LibraryBuilder> {
+abstract class LibraryBuilder
+    with HasAnnotationsBuilder
+    implements Builder<Library, LibraryBuilder> {
   factory LibraryBuilder() = _$LibraryBuilder;
   LibraryBuilder._();
 
+  @override
+  ListBuilder<Expression> annotations = ListBuilder<Expression>();
+
   ListBuilder<Spec> body = ListBuilder<Spec>();
   ListBuilder<Directive> directives = ListBuilder<Directive>();
+
+  String? name;
 }

--- a/lib/src/specs/library.g.dart
+++ b/lib/src/specs/library.g.dart
@@ -8,14 +8,25 @@ part of 'library.dart';
 
 class _$Library extends Library {
   @override
+  final BuiltList<Expression> annotations;
+  @override
   final BuiltList<Directive> directives;
   @override
   final BuiltList<Spec> body;
+  @override
+  final String? name;
 
   factory _$Library([void Function(LibraryBuilder)? updates]) =>
       (new LibraryBuilder()..update(updates)).build() as _$Library;
 
-  _$Library._({required this.directives, required this.body}) : super._() {
+  _$Library._(
+      {required this.annotations,
+      required this.directives,
+      required this.body,
+      this.name})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        annotations, 'Library', 'annotations');
     BuiltValueNullFieldError.checkNotNull(directives, 'Library', 'directives');
     BuiltValueNullFieldError.checkNotNull(body, 'Library', 'body');
   }
@@ -31,26 +42,45 @@ class _$Library extends Library {
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
     return other is Library &&
+        annotations == other.annotations &&
         directives == other.directives &&
-        body == other.body;
+        body == other.body &&
+        name == other.name;
   }
 
   @override
   int get hashCode {
-    return $jf($jc($jc(0, directives.hashCode), body.hashCode));
+    return $jf($jc(
+        $jc($jc($jc(0, annotations.hashCode), directives.hashCode),
+            body.hashCode),
+        name.hashCode));
   }
 
   @override
   String toString() {
     return (newBuiltValueToStringHelper('Library')
+          ..add('annotations', annotations)
           ..add('directives', directives)
-          ..add('body', body))
+          ..add('body', body)
+          ..add('name', name))
         .toString();
   }
 }
 
 class _$LibraryBuilder extends LibraryBuilder {
   _$Library? _$v;
+
+  @override
+  ListBuilder<Expression> get annotations {
+    _$this;
+    return super.annotations;
+  }
+
+  @override
+  set annotations(ListBuilder<Expression> annotations) {
+    _$this;
+    super.annotations = annotations;
+  }
 
   @override
   ListBuilder<Directive> get directives {
@@ -76,13 +106,27 @@ class _$LibraryBuilder extends LibraryBuilder {
     super.body = body;
   }
 
+  @override
+  String? get name {
+    _$this;
+    return super.name;
+  }
+
+  @override
+  set name(String? name) {
+    _$this;
+    super.name = name;
+  }
+
   _$LibraryBuilder() : super._();
 
   LibraryBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
+      super.annotations = $v.annotations.toBuilder();
       super.directives = $v.directives.toBuilder();
       super.body = $v.body.toBuilder();
+      super.name = $v.name;
       _$v = null;
     }
     return this;
@@ -104,10 +148,16 @@ class _$LibraryBuilder extends LibraryBuilder {
     _$Library _$result;
     try {
       _$result = _$v ??
-          new _$Library._(directives: directives.build(), body: body.build());
+          new _$Library._(
+              annotations: annotations.build(),
+              directives: directives.build(),
+              body: body.build(),
+              name: name);
     } catch (_) {
       late String _$failedField;
       try {
+        _$failedField = 'annotations';
+        annotations.build();
         _$failedField = 'directives';
         directives.build();
         _$failedField = 'body';

--- a/test/specs/library_test.dart
+++ b/test/specs/library_test.dart
@@ -137,5 +137,36 @@ void main() {
           ''', DartEmitter()),
       );
     });
+
+    test('should emit a source file with annotations', () {
+      expect(
+        Library(
+          (b) => b
+            ..name = 'js_interop'
+            ..annotations.add(
+              refer('JS', 'package:js/js.dart').call([]),
+            ),
+        ),
+        equalsDart(r'''
+          @JS()
+          library js_interop;
+          import 'package:js/js.dart';
+        ''', DartEmitter(allocator: Allocator())),
+      );
+    });
+
+    test('should error on unnamed library with annotations', () {
+      expect(
+        () {
+          Library(
+            (b) => b
+              ..annotations.add(
+                refer('JS', 'package:js/js.dart').call([]),
+              ),
+          ).accept(DartEmitter());
+        },
+        throwsStateError,
+      );
+    });
   });
 }


### PR DESCRIPTION
Adds the ability to annotate a `Library` generated by `code_builder`. This is to support scenarios like JavaScript interop using `package:js` where the library itself needs to be annotated with `@JS()`.