### PR TITLE
Fix docs for Expression.assign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
   `no_leading_underscores_for_library_prefixes` is most useful for hand edited
   code where the appearance of a private name which is already not visible
   outside the library is confusing.
+* Fix the docs for `Expression.assign` which had the argument and receiver
+  flipped.
 
 ## 4.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
   `no_leading_underscores_for_library_prefixes` is most useful for hand edited
   code where the appearance of a private name which is already not visible
   outside the library is confusing.
-* Fix the docs for `Expression.assign` which had the argument and receiver
-  flipped.
+* Fix the docs for `Expression.assign`, `ifNullThen`, and `assignNullAware`
+  which had the argument and receiver flipped.
 
 ## 4.1.0
 

--- a/lib/src/specs/expression.dart
+++ b/lib/src/specs/expression.dart
@@ -186,14 +186,14 @@ abstract class Expression implements Spec {
         '=',
       );
 
-  /// Return `{other} ?? {this}`.
+  /// Return `{this} ?? {other}`.
   Expression ifNullThen(Expression other) => BinaryExpression._(
         this,
         other,
         '??',
       );
 
-  /// Return `{other} ??= {this}`.
+  /// Return `{this} ??= {other}`.
   Expression assignNullAware(Expression other) => BinaryExpression._(
         this,
         other,

--- a/lib/src/specs/expression.dart
+++ b/lib/src/specs/expression.dart
@@ -179,7 +179,7 @@ abstract class Expression implements Spec {
         'await',
       );
 
-  /// Return `{other} = {this}`.
+  /// Return `{this} = {other}`.
   Expression assign(Expression other) => BinaryExpression._(
         this,
         other,


### PR DESCRIPTION
Towards #343

The doc showed the argument and the receiver flipped in the output.