### PR TITLE
feat: add initial version on the switch statement

### DIFF
--- a/lib/code_builder.dart
+++ b/lib/code_builder.dart
@@ -55,5 +55,7 @@ export 'src/specs/method.dart'
         ParameterBuilder;
 export 'src/specs/mixin.dart' show Mixin, MixinBuilder;
 export 'src/specs/reference.dart' show refer, Reference;
+export 'src/specs/switch.dart'
+    show Switch, SwitchBuilder, SwitchCase, SwitchCaseBuilder;
 export 'src/specs/type_function.dart' show FunctionType, FunctionTypeBuilder;
 export 'src/specs/type_reference.dart' show TypeReference, TypeReferenceBuilder;

--- a/lib/src/emitter.dart
+++ b/lib/src/emitter.dart
@@ -16,6 +16,7 @@ import 'specs/library.dart';
 import 'specs/method.dart';
 import 'specs/mixin.dart';
 import 'specs/reference.dart';
+import 'specs/switch.dart';
 import 'specs/type_function.dart';
 import 'specs/type_reference.dart';
 import 'visitors.dart';
@@ -624,6 +625,27 @@ class DartEmitter extends Object
   @override
   StringSink visitReference(Reference spec, [StringSink? output]) =>
       (output ??= StringBuffer())..write(allocator.allocate(spec));
+
+  @override
+  StringSink visitSwitch(Switch spec, [StringSink? output]) {
+    final out = output ??= StringBuffer();
+    spec.docs.forEach(out.writeln);
+    out.writeln('switch (${spec.condition}) {');
+    for (var v in spec.cases) {
+      v.docs.forEach(out.writeln);
+      out.writeln('case ${v.condition}:');
+      v.body!.accept(this, output);
+      if (v.break$!) {
+        out.writeln(' break;');
+      }
+    }
+    if (spec.default$ != null) {
+      out.writeln('default:');
+      spec.default$!.accept(this, output);
+    }
+    out.writeln(' }');
+    return out;
+  }
 
   @override
   StringSink visitSpec(Spec spec, [StringSink? output]) =>

--- a/lib/src/emitter.dart
+++ b/lib/src/emitter.dart
@@ -630,20 +630,24 @@ class DartEmitter extends Object
   StringSink visitSwitch(Switch spec, [StringSink? output]) {
     final out = output ??= StringBuffer();
     spec.docs.forEach(out.writeln);
-    out.writeln('switch (${spec.condition}) {');
+    out.write('switch (');
+    spec.condition.accept(this, output);
+    out.writeln(') {');
     for (var v in spec.cases) {
-      v.docs.forEach(out.writeln);
-      out.writeln('case ${v.condition}:');
-      v.body!.accept(this, output);
-      if (v.break$!) {
-        out.writeln(' break;');
+      out.write('case ');
+      v.condition!.accept(this, output);
+      out.writeln(':');
+      v.body!.accept(this, output).writeln();
+      if (v.break$ == true) {
+        out.writeln('break;');
       }
     }
     if (spec.default$ != null) {
       out.writeln('default:');
-      spec.default$!.accept(this, output);
+      spec.default$!.accept(this, output).writeln();
     }
-    out.writeln(' }');
+    out.writeln('}');
+
     return out;
   }
 

--- a/lib/src/specs/switch.dart
+++ b/lib/src/specs/switch.dart
@@ -1,0 +1,92 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+import 'package:meta/meta.dart';
+
+import '../../code_builder.dart';
+import '../mixins/dartdoc.dart';
+import '../visitors.dart';
+
+part 'switch.g.dart';
+
+@immutable
+abstract class Switch extends Object
+    with HasDartDocs
+    implements Built<Switch, SwitchBuilder>, Spec {
+  factory Switch([void Function(SwitchBuilder) updates]) = _$Switch;
+
+  Switch._();
+
+  Expression get condition;
+
+  BuiltList<SwitchCase> get cases;
+
+  Code? get default$;
+
+  @override
+  BuiltList<String> get docs;
+
+  @override
+  R accept<R>(
+    SpecVisitor<R> visitor, [
+    R? context,
+  ]) =>
+      visitor.visitSwitch(this, context);
+}
+
+abstract class SwitchBuilder extends Object
+    with HasDartDocsBuilder
+    implements Builder<Switch, SwitchBuilder> {
+  factory SwitchBuilder() = _$SwitchBuilder;
+
+  SwitchBuilder._();
+
+  Expression? condition;
+
+  ListBuilder<SwitchCase> cases = ListBuilder<SwitchCase>();
+
+  Code? default$;
+
+  @override
+  ListBuilder<String> docs = ListBuilder<String>();
+}
+
+@immutable
+abstract class SwitchCase extends Object
+    with HasDartDocs
+    implements Built<SwitchCase, SwitchCaseBuilder> {
+  factory SwitchCase([void Function(SwitchCaseBuilder) updates]) = _$SwitchCase;
+
+  SwitchCase._();
+
+  Expression? get condition;
+
+  Code? get body;
+
+  /// Whether this case should be suffixed with 'break'.
+  bool? get break$;
+
+  @override
+  BuiltList<String> get docs;
+}
+
+abstract class SwitchCaseBuilder extends Object
+    with HasDartDocsBuilder
+    implements Builder<SwitchCase, SwitchCaseBuilder> {
+  factory SwitchCaseBuilder() = _$SwitchCaseBuilder;
+
+  SwitchCaseBuilder._();
+
+  Expression? condition;
+
+  Code? body;
+
+  /// Whether this case should be suffixed with 'break'.
+  bool? break$ = true;
+
+  @override
+  ListBuilder<String> docs = ListBuilder<String>();
+}

--- a/lib/src/specs/switch.dart
+++ b/lib/src/specs/switch.dart
@@ -13,7 +13,7 @@ import '../visitors.dart';
 part 'switch.g.dart';
 
 @immutable
-abstract class Switch extends Object
+abstract class Switch extends Expression
     with HasDartDocs
     implements Built<Switch, SwitchBuilder>, Spec {
   factory Switch([void Function(SwitchBuilder) updates]) = _$Switch;

--- a/lib/src/specs/switch.g.dart
+++ b/lib/src/specs/switch.g.dart
@@ -1,0 +1,333 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'switch.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+class _$Switch extends Switch {
+  @override
+  final Expression condition;
+  @override
+  final BuiltList<SwitchCase> cases;
+  @override
+  final Code? default$;
+  @override
+  final BuiltList<String> docs;
+
+  factory _$Switch([void Function(SwitchBuilder)? updates]) =>
+      (new SwitchBuilder()..update(updates)).build() as _$Switch;
+
+  _$Switch._(
+      {required this.condition,
+      required this.cases,
+      this.default$,
+      required this.docs})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(condition, r'Switch', 'condition');
+    BuiltValueNullFieldError.checkNotNull(cases, r'Switch', 'cases');
+    BuiltValueNullFieldError.checkNotNull(docs, r'Switch', 'docs');
+  }
+
+  @override
+  Switch rebuild(void Function(SwitchBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  _$SwitchBuilder toBuilder() => new _$SwitchBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is Switch &&
+        condition == other.condition &&
+        cases == other.cases &&
+        default$ == other.default$ &&
+        docs == other.docs;
+  }
+
+  @override
+  int get hashCode {
+    return $jf($jc(
+        $jc($jc($jc(0, condition.hashCode), cases.hashCode), default$.hashCode),
+        docs.hashCode));
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'Switch')
+          ..add('condition', condition)
+          ..add('cases', cases)
+          ..add('default\$', default$)
+          ..add('docs', docs))
+        .toString();
+  }
+}
+
+class _$SwitchBuilder extends SwitchBuilder {
+  _$Switch? _$v;
+
+  @override
+  Expression? get condition {
+    _$this;
+    return super.condition;
+  }
+
+  @override
+  set condition(Expression? condition) {
+    _$this;
+    super.condition = condition;
+  }
+
+  @override
+  ListBuilder<SwitchCase> get cases {
+    _$this;
+    return super.cases;
+  }
+
+  @override
+  set cases(ListBuilder<SwitchCase> cases) {
+    _$this;
+    super.cases = cases;
+  }
+
+  @override
+  Code? get default$ {
+    _$this;
+    return super.default$;
+  }
+
+  @override
+  set default$(Code? default$) {
+    _$this;
+    super.default$ = default$;
+  }
+
+  @override
+  ListBuilder<String> get docs {
+    _$this;
+    return super.docs;
+  }
+
+  @override
+  set docs(ListBuilder<String> docs) {
+    _$this;
+    super.docs = docs;
+  }
+
+  _$SwitchBuilder() : super._();
+
+  SwitchBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      super.condition = $v.condition;
+      super.cases = $v.cases.toBuilder();
+      super.default$ = $v.default$;
+      super.docs = $v.docs.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(Switch other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$Switch;
+  }
+
+  @override
+  void update(void Function(SwitchBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  Switch build() => _build();
+
+  _$Switch _build() {
+    _$Switch _$result;
+    try {
+      _$result = _$v ??
+          new _$Switch._(
+              condition: BuiltValueNullFieldError.checkNotNull(
+                  condition, r'Switch', 'condition'),
+              cases: cases.build(),
+              default$: default$,
+              docs: docs.build());
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'cases';
+        cases.build();
+
+        _$failedField = 'docs';
+        docs.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            r'Switch', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$SwitchCase extends SwitchCase {
+  @override
+  final Expression? condition;
+  @override
+  final Code? body;
+  @override
+  final bool? break$;
+  @override
+  final BuiltList<String> docs;
+
+  factory _$SwitchCase([void Function(SwitchCaseBuilder)? updates]) =>
+      (new SwitchCaseBuilder()..update(updates)).build() as _$SwitchCase;
+
+  _$SwitchCase._({this.condition, this.body, this.break$, required this.docs})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(docs, r'SwitchCase', 'docs');
+  }
+
+  @override
+  SwitchCase rebuild(void Function(SwitchCaseBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  _$SwitchCaseBuilder toBuilder() => new _$SwitchCaseBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is SwitchCase &&
+        condition == other.condition &&
+        body == other.body &&
+        break$ == other.break$ &&
+        docs == other.docs;
+  }
+
+  @override
+  int get hashCode {
+    return $jf($jc(
+        $jc($jc($jc(0, condition.hashCode), body.hashCode), break$.hashCode),
+        docs.hashCode));
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'SwitchCase')
+          ..add('condition', condition)
+          ..add('body', body)
+          ..add('break\$', break$)
+          ..add('docs', docs))
+        .toString();
+  }
+}
+
+class _$SwitchCaseBuilder extends SwitchCaseBuilder {
+  _$SwitchCase? _$v;
+
+  @override
+  Expression? get condition {
+    _$this;
+    return super.condition;
+  }
+
+  @override
+  set condition(Expression? condition) {
+    _$this;
+    super.condition = condition;
+  }
+
+  @override
+  Code? get body {
+    _$this;
+    return super.body;
+  }
+
+  @override
+  set body(Code? body) {
+    _$this;
+    super.body = body;
+  }
+
+  @override
+  bool? get break$ {
+    _$this;
+    return super.break$;
+  }
+
+  @override
+  set break$(bool? break$) {
+    _$this;
+    super.break$ = break$;
+  }
+
+  @override
+  ListBuilder<String> get docs {
+    _$this;
+    return super.docs;
+  }
+
+  @override
+  set docs(ListBuilder<String> docs) {
+    _$this;
+    super.docs = docs;
+  }
+
+  _$SwitchCaseBuilder() : super._();
+
+  SwitchCaseBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      super.condition = $v.condition;
+      super.body = $v.body;
+      super.break$ = $v.break$;
+      super.docs = $v.docs.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(SwitchCase other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$SwitchCase;
+  }
+
+  @override
+  void update(void Function(SwitchCaseBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  SwitchCase build() => _build();
+
+  _$SwitchCase _build() {
+    _$SwitchCase _$result;
+    try {
+      _$result = _$v ??
+          new _$SwitchCase._(
+              condition: condition,
+              body: body,
+              break$: break$,
+              docs: docs.build());
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'docs';
+        docs.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            r'SwitchCase', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas

--- a/lib/src/visitors.dart
+++ b/lib/src/visitors.dart
@@ -16,6 +16,7 @@ import 'specs/library.dart';
 import 'specs/method.dart';
 import 'specs/mixin.dart';
 import 'specs/reference.dart';
+import 'specs/switch.dart';
 import 'specs/type_function.dart';
 import 'specs/type_reference.dart';
 
@@ -46,6 +47,8 @@ abstract class SpecVisitor<T> {
   T visitMethod(Method spec, [T? context]);
 
   T visitReference(Reference spec, [T? context]);
+
+  T visitSwitch(Switch spec, [T? context]);
 
   T visitSpec(Spec spec, [T? context]);
 

--- a/test/specs/switch_test.dart
+++ b/test/specs/switch_test.dart
@@ -1,0 +1,76 @@
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:code_builder/code_builder.dart';
+import 'package:test/test.dart';
+
+import '../common.dart';
+
+void main() {
+  useDartfmt();
+
+  test('should create a switch', () {
+    expect(
+      Switch((b) => b..condition = literal(true)),
+      equalsDart(r'''
+        switch (true) {
+        }
+      '''),
+    );
+  });
+
+  test('should create a switch with a case', () {
+    expect(
+      Switch((b) => b
+        ..condition = literal(true)
+        ..cases.add(SwitchCase(
+          (b) => b
+            ..condition = literal(false)
+            ..body = refer('Exception').call([]).thrown.statement
+            ..break$ = false,
+        ))),
+      equalsDart(r'''
+        switch (true) {
+          case false:
+            throw Exception();
+        }
+      '''),
+    );
+  });
+
+  test('should create a switch with a default', () {
+    expect(
+      Switch(
+        (b) => b
+          ..condition = literal(true)
+          ..default$ = refer('print').call([literal('hello')]).statement,
+      ),
+      equalsDart(r'''
+        switch (true) {
+          default:
+            print('hello');
+        }
+      '''),
+    );
+  });
+
+  test('should add a break statement by default', () {
+    expect(
+      Switch((b) => b
+        ..condition = literal(true)
+        ..cases.add(SwitchCase(
+          (b) => b
+            ..condition = literal(false)
+            ..body = refer('print').call([literal('Oh no!')]).statement,
+        ))),
+      equalsDart(r'''
+        switch (true) {
+          case false:
+            print('Oh no!');
+            break;
+        }
+      '''),
+    );
+  });
+}

--- a/test/specs/switch_test.dart
+++ b/test/specs/switch_test.dart
@@ -10,6 +10,9 @@ import '../common.dart';
 void main() {
   useDartfmt();
 
+  switch (true) {
+  }
+
   test('should create a switch', () {
     expect(
       Switch((b) => b..condition = literal(true)),
@@ -69,6 +72,54 @@ void main() {
           case false:
             print('Oh no!');
             break;
+        }
+      '''),
+    );
+  });
+
+  test('should be able to be used within a code block', () {
+    expect(
+      Method(
+        (b) => b
+          ..returns = refer('String?')
+          ..name = 'getStatus'
+          ..requiredParameters.add(Parameter(
+            (b) => b
+              ..type = refer('int')
+              ..name = 'value',
+          ))
+          ..body = Block.of([
+            Switch(
+              (b) => b
+                ..condition = refer('value')
+                ..cases.addAll([
+                  SwitchCase(
+                    (b) => b
+                      ..condition = literal(200)
+                      ..body = literal('OK').returned.statement
+                      ..break$ = false,
+                  ),
+                  SwitchCase(
+                    (b) => b
+                      ..condition = literal(201)
+                      ..body = literal('CREATED').returned.statement
+                      ..break$ = false,
+                  ),
+                ])
+                ..default$ = literal(null).returned.statement,
+            ).code,
+          ]),
+      ),
+      equalsDart(r'''
+        String? getStatus(int value) {
+          switch (value) {
+            case 200:
+              return 'OK';
+            case 201:
+              return 'CREATED';
+            default:
+              return null;
+          }
         }
       '''),
     );


### PR DESCRIPTION
I would like to be able to generate Switch statements using the `code_builder` package. I've written a basic implementation and I'm looking for any feedback on my request.

There is one thing that I'm not quite sure about yet:
- The `SwitchCase` class has a `break$` field to suffix the body with a break statement. Is there any other logical way to specify this? Or should we infer this from the return value of the case body?

Thanks in advance!