### PR TITLE
Only emit 'late' when using null-safety syntax.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.2.1-dev
+
+* Only emit `late` keyword when using null safety syntax.
+
 ## 4.2.0
 
 * Add an ignore for a lint from the `package:lints` recommended set. The lint,

--- a/lib/src/emitter.dart
+++ b/lib/src/emitter.dart
@@ -358,7 +358,7 @@ class DartEmitter extends Object
     if (spec.static) {
       output.write('static ');
     }
-    if (spec.late) {
+    if (spec.late && _useNullSafetySyntax) {
       output.write('late ');
     }
     switch (spec.modifier) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: code_builder
-version: 4.2.0
+version: 4.2.1-dev
 description: >-
   A fluent, builder-based library for generating valid Dart code
 repository: https://github.com/dart-lang/code_builder

--- a/test/specs/field_test.dart
+++ b/test/specs/field_test.dart
@@ -52,13 +52,24 @@ void main() {
     );
   });
 
-  test('should create a late field', () {
+  test('should create a late field if using null-safety', () {
     expect(
       Field((b) => b
         ..late = true
         ..name = 'foo'),
       equalsDart(r'''
         late var foo;
+      ''', DartEmitter(useNullSafetySyntax: true)),
+    );
+  });
+
+  test('should not create a late field if not using null-safety', () {
+    expect(
+      Field((b) => b
+        ..late = true
+        ..name = 'foo'),
+      equalsDart(r'''
+        var foo;
       '''),
     );
   });
@@ -71,7 +82,7 @@ void main() {
         ..name = 'foo'),
       equalsDart(r'''
         static late var foo;
-      '''),
+      ''', DartEmitter(useNullSafetySyntax: true)),
     );
   });
 


### PR DESCRIPTION
This addresses #370, avoiding late being written out when it would cause a syntax error for non-null-safe parsing.