### PR TITLE
Fix some missing implicit const contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 4.2.1-dev
 
 * Only emit `late` keyword when using null safety syntax.
+* Use implicit `const` when assigning to a `declareConst` variable.
 
 ## 4.2.0
 

--- a/lib/src/specs/expression/binary.dart
+++ b/lib/src/specs/expression/binary.dart
@@ -10,6 +10,7 @@ class BinaryExpression extends Expression {
   final Expression right;
   final String operator;
   final bool addSpace;
+  @override
   final bool isConst;
 
   const BinaryExpression._(

--- a/lib/src/specs/expression/invoke.dart
+++ b/lib/src/specs/expression/invoke.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore_for_file: deprecated_member_use_from_same_package
+
 part of code_builder.src.specs.expression;
 
 /// Represents invoking [target] as a method with arguments.
@@ -10,7 +12,11 @@ class InvokeExpression extends Expression {
   final Expression target;
 
   /// Optional; type of invocation.
+  @Deprecated('Use isConst instead')
   final InvokeExpressionType? type;
+
+  @override
+  final bool isConst;
 
   final List<Expression> positionalArguments;
   final Map<String, Expression> namedArguments;
@@ -19,11 +25,12 @@ class InvokeExpression extends Expression {
 
   const InvokeExpression._(
     this.target,
-    this.positionalArguments, [
-    this.namedArguments = const {},
-    this.typeArguments = const [],
-  ])  : name = null,
-        type = null;
+    this.positionalArguments,
+    this.namedArguments,
+    this.typeArguments,
+  )   : name = null,
+        type = null,
+        isConst = false;
 
   const InvokeExpression.newOf(
     this.target,
@@ -31,7 +38,8 @@ class InvokeExpression extends Expression {
     this.namedArguments = const {},
     this.typeArguments = const [],
     this.name,
-  ]) : type = InvokeExpressionType.newInstance;
+  ])  : type = InvokeExpressionType.newInstance,
+        isConst = false;
 
   const InvokeExpression.constOf(
     this.target,
@@ -39,7 +47,8 @@ class InvokeExpression extends Expression {
     this.namedArguments = const {},
     this.typeArguments = const [],
     this.name,
-  ]) : type = InvokeExpressionType.constInstance;
+  ])  : type = InvokeExpressionType.constInstance,
+        isConst = true;
 
   @override
   R accept<R>(ExpressionVisitor<R> visitor, [R? context]) =>

--- a/lib/src/specs/expression/literal.dart
+++ b/lib/src/specs/expression/literal.dart
@@ -123,6 +123,7 @@ class LiteralExpression extends Expression {
 }
 
 class LiteralListExpression extends Expression {
+  @override
   final bool isConst;
   final List<Object?> values;
   final Reference? type;
@@ -138,6 +139,7 @@ class LiteralListExpression extends Expression {
 }
 
 class LiteralSetExpression extends Expression {
+  @override
   final bool isConst;
   final Set<Object?> values;
   final Reference? type;
@@ -153,6 +155,7 @@ class LiteralSetExpression extends Expression {
 }
 
 class LiteralMapExpression extends Expression {
+  @override
   final bool isConst;
   final Map<Object?, Object?> values;
   final Reference? keyType;

--- a/test/const_test.dart
+++ b/test/const_test.dart
@@ -29,6 +29,23 @@ void main() {
     );
   });
 
+  test('assign to declared constant', () {
+    expect(
+      declareConst('constField').assign(constMap),
+      equalsDart(r'''
+          const constField = {'list': [], 'duration': Duration()}''',
+          DartEmitter.scoped()),
+    );
+  });
+
+  test('assign to declared non-constant', () {
+    expect(
+        declareVar('varField').assign(constMap),
+        equalsDart(r'''
+          var varField = const {'list': [], 'duration': Duration()}''',
+            DartEmitter.scoped()));
+  });
+
   final library = Library((b) => b
     ..body.add(Field((b) => b
       ..name = 'val1'


### PR DESCRIPTION
There are some expressions where an `isConst` field implies that sub
expressions can omit the `const` keyword. This is manually handled in
the appropriate visit methods for the expressions where a const context
is sensible. In `InvokeExpression` a `type` field expressed the same
intent.

Using `declareConst` and `assign` did not carry the const context, so an
expression would have an omittable `const` keyword.

- Add an `isConst` getter on `Expression`. Default to false since the
  expressions which already can imply const already have definitions
  with correct usage, except for `InvokeExpression` which had a
  different API. This is only necessary to allow forwarding in `assign`
  without overriding in each subclass which can imply a const context.
- In assignments, forward `isConst` to the `BinaryExpression`. A const
  left hand side implies const for the right hand side.
- Deprecate the `type` field for `InvokeExpression` in favor of a new
  override for `isConst`. There is no need for a null unknown-const
  state. Expressions are by default assumed to not imply a const context
  and only relevant expression types are checked for `isConst` by the
  relevant visitors. Update the invoke expression visitor to use
  `isConst` over checking the type. No methods may be invoked in a const
  expression and the private constructor is used for invoking methods,
  so assume `false`.
- Always use a `BinaryExpression` for `declareConst`, and mark it as
  const. This allows the assignment to carry the context through to the
  other expressions.
- Add tests that assigning to a `declareConst` uses an implicit `const`
  on the right hand side, while assigning to a non-const var uses an
  explicit `const`.