### PR TITLE
Deprecate assignVar, assignFinal, assignConst

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Only emit `late` keyword when using null safety syntax.
 * Use implicit `const` when assigning to a `declareConst` variable.
+* Deprecate `assignVar`, `assignConst`, and `assignFinal`.
 
 ## 4.2.0
 

--- a/lib/src/specs/expression.dart
+++ b/lib/src/specs/expression.dart
@@ -209,6 +209,7 @@ abstract class Expression implements Spec {
       );
 
   /// Return `var {name} = {this}`.
+  @Deprecated('Use `declareVar(name).assign(expression)`')
   Expression assignVar(String name, [Reference? type]) => BinaryExpression._(
         type == null
             ? LiteralExpression._('var $name')
@@ -222,6 +223,7 @@ abstract class Expression implements Spec {
       );
 
   /// Return `final {name} = {this}`.
+  @Deprecated('Use `declareFinal(name).assign(expression)`')
   Expression assignFinal(String name, [Reference? type]) => BinaryExpression._(
         type == null
             ? const LiteralExpression._('final')
@@ -235,6 +237,7 @@ abstract class Expression implements Spec {
       );
 
   /// Return `const {name} = {this}`.
+  @Deprecated('Use `declareConst(name).assign(expression)`')
   Expression assignConst(String name, [Reference? type]) => BinaryExpression._(
         type == null
             ? const LiteralExpression._('const')

--- a/test/const_test.dart
+++ b/test/const_test.dart
@@ -22,6 +22,7 @@ void main() {
 
   test('assignConst', () {
     expect(
+      // ignore: deprecated_member_use_from_same_package
       constMap.assignConst('constField'),
       equalsDart(r'''
           const constField = {'list': [], 'duration': Duration()}''',

--- a/test/specs/code/expression_test.dart
+++ b/test/specs/code/expression_test.dart
@@ -412,6 +412,7 @@ void main() {
       refer('bar')
           .index(literalTrue)
           .ifNullThen(literalFalse)
+          // ignore: deprecated_member_use_from_same_package
           .assignVar('foo')
           .statement,
       equalsDart('var foo = bar[true] ?? false;'),
@@ -427,6 +428,7 @@ void main() {
 
   test('should emit an index operator', () {
     expect(
+      // ignore: deprecated_member_use_from_same_package
       refer('bar').index(literalString('key')).assignVar('foo').statement,
       equalsDart("var foo = bar['key'];"),
     );
@@ -437,6 +439,7 @@ void main() {
       refer('bar')
           .index(literalString('key'))
           .assign(literalFalse)
+          // ignore: deprecated_member_use_from_same_package
           .assignVar('foo')
           .statement,
       equalsDart("var foo = bar['key'] = false;"),
@@ -448,6 +451,7 @@ void main() {
       refer('bar')
           .index(literalTrue)
           .assignNullAware(literalFalse)
+          // ignore: deprecated_member_use_from_same_package
           .assignVar('foo')
           .statement,
       equalsDart('var foo = bar[true] ??= false;'),
@@ -456,6 +460,7 @@ void main() {
 
   test('should emit assigning to a var', () {
     expect(
+      // ignore: deprecated_member_use_from_same_package
       literalTrue.assignVar('foo'),
       equalsDart('var foo = true'),
     );
@@ -463,6 +468,7 @@ void main() {
 
   test('should emit assigning to a type', () {
     expect(
+      // ignore: deprecated_member_use_from_same_package
       literalTrue.assignVar('foo', refer('bool')),
       equalsDart('bool foo = true'),
     );
@@ -470,6 +476,7 @@ void main() {
 
   test('should emit assigning to a final', () {
     expect(
+      // ignore: deprecated_member_use_from_same_package
       literalTrue.assignFinal('foo'),
       equalsDart('final foo = true'),
     );
@@ -477,6 +484,7 @@ void main() {
 
   test('should emit assigning to a const', () {
     expect(
+      // ignore: deprecated_member_use_from_same_package
       literalTrue.assignConst('foo'),
       equalsDart('const foo = true'),
     );


### PR DESCRIPTION
Point to the relevant `declare*` API which replaces them.