### PR TITLE
Add support for trailing commas in Emitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 * Only emit `late` keyword when using null safety syntax.
 * Use implicit `const` when assigning to a `declareConst` variable.
 * Deprecate `assignVar`, `assignConst`, and `assignFinal`.
+* Add trailing commas to any parameter list, argument list, or collection
+  literal which has more than one element.
 
 ## 4.2.0
 

--- a/lib/src/emitter.dart
+++ b/lib/src/emitter.dart
@@ -68,33 +68,22 @@ class DartEmitter extends Object
   /// a Dart language version which supports it.
   final bool _useNullSafetySyntax;
 
-  /// If trailing commas should be used where they are allowed.
-  ///
-  /// If `true`, an argument list, parameter list, or collection literal with
-  /// more than one element will end with a trailing comma.
-  final bool _useTrailingCommas;
-
   /// Creates a new instance of [DartEmitter].
   ///
   /// May specify an [Allocator] to use for symbols, otherwise uses a no-op.
   DartEmitter(
       {this.allocator = Allocator.none,
       this.orderDirectives = false,
-      bool useNullSafetySyntax = false,
-      bool useTrailingCommas = false})
-      : _useNullSafetySyntax = useNullSafetySyntax,
-        _useTrailingCommas = useTrailingCommas;
+      bool useNullSafetySyntax = false})
+      : _useNullSafetySyntax = useNullSafetySyntax;
 
   /// Creates a new instance of [DartEmitter] with simple automatic imports.
   factory DartEmitter.scoped(
-          {bool orderDirectives = false,
-          bool useNullSafetySyntax = false,
-          bool useTrailingCommas = false}) =>
+          {bool orderDirectives = false, bool useNullSafetySyntax = false}) =>
       DartEmitter(
           allocator: Allocator.simplePrefixing(),
           orderDirectives: orderDirectives,
-          useNullSafetySyntax: useNullSafetySyntax,
-          useTrailingCommas: useTrailingCommas);
+          useNullSafetySyntax: useNullSafetySyntax);
 
   static bool _isLambdaBody(Code? code) =>
       code is ToCodeExpression && !code.isStatement;
@@ -107,9 +96,6 @@ class DartEmitter extends Object
   static bool _isLambdaConstructor(Constructor constructor) =>
       constructor.lambda ??
       constructor.factory && _isLambdaBody(constructor.body);
-
-  @override
-  bool get useTrailingCommas => _useTrailingCommas;
 
   @override
   StringSink visitAnnotation(Expression spec, [StringSink? output]) {
@@ -234,7 +220,7 @@ class DartEmitter extends Object
       for (final p in spec.requiredParameters) {
         count++;
         _visitParameter(p, output);
-        if ((useTrailingCommas && hasMultipleParameters) ||
+        if (hasMultipleParameters ||
             spec.requiredParameters.length != count ||
             spec.optionalParameters.isNotEmpty) {
           output.write(', ');
@@ -252,8 +238,7 @@ class DartEmitter extends Object
       for (final p in spec.optionalParameters) {
         count++;
         _visitParameter(p, output, optional: true, named: named);
-        if ((useTrailingCommas && hasMultipleParameters) ||
-            spec.optionalParameters.length != count) {
+        if (hasMultipleParameters || spec.optionalParameters.length != count) {
           output.write(', ');
         }
       }
@@ -471,12 +456,11 @@ class DartEmitter extends Object
       out.write('>');
     }
     out.write('(');
-    final needsTrailingComma = useTrailingCommas &&
-        spec.requiredParameters.length +
-                spec.optionalParameters.length +
-                spec.namedRequiredParameters.length +
-                spec.namedParameters.length >
-            1;
+    final needsTrailingComma = spec.requiredParameters.length +
+            spec.optionalParameters.length +
+            spec.namedRequiredParameters.length +
+            spec.namedParameters.length >
+        1;
     visitAll<Reference>(spec.requiredParameters, out, (spec) {
       spec.accept(this, out);
     });
@@ -488,11 +472,6 @@ class DartEmitter extends Object
             hasNamedParameters)) {
       out.write(', ');
     }
-    /*if (useTrailingCommas &&
-        spec.requiredParameters.isNotEmpty &&
-        hasMultipleParameters) {
-      out.write(', ');
-    }*/
     if (spec.optionalParameters.isNotEmpty) {
       out.write('[');
       visitAll<Reference>(spec.optionalParameters, out, (spec) {
@@ -570,7 +549,7 @@ class DartEmitter extends Object
         for (final p in spec.requiredParameters) {
           count++;
           _visitParameter(p, output);
-          if ((useTrailingCommas && hasMultipleParameters) ||
+          if (hasMultipleParameters ||
               spec.requiredParameters.length != count ||
               spec.optionalParameters.isNotEmpty) {
             output.write(', ');
@@ -588,7 +567,7 @@ class DartEmitter extends Object
         for (final p in spec.optionalParameters) {
           count++;
           _visitParameter(p, output, optional: true, named: named);
-          if ((useTrailingCommas && hasMultipleParameters) ||
+          if (hasMultipleParameters ||
               spec.optionalParameters.length != count) {
             output.write(', ');
           }

--- a/lib/src/specs/expression.dart
+++ b/lib/src/specs/expression.dart
@@ -421,6 +421,8 @@ abstract class ExpressionVisitor<T> implements SpecVisitor<T> {
 ///
 /// **INTERNAL ONLY**.
 abstract class ExpressionEmitter implements ExpressionVisitor<StringSink> {
+  bool get useTrailingCommas => false;
+
   @override
   StringSink visitToCodeExpression(ToCodeExpression expression,
       [StringSink? output]) {
@@ -497,6 +499,11 @@ abstract class ExpressionEmitter implements ExpressionVisitor<StringSink> {
           ..write(': ');
         expression.namedArguments[name]!.accept(this, out);
       });
+      final argumentCount = expression.positionalArguments.length +
+          expression.namedArguments.length;
+      if (useTrailingCommas && argumentCount > 1) {
+        out.write(', ');
+      }
       return out..write(')');
     });
   }
@@ -535,6 +542,9 @@ abstract class ExpressionEmitter implements ExpressionVisitor<StringSink> {
       visitAll<Object?>(expression.values, out, (value) {
         _acceptLiteral(value, out);
       });
+      if (useTrailingCommas && expression.values.length > 1) {
+        out.write(', ');
+      }
       return out..write(']');
     });
   }
@@ -556,6 +566,9 @@ abstract class ExpressionEmitter implements ExpressionVisitor<StringSink> {
       visitAll<Object?>(expression.values, out, (value) {
         _acceptLiteral(value, out);
       });
+      if (useTrailingCommas && expression.values.length > 1) {
+        out.write(', ');
+      }
       return out..write('}');
     });
   }
@@ -585,6 +598,9 @@ abstract class ExpressionEmitter implements ExpressionVisitor<StringSink> {
         out.write(': ');
         _acceptLiteral(value, out);
       });
+      if (useTrailingCommas && expression.values.length > 1) {
+        out.write(', ');
+      }
       return out..write('}');
     });
   }

--- a/lib/src/specs/expression.dart
+++ b/lib/src/specs/expression.dart
@@ -421,8 +421,6 @@ abstract class ExpressionVisitor<T> implements SpecVisitor<T> {
 ///
 /// **INTERNAL ONLY**.
 abstract class ExpressionEmitter implements ExpressionVisitor<StringSink> {
-  bool get useTrailingCommas => false;
-
   @override
   StringSink visitToCodeExpression(ToCodeExpression expression,
       [StringSink? output]) {
@@ -501,7 +499,7 @@ abstract class ExpressionEmitter implements ExpressionVisitor<StringSink> {
       });
       final argumentCount = expression.positionalArguments.length +
           expression.namedArguments.length;
-      if (useTrailingCommas && argumentCount > 1) {
+      if (argumentCount > 1) {
         out.write(', ');
       }
       return out..write(')');
@@ -542,7 +540,7 @@ abstract class ExpressionEmitter implements ExpressionVisitor<StringSink> {
       visitAll<Object?>(expression.values, out, (value) {
         _acceptLiteral(value, out);
       });
-      if (useTrailingCommas && expression.values.length > 1) {
+      if (expression.values.length > 1) {
         out.write(', ');
       }
       return out..write(']');
@@ -566,7 +564,7 @@ abstract class ExpressionEmitter implements ExpressionVisitor<StringSink> {
       visitAll<Object?>(expression.values, out, (value) {
         _acceptLiteral(value, out);
       });
-      if (useTrailingCommas && expression.values.length > 1) {
+      if (expression.values.length > 1) {
         out.write(', ');
       }
       return out..write('}');
@@ -598,7 +596,7 @@ abstract class ExpressionEmitter implements ExpressionVisitor<StringSink> {
         out.write(': ');
         _acceptLiteral(value, out);
       });
-      if (useTrailingCommas && expression.values.length > 1) {
+      if (expression.values.length > 1) {
         out.write(', ');
       }
       return out..write('}');

--- a/test/const_test.dart
+++ b/test/const_test.dart
@@ -17,7 +17,7 @@ void main() {
 
   test('expression', () {
     expect(constMap, equalsDart(r'''
-          const {'list': [], 'duration': Duration()}'''));
+          const {'list': [], 'duration': Duration(), }'''));
   });
 
   test('assignConst', () {
@@ -25,7 +25,7 @@ void main() {
       // ignore: deprecated_member_use_from_same_package
       constMap.assignConst('constField'),
       equalsDart(r'''
-          const constField = {'list': [], 'duration': Duration()}''',
+          const constField = {'list': [], 'duration': Duration(), }''',
           DartEmitter.scoped()),
     );
   });
@@ -34,7 +34,7 @@ void main() {
     expect(
       declareConst('constField').assign(constMap),
       equalsDart(r'''
-          const constField = {'list': [], 'duration': Duration()}''',
+          const constField = {'list': [], 'duration': Duration(), }''',
           DartEmitter.scoped()),
     );
   });
@@ -43,7 +43,7 @@ void main() {
     expect(
         declareVar('varField').assign(constMap),
         equalsDart(r'''
-          var varField = const {'list': [], 'duration': Duration()}''',
+          var varField = const {'list': [], 'duration': Duration(), }''',
             DartEmitter.scoped()));
   });
 

--- a/test/e2e/injection_test.dart
+++ b/test/e2e/injection_test.dart
@@ -45,7 +45,7 @@ void main() {
           final Module _module;
 
           @override
-          Thing getThing() => Thing(_module.get1(), _module.get2());
+          Thing getThing() => Thing(_module.get1(), _module.get2(), );
         }
       '''),
     );
@@ -59,7 +59,7 @@ void main() {
           final _i2.Module _module;
 
           @override
-          _i3.Thing getThing() => _i3.Thing(_module.get1(), _module.get2());
+          _i3.Thing getThing() => _i3.Thing(_module.get1(), _module.get2(), );
         }
       ''', DartEmitter(allocator: Allocator.simplePrefixing())),
     );

--- a/test/specs/class_test.dart
+++ b/test/specs/class_test.dart
@@ -10,6 +10,8 @@ import '../common.dart';
 void main() {
   useDartfmt();
 
+  final trailingCommasEmitter = DartEmitter(useTrailingCommas: true);
+
   test('should create a class', () {
     expect(
       Class((b) => b..name = 'Foo'),
@@ -312,7 +314,7 @@ void main() {
     );
   });
 
-  test('should create a class with method parameters', () {
+  test('should create a class with a constructor with parameters', () {
     expect(
       Class((b) => b
         ..name = 'Foo'
@@ -385,6 +387,45 @@ void main() {
           Foo(super.a, super.b, {super.c});
         }
       '''),
+    );
+  });
+
+  test(
+      'should create a class with a constructor with a positional parameter '
+      'without a trailing comma', () {
+    expect(
+      Class((b) => b
+        ..name = 'Foo'
+        ..constructors.add(Constructor((b) => b
+          ..requiredParameters.add(
+            Parameter((b) => b..name = 'a'),
+          )))),
+      equalsDart(r'''
+        class Foo {
+          Foo(a);
+        }
+      ''', trailingCommasEmitter),
+    );
+  });
+
+  test(
+      'should create a class with a constructor with a positional parameter '
+      'and a named parameter with a trailing comma', () {
+    expect(
+      Class((b) => b
+        ..name = 'Foo'
+        ..constructors.add(Constructor((b) => b
+          ..requiredParameters.add(Parameter((b) => b..name = 'a'))
+          ..optionalParameters.add(
+            Parameter((b) => b
+              ..name = 'b'
+              ..named = true),
+          )))),
+      equalsDart(r'''
+        class Foo {
+          Foo(a, {b, });
+        }
+      ''', trailingCommasEmitter),
     );
   });
 }

--- a/test/specs/class_test.dart
+++ b/test/specs/class_test.dart
@@ -10,8 +10,6 @@ import '../common.dart';
 void main() {
   useDartfmt();
 
-  final trailingCommasEmitter = DartEmitter(useTrailingCommas: true);
-
   test('should create a class', () {
     expect(
       Class((b) => b..name = 'Foo'),
@@ -330,7 +328,7 @@ void main() {
           ])))),
       equalsDart(r'''
         class Foo {
-          Foo(a, b, {c});
+          Foo(a, b, {c, });
         }
       '''),
     );
@@ -357,7 +355,7 @@ void main() {
           ])))),
       equalsDart(r'''
         class Foo {
-          Foo(this.a, this.b, {this.c});
+          Foo(this.a, this.b, {this.c, });
         }
       '''),
     );
@@ -384,48 +382,9 @@ void main() {
           ])))),
       equalsDart(r'''
         class Foo {
-          Foo(super.a, super.b, {super.c});
+          Foo(super.a, super.b, {super.c, });
         }
       '''),
-    );
-  });
-
-  test(
-      'should create a class with a constructor with a positional parameter '
-      'without a trailing comma', () {
-    expect(
-      Class((b) => b
-        ..name = 'Foo'
-        ..constructors.add(Constructor((b) => b
-          ..requiredParameters.add(
-            Parameter((b) => b..name = 'a'),
-          )))),
-      equalsDart(r'''
-        class Foo {
-          Foo(a);
-        }
-      ''', trailingCommasEmitter),
-    );
-  });
-
-  test(
-      'should create a class with a constructor with a positional parameter '
-      'and a named parameter with a trailing comma', () {
-    expect(
-      Class((b) => b
-        ..name = 'Foo'
-        ..constructors.add(Constructor((b) => b
-          ..requiredParameters.add(Parameter((b) => b..name = 'a'))
-          ..optionalParameters.add(
-            Parameter((b) => b
-              ..name = 'b'
-              ..named = true),
-          )))),
-      equalsDart(r'''
-        class Foo {
-          Foo(a, {b, });
-        }
-      ''', trailingCommasEmitter),
     );
   });
 }

--- a/test/specs/code/expression_test.dart
+++ b/test/specs/code/expression_test.dart
@@ -10,6 +10,8 @@ import '../../common.dart';
 void main() {
   useDartfmt();
 
+  final trailingCommasEmitter = DartEmitter(useTrailingCommas: true);
+
   test('should emit a simple expression', () {
     expect(literalNull, equalsDart('null'));
   });
@@ -111,6 +113,27 @@ void main() {
         refer('Map').newInstance([])
       ]),
       equalsDart('[[], {}, true, null, Map()]'),
+    );
+  });
+
+  test('should emit a list with no elements without a trailing comma', () {
+    expect(
+      literalList([]),
+      equalsDart('[]', trailingCommasEmitter),
+    );
+  });
+
+  test('should emit a list with a single element without a trailing comma', () {
+    expect(
+      literalList([true]),
+      equalsDart('[true]', trailingCommasEmitter),
+    );
+  });
+
+  test('should emit a list with multiple elements with a trailing comma', () {
+    expect(
+      literalList([true, false]),
+      equalsDart('[true, false, ]', trailingCommasEmitter),
     );
   });
 
@@ -222,6 +245,65 @@ void main() {
         'baz': literal(3),
       }),
       equalsDart('foo(1, bar: 2, baz: 3)'),
+    );
+  });
+
+  test(
+      'should emit invoking a method with a single positional argument without '
+      'a trailing comma', () {
+    expect(
+      refer('foo').call([
+        literal(1),
+      ]),
+      equalsDart('foo(1)', trailingCommasEmitter),
+    );
+  });
+
+  test(
+      'should emit invoking a method with multiple positional arguments with a '
+      'trailing comma', () {
+    expect(
+      refer('foo').call([
+        literal(1),
+        literal(2),
+      ]),
+      equalsDart('foo(1, 2, )', trailingCommasEmitter),
+    );
+  });
+
+  test(
+      'should emit invoking a method with a positional argument and a named '
+      'argument with a trailing comma', () {
+    expect(
+      refer('foo').call([
+        literal(1),
+      ], {
+        'bar': literal(2),
+      }),
+      equalsDart('foo(1, bar: 2, )', trailingCommasEmitter),
+    );
+  });
+
+  test(
+      'should emit invoking a method with a named argument without a trailing '
+      'comma', () {
+    expect(
+      refer('foo').call([], {
+        'bar': literal(2),
+      }),
+      equalsDart('foo(bar: 2)', trailingCommasEmitter),
+    );
+  });
+
+  test(
+      'should emit invoking a method with multiple named arguments with a '
+      'trailing comma', () {
+    expect(
+      refer('foo').call([], {
+        'bar': literal(2),
+        'baz': literal(3),
+      }),
+      equalsDart('foo(bar: 2, baz: 3, )', trailingCommasEmitter),
     );
   });
 

--- a/test/specs/code/expression_test.dart
+++ b/test/specs/code/expression_test.dart
@@ -10,8 +10,6 @@ import '../../common.dart';
 void main() {
   useDartfmt();
 
-  final trailingCommasEmitter = DartEmitter(useTrailingCommas: true);
-
   test('should emit a simple expression', () {
     expect(literalNull, equalsDart('null'));
   });
@@ -98,7 +96,7 @@ void main() {
         refer('three'): 3,
         refer('Map').newInstance([]): null,
       }),
-      equalsDart(r"{1: 'one', 2: two, three: 3, Map(): null}"),
+      equalsDart(r"{1: 'one', 2: two, three: 3, Map(): null, }"),
     );
   });
 
@@ -112,28 +110,7 @@ void main() {
         null,
         refer('Map').newInstance([])
       ]),
-      equalsDart('[[], {}, true, null, Map()]'),
-    );
-  });
-
-  test('should emit a list with no elements without a trailing comma', () {
-    expect(
-      literalList([]),
-      equalsDart('[]', trailingCommasEmitter),
-    );
-  });
-
-  test('should emit a list with a single element without a trailing comma', () {
-    expect(
-      literalList([true]),
-      equalsDart('[true]', trailingCommasEmitter),
-    );
-  });
-
-  test('should emit a list with multiple elements with a trailing comma', () {
-    expect(
-      literalList([true, false]),
-      equalsDart('[true, false, ]', trailingCommasEmitter),
+      equalsDart('[[], {}, true, null, Map(), ]'),
     );
   });
 
@@ -148,7 +125,7 @@ void main() {
         null,
         refer('Map').newInstance([])
       ]),
-      equalsDart('{[], {}, true, null, Map()}'),
+      equalsDart('{[], {}, true, null, Map(), }'),
     );
   });
 
@@ -213,7 +190,7 @@ void main() {
         literal(2),
         literal(3),
       ]),
-      equalsDart('foo(1, 2, 3)'),
+      equalsDart('foo(1, 2, 3, )'),
     );
   });
 
@@ -232,7 +209,7 @@ void main() {
         'bar': literal(1),
         'baz': literal(2),
       }),
-      equalsDart('foo(bar: 1, baz: 2)'),
+      equalsDart('foo(bar: 1, baz: 2, )'),
     );
   });
 
@@ -244,66 +221,7 @@ void main() {
         'bar': literal(2),
         'baz': literal(3),
       }),
-      equalsDart('foo(1, bar: 2, baz: 3)'),
-    );
-  });
-
-  test(
-      'should emit invoking a method with a single positional argument without '
-      'a trailing comma', () {
-    expect(
-      refer('foo').call([
-        literal(1),
-      ]),
-      equalsDart('foo(1)', trailingCommasEmitter),
-    );
-  });
-
-  test(
-      'should emit invoking a method with multiple positional arguments with a '
-      'trailing comma', () {
-    expect(
-      refer('foo').call([
-        literal(1),
-        literal(2),
-      ]),
-      equalsDart('foo(1, 2, )', trailingCommasEmitter),
-    );
-  });
-
-  test(
-      'should emit invoking a method with a positional argument and a named '
-      'argument with a trailing comma', () {
-    expect(
-      refer('foo').call([
-        literal(1),
-      ], {
-        'bar': literal(2),
-      }),
-      equalsDart('foo(1, bar: 2, )', trailingCommasEmitter),
-    );
-  });
-
-  test(
-      'should emit invoking a method with a named argument without a trailing '
-      'comma', () {
-    expect(
-      refer('foo').call([], {
-        'bar': literal(2),
-      }),
-      equalsDart('foo(bar: 2)', trailingCommasEmitter),
-    );
-  });
-
-  test(
-      'should emit invoking a method with multiple named arguments with a '
-      'trailing comma', () {
-    expect(
-      refer('foo').call([], {
-        'bar': literal(2),
-        'baz': literal(3),
-      }),
-      equalsDart('foo(bar: 2, baz: 3, )', trailingCommasEmitter),
+      equalsDart('foo(1, bar: 2, baz: 3, )'),
     );
   });
 
@@ -369,7 +287,7 @@ void main() {
       FunctionType((b) => b
         ..requiredParameters.add(refer('String'))
         ..optionalParameters.add(refer('int'))),
-      equalsDart('Function(String, [int])'),
+      equalsDart('Function(String, [int, ])'),
     );
   });
 
@@ -380,7 +298,7 @@ void main() {
           'x': refer('int'),
           'y': refer('int'),
         })),
-      equalsDart('Function({int x, int y})'),
+      equalsDart('Function({int x, int y, })'),
     );
   });
 
@@ -395,7 +313,7 @@ void main() {
         ..namedParameters.addAll({
           'y': refer('int'),
         })),
-      equalsDart('Function({required int x, int y})'),
+      equalsDart('Function({required int x, int y, })'),
     );
   });
 
@@ -406,7 +324,7 @@ void main() {
           'x': refer('int'),
           'y': refer('int'),
         })),
-      equalsDart('Function({required int x, required int y})'),
+      equalsDart('Function({required int x, required int y, })'),
     );
   });
 
@@ -455,7 +373,7 @@ void main() {
         literalString('foo'),
         Method((b) => b..body = literalTrue.code).closure,
       ]),
-      equalsDart("map.putIfAbsent('foo', () => true)"),
+      equalsDart("map.putIfAbsent('foo', () => true, )"),
     );
   });
 
@@ -467,7 +385,7 @@ void main() {
           ..types.add(refer('T'))
           ..body = literalTrue.code).genericClosure,
       ]),
-      equalsDart("map.putIfAbsent('foo', <T>() => true)"),
+      equalsDart("map.putIfAbsent('foo', <T>() => true, )"),
     );
   });
 

--- a/test/specs/method_test.dart
+++ b/test/specs/method_test.dart
@@ -10,6 +10,8 @@ import '../common.dart';
 void main() {
   useDartfmt();
 
+  final trailingCommasEmitter = DartEmitter(useTrailingCommas: true);
+
   test('should create a method', () {
     expect(
       Method((b) => b..name = 'foo'),
@@ -161,6 +163,101 @@ void main() {
       equalsDart(r'''
         String Function([int])
       '''),
+    );
+  });
+
+  test(
+      'should create a function type with an optional parameter without a '
+      'trailing comma', () {
+    expect(
+      FunctionType((b) => b
+        ..returnType = refer('String')
+        ..requiredParameters.add(refer('int'))),
+      equalsDart(r'''
+        String Function(int)
+      ''', trailingCommasEmitter),
+    );
+  });
+
+  test(
+      'should create a function type with multiple required parameters with a '
+      'trailing comma', () {
+    expect(
+      FunctionType((b) => b
+        ..returnType = refer('String')
+        ..requiredParameters.add(refer('int'))
+        ..requiredParameters.add(refer('String'))),
+      equalsDart(r'''
+        String Function(int, String, )
+      ''', trailingCommasEmitter),
+    );
+  });
+
+  test(
+      'should create a function type with an optional parameter without a '
+      'trailing comma', () {
+    expect(
+      FunctionType((b) => b
+        ..returnType = refer('String')
+        ..optionalParameters.add(refer('int'))),
+      equalsDart(r'''
+        String Function([int])
+      ''', trailingCommasEmitter),
+    );
+  });
+
+  test(
+      'should create a function type with multiple optional parameters with a '
+      'trailing comma', () {
+    expect(
+      FunctionType((b) => b
+        ..returnType = refer('String')
+        ..optionalParameters.add(refer('int'))
+        ..optionalParameters.add(refer('String'))),
+      equalsDart(r'''
+        String Function([int, String, ])
+      ''', trailingCommasEmitter),
+    );
+  });
+
+  test(
+      'should create a function type with a named parameter with a trailing '
+      'comma', () {
+    expect(
+      FunctionType((b) => b
+        ..returnType = refer('String')
+        ..namedParameters['bar'] = refer('int')),
+      equalsDart(r'''
+        String Function({int bar})
+      ''', trailingCommasEmitter),
+    );
+  });
+
+  test(
+      'should create a function type with multiple named parameters with a '
+      'trailing comma', () {
+    expect(
+      FunctionType((b) => b
+        ..returnType = refer('String')
+        ..namedParameters['bar'] = refer('int')
+        ..namedParameters['baz'] = refer('String')),
+      equalsDart(r'''
+        String Function({int bar, String baz, })
+      ''', trailingCommasEmitter),
+    );
+  });
+
+  test(
+      'should create a function type with a required parameter and a named '
+      'parameter with a trailing comma', () {
+    expect(
+      FunctionType((b) => b
+        ..returnType = refer('String')
+        ..requiredParameters.add(refer('int'))
+        ..namedParameters['bar'] = refer('int')),
+      equalsDart(r'''
+        String Function(int, {int bar, })
+      ''', trailingCommasEmitter),
     );
   });
 
@@ -347,7 +444,7 @@ void main() {
     );
   });
 
-  test('should create a method with a paremter', () {
+  test('should create a method with a parameter', () {
     expect(
       Method(
         (b) => b
@@ -588,6 +685,73 @@ void main() {
       equalsDart(r'''
         foo(a, {b});
       '''),
+    );
+  });
+
+  test(
+      'should create a method with a required parameter without a trailing '
+      'comma', () {
+    expect(
+      Method(
+        (b) => b
+          ..name = 'fib'
+          ..requiredParameters.add(Parameter((b) => b.name = 'i')),
+      ),
+      equalsDart(r'''
+        fib(i);
+      ''', trailingCommasEmitter),
+    );
+  });
+
+  test(
+      'should create a method with multiple required parameters with a '
+      'trailing comma', () {
+    expect(
+      Method(
+        (b) => b
+          ..name = 'fib'
+          ..requiredParameters.add(Parameter((b) => b.name = 'i'))
+          ..requiredParameters.add(Parameter((b) => b.name = 'j')),
+      ),
+      equalsDart(r'''
+        fib(i, j, );
+      ''', trailingCommasEmitter),
+    );
+  });
+
+  test(
+      'should create a method with a required parameter and an optional '
+      'parameter with a trailing comma', () {
+    expect(
+      Method(
+        (b) => b
+          ..name = 'fib'
+          ..requiredParameters.add(Parameter((b) => b.name = 'i'))
+          ..optionalParameters.add(Parameter((b) => b.name = 'j')),
+      ),
+      equalsDart(r'''
+        fib(i, [j, ]);
+      ''', trailingCommasEmitter),
+    );
+  });
+
+  test(
+      'should create a method with a required parameter and a named parameter '
+      'with a trailing comma', () {
+    expect(
+      Method(
+        (b) => b
+          ..name = 'fib'
+          ..requiredParameters.add(Parameter((b) => b.name = 'i'))
+          ..optionalParameters.add(Parameter(
+            (b) => b
+              ..named = true
+              ..name = 'j',
+          )),
+      ),
+      equalsDart(r'''
+        fib(i, {j, });
+      ''', trailingCommasEmitter),
     );
   });
 }

--- a/test/specs/method_test.dart
+++ b/test/specs/method_test.dart
@@ -10,8 +10,6 @@ import '../common.dart';
 void main() {
   useDartfmt();
 
-  final trailingCommasEmitter = DartEmitter(useTrailingCommas: true);
-
   test('should create a method', () {
     expect(
       Method((b) => b..name = 'foo'),
@@ -167,101 +165,6 @@ void main() {
   });
 
   test(
-      'should create a function type with an optional parameter without a '
-      'trailing comma', () {
-    expect(
-      FunctionType((b) => b
-        ..returnType = refer('String')
-        ..requiredParameters.add(refer('int'))),
-      equalsDart(r'''
-        String Function(int)
-      ''', trailingCommasEmitter),
-    );
-  });
-
-  test(
-      'should create a function type with multiple required parameters with a '
-      'trailing comma', () {
-    expect(
-      FunctionType((b) => b
-        ..returnType = refer('String')
-        ..requiredParameters.add(refer('int'))
-        ..requiredParameters.add(refer('String'))),
-      equalsDart(r'''
-        String Function(int, String, )
-      ''', trailingCommasEmitter),
-    );
-  });
-
-  test(
-      'should create a function type with an optional parameter without a '
-      'trailing comma', () {
-    expect(
-      FunctionType((b) => b
-        ..returnType = refer('String')
-        ..optionalParameters.add(refer('int'))),
-      equalsDart(r'''
-        String Function([int])
-      ''', trailingCommasEmitter),
-    );
-  });
-
-  test(
-      'should create a function type with multiple optional parameters with a '
-      'trailing comma', () {
-    expect(
-      FunctionType((b) => b
-        ..returnType = refer('String')
-        ..optionalParameters.add(refer('int'))
-        ..optionalParameters.add(refer('String'))),
-      equalsDart(r'''
-        String Function([int, String, ])
-      ''', trailingCommasEmitter),
-    );
-  });
-
-  test(
-      'should create a function type with a named parameter with a trailing '
-      'comma', () {
-    expect(
-      FunctionType((b) => b
-        ..returnType = refer('String')
-        ..namedParameters['bar'] = refer('int')),
-      equalsDart(r'''
-        String Function({int bar})
-      ''', trailingCommasEmitter),
-    );
-  });
-
-  test(
-      'should create a function type with multiple named parameters with a '
-      'trailing comma', () {
-    expect(
-      FunctionType((b) => b
-        ..returnType = refer('String')
-        ..namedParameters['bar'] = refer('int')
-        ..namedParameters['baz'] = refer('String')),
-      equalsDart(r'''
-        String Function({int bar, String baz, })
-      ''', trailingCommasEmitter),
-    );
-  });
-
-  test(
-      'should create a function type with a required parameter and a named '
-      'parameter with a trailing comma', () {
-    expect(
-      FunctionType((b) => b
-        ..returnType = refer('String')
-        ..requiredParameters.add(refer('int'))
-        ..namedParameters['bar'] = refer('int')),
-      equalsDart(r'''
-        String Function(int, {int bar, })
-      ''', trailingCommasEmitter),
-    );
-  });
-
-  test(
       'should create a function type with a required '
       'and an optional positional parameter', () {
     expect(
@@ -270,7 +173,7 @@ void main() {
         ..requiredParameters.add(refer('int'))
         ..optionalParameters.add(refer('int'))),
       equalsDart(r'''
-        String Function(int, [int])
+        String Function(int, [int, ])
       '''),
     );
   });
@@ -304,7 +207,7 @@ void main() {
         ..requiredParameters.add(refer('int'))
         ..namedParameters['named'] = refer('int')),
       equalsDart(r'''
-        String Function(int, {int named})
+        String Function(int, {int named, })
       '''),
     );
   });
@@ -329,7 +232,7 @@ void main() {
         ..namedRequiredParameters['named'] = refer('int')
         ..namedParameters['optional'] = refer('int')),
       equalsDart(r'''
-        String Function({required int named, int optional})
+        String Function({required int named, int optional, })
       '''),
     );
   });
@@ -537,7 +440,7 @@ void main() {
           ]),
       ),
       equalsDart(r'''
-        foo<T extends Iterable>(T t, X<T> x);
+        foo<T extends Iterable>(T t, X<T> x, );
       '''),
     );
   });
@@ -568,7 +471,7 @@ void main() {
           ]),
       ),
       equalsDart(r'''
-        foo([a, b]);
+        foo([a, b, ]);
       '''),
     );
   });
@@ -683,75 +586,8 @@ void main() {
           ),
       ),
       equalsDart(r'''
-        foo(a, {b});
+        foo(a, {b, });
       '''),
-    );
-  });
-
-  test(
-      'should create a method with a required parameter without a trailing '
-      'comma', () {
-    expect(
-      Method(
-        (b) => b
-          ..name = 'fib'
-          ..requiredParameters.add(Parameter((b) => b.name = 'i')),
-      ),
-      equalsDart(r'''
-        fib(i);
-      ''', trailingCommasEmitter),
-    );
-  });
-
-  test(
-      'should create a method with multiple required parameters with a '
-      'trailing comma', () {
-    expect(
-      Method(
-        (b) => b
-          ..name = 'fib'
-          ..requiredParameters.add(Parameter((b) => b.name = 'i'))
-          ..requiredParameters.add(Parameter((b) => b.name = 'j')),
-      ),
-      equalsDart(r'''
-        fib(i, j, );
-      ''', trailingCommasEmitter),
-    );
-  });
-
-  test(
-      'should create a method with a required parameter and an optional '
-      'parameter with a trailing comma', () {
-    expect(
-      Method(
-        (b) => b
-          ..name = 'fib'
-          ..requiredParameters.add(Parameter((b) => b.name = 'i'))
-          ..optionalParameters.add(Parameter((b) => b.name = 'j')),
-      ),
-      equalsDart(r'''
-        fib(i, [j, ]);
-      ''', trailingCommasEmitter),
-    );
-  });
-
-  test(
-      'should create a method with a required parameter and a named parameter '
-      'with a trailing comma', () {
-    expect(
-      Method(
-        (b) => b
-          ..name = 'fib'
-          ..requiredParameters.add(Parameter((b) => b.name = 'i'))
-          ..optionalParameters.add(Parameter(
-            (b) => b
-              ..named = true
-              ..name = 'j',
-          )),
-      ),
-      equalsDart(r'''
-        fib(i, {j, });
-      ''', trailingCommasEmitter),
     );
   });
 }


### PR DESCRIPTION
Fixes https://github.com/dart-lang/code_builder/issues/365

This adds trailing commas in various places according to the following rules:

* in a collection literal if there are more than one element
* in an argument list if there are more than one argument (positional or named)
* in a constructor parameter list, method parameter list, or function type parameter list, if there are more than one parameter (positional, optional, or named)

The last one was certainly the most complex, because of the optional/named delimiters (`[]`/`{}`).
* A parameter list with one positional or one optional or one named parameter does _not_ get a trailing comma.
* A parameter list with multiple positional parameters and no optional or named parameters gets a trailing comma.
* A parameter list with at least one optional parameter or at least one named parameter, and at least two parameters in total, gets a trailing comma before the closing delimiter (`]` or `}`).