### PR TITLE
Mention imports in the DartEmitter docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.3.1-dev
+
+* Mention how the `allocator` argument relates to imports in the `DartEmitter`
+  constructor doc.
+
 ## 4.3.0
 
 * Add support for adding more implementation in `enum` classes.

--- a/lib/src/emitter.dart
+++ b/lib/src/emitter.dart
@@ -70,7 +70,9 @@ class DartEmitter extends Object
 
   /// Creates a new instance of [DartEmitter].
   ///
-  /// May specify an [Allocator] to use for symbols, otherwise uses a no-op.
+  /// May specify an [Allocator] to use for references and imports,
+  /// otherwise uses [Allocator.none] which never prefixes references and will
+  /// not automatically emit import directives.
   DartEmitter(
       {this.allocator = Allocator.none,
       this.orderDirectives = false,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: code_builder
-version: 4.3.0
+version: 4.3.1-dev
 description: >-
   A fluent, builder-based library for generating valid Dart code
 repository: https://github.com/dart-lang/code_builder


### PR DESCRIPTION
This has come up as a point of confusion a few times - by default a `DartEmitter` will not emit any imports. Call out imports in the constructor doc comment.