### PR TITLE
reduce the use of trailing commas; add blank lines between groups of fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 4.4.1-dev
+
+* Only use trailing commas if a collection (parameter list, ...) has many
+  elements.
+* Don't use trailing commas for parameters lists without optional arguments.
+
 ## 4.4.0
 
 * Mention how the `allocator` argument relates to imports in the `DartEmitter`
@@ -5,9 +11,6 @@
 * Add support for emitting typedefs.
 * Add support for emitting leading line comments for libraries.
 * Add support for emitting `ignore_for_file` analyzer directive comments.
-* Only use trailing commas if a collection (parameter list, ...) has many
-  elements.
-* Don't use trailing commas for parameters lists without optional arguments.
 
 ## 4.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add support for emitting `ignore_for_file` analyzer directive comments.
 * Only use trailing commas if a collection (parameter list, ...) has many
   elements.
+* Don't use trailing commas for parameters lists without optional arguments.
 
 ## 4.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## 4.5.0-dev
 
-* Only use trailing commas if a collection (parameter list, ...) has many
+* Use trailing commas for methods with more than a few parameters.
+* Use trailing commas for collections (parameter list, ...) with more than a few
   elements.
-* Don't use trailing commas for parameters lists without optional arguments.
 
 ## 4.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 4.4.1-dev
+## 4.5.0-dev
 
 * Only use trailing commas if a collection (parameter list, ...) has many
   elements.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 4.3.1
+## 4.4.0
 
 * Mention how the `allocator` argument relates to imports in the `DartEmitter`
   constructor doc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
-## 4.3.1-dev
+## 4.3.1
 
 * Mention how the `allocator` argument relates to imports in the `DartEmitter`
   constructor doc.
 * Add support for emitting typedefs.
 * Add support for emitting leading line comments for libraries.
 * Add support for emitting `ignore_for_file` analyzer directive comments.
+* Only use trailing commas if a collection (parameter list, ...) has many
+  elements.
 
 ## 4.3.0
 

--- a/lib/src/emitter.dart
+++ b/lib/src/emitter.dart
@@ -141,16 +141,25 @@ class DartEmitter extends Object
       visitConstructor(c, spec.name, out);
       out.writeln();
     }
-    for (var f in spec.fields) {
-      visitField(f, out);
+    if (spec.fields.isNotEmpty) {
       out.writeln();
-    }
-    for (var m in spec.methods) {
-      visitMethod(m, out);
-      if (_isLambdaMethod(m)) {
-        out.write(';');
+      var isStatic = spec.fields.isEmpty ? null : spec.fields.first.static;
+      for (var f in spec.fields) {
+        if (isStatic != f.static) out.writeln();
+        isStatic = f.static;
+        visitField(f, out);
+        out.writeln();
       }
+    }
+    if (spec.methods.isNotEmpty) {
       out.writeln();
+      for (var m in spec.methods) {
+        visitMethod(m, out);
+        if (_isLambdaMethod(m)) {
+          out.write(';');
+        }
+        out.writeln();
+      }
     }
     out.writeln(' }');
     return out;
@@ -223,8 +232,7 @@ class DartEmitter extends Object
       for (final p in spec.requiredParameters) {
         count++;
         _visitParameter(p, output);
-        if (hasMultipleParameters ||
-            spec.requiredParameters.length != count ||
+        if (spec.requiredParameters.length != count ||
             spec.optionalParameters.isNotEmpty) {
           output.write(', ');
         }
@@ -391,7 +399,7 @@ class DartEmitter extends Object
         spec.assignment!.accept(this, output);
       });
     }
-    output.writeln(';');
+    output.write(';');
     return output;
   }
 
@@ -585,8 +593,7 @@ class DartEmitter extends Object
         for (final p in spec.requiredParameters) {
           count++;
           _visitParameter(p, output);
-          if (hasMultipleParameters ||
-              spec.requiredParameters.length != count ||
+          if (spec.requiredParameters.length != count ||
               spec.optionalParameters.isNotEmpty) {
             output.write(', ');
           }
@@ -773,7 +780,10 @@ class DartEmitter extends Object
       visitConstructor(c, spec.name, out);
       out.writeln();
     }
+    var isStatic = spec.fields.isEmpty ? null : spec.fields.first.static;
     for (var f in spec.fields) {
+      if (isStatic != f.static) out.writeln();
+      isStatic = f.static;
       visitField(f, out);
       out.writeln();
     }

--- a/lib/src/emitter.dart
+++ b/lib/src/emitter.dart
@@ -21,6 +21,8 @@ import 'specs/type_reference.dart';
 import 'specs/typedef.dart';
 import 'visitors.dart';
 
+const _useTrailingCommaCount = 3;
+
 /// Helper method improving on [StringSink.writeAll].
 ///
 /// For every `Spec` in [elements], executing [visit].
@@ -222,15 +224,17 @@ class DartEmitter extends Object
         ..write(spec.name);
     }
     output.write('(');
-    final hasMultipleParameters =
-        spec.requiredParameters.length + spec.optionalParameters.length > 1;
+    final useTrailingCommas =
+        spec.requiredParameters.length + spec.optionalParameters.length >
+            _useTrailingCommaCount;
     if (spec.requiredParameters.isNotEmpty) {
       var count = 0;
       for (final p in spec.requiredParameters) {
         count++;
         _visitParameter(p, output);
-        if (spec.requiredParameters.length != count ||
-            spec.optionalParameters.isNotEmpty) {
+        if (spec.requiredParameters.length != count) {
+          output.write(', ');
+        } else if (useTrailingCommas || spec.optionalParameters.isNotEmpty) {
           output.write(', ');
         }
       }
@@ -246,7 +250,7 @@ class DartEmitter extends Object
       for (final p in spec.optionalParameters) {
         count++;
         _visitParameter(p, output, optional: true, named: named);
-        if (hasMultipleParameters || spec.optionalParameters.length != count) {
+        if (useTrailingCommas || spec.optionalParameters.length != count) {
           output.write(', ');
         }
       }
@@ -583,15 +587,17 @@ class DartEmitter extends Object
       }
       visitTypeParameters(spec.types.map((r) => r.type), output);
       output.write('(');
-      final hasMultipleParameters =
-          spec.requiredParameters.length + spec.optionalParameters.length > 1;
+      final useTrailingCommas =
+          spec.requiredParameters.length + spec.optionalParameters.length >
+              _useTrailingCommaCount;
       if (spec.requiredParameters.isNotEmpty) {
         var count = 0;
         for (final p in spec.requiredParameters) {
           count++;
           _visitParameter(p, output);
-          if (spec.requiredParameters.length != count ||
-              spec.optionalParameters.isNotEmpty) {
+          if (spec.requiredParameters.length != count) {
+            output.write(', ');
+          } else if (useTrailingCommas || spec.optionalParameters.isNotEmpty) {
             output.write(', ');
           }
         }
@@ -607,8 +613,7 @@ class DartEmitter extends Object
         for (final p in spec.optionalParameters) {
           count++;
           _visitParameter(p, output, optional: true, named: named);
-          if (hasMultipleParameters ||
-              spec.optionalParameters.length != count) {
+          if (useTrailingCommas || spec.optionalParameters.length != count) {
             output.write(', ');
           }
         }

--- a/lib/src/emitter.dart
+++ b/lib/src/emitter.dart
@@ -143,10 +143,7 @@ class DartEmitter extends Object
     }
     if (spec.fields.isNotEmpty) {
       out.writeln();
-      var isStatic = spec.fields.isEmpty ? null : spec.fields.first.static;
       for (var f in spec.fields) {
-        if (isStatic != f.static) out.writeln();
-        isStatic = f.static;
         visitField(f, out);
         out.writeln();
       }
@@ -780,10 +777,7 @@ class DartEmitter extends Object
       visitConstructor(c, spec.name, out);
       out.writeln();
     }
-    var isStatic = spec.fields.isEmpty ? null : spec.fields.first.static;
     for (var f in spec.fields) {
-      if (isStatic != f.static) out.writeln();
-      isStatic = f.static;
       visitField(f, out);
       out.writeln();
     }

--- a/lib/src/specs/expression.dart
+++ b/lib/src/specs/expression.dart
@@ -21,7 +21,7 @@ part 'expression/invoke.dart';
 part 'expression/literal.dart';
 part 'expression/parenthesized.dart';
 
-/// Represents a [code] block that wraps an [Expression].
+const _useTrailingCommaCount = 3;
 
 /// Represents a Dart expression.
 ///
@@ -383,6 +383,7 @@ Code createTypeDef(String name, FunctionType type) => BinaryExpression._(
         LiteralExpression._('typedef $name'), type.expression, '=')
     .statement;
 
+/// Represents a [Code] block that wraps an [Expression].
 class ToCodeExpression implements Code {
   final Expression code;
 
@@ -499,7 +500,7 @@ abstract class ExpressionEmitter implements ExpressionVisitor<StringSink> {
       });
       final argumentCount = expression.positionalArguments.length +
           expression.namedArguments.length;
-      if (argumentCount > 3) {
+      if (argumentCount > _useTrailingCommaCount) {
         out.write(', ');
       }
       return out..write(')');
@@ -540,7 +541,7 @@ abstract class ExpressionEmitter implements ExpressionVisitor<StringSink> {
       visitAll<Object?>(expression.values, out, (value) {
         _acceptLiteral(value, out);
       });
-      if (expression.values.length > 3) {
+      if (expression.values.length > _useTrailingCommaCount) {
         out.write(', ');
       }
       return out..write(']');

--- a/lib/src/specs/expression.dart
+++ b/lib/src/specs/expression.dart
@@ -499,7 +499,7 @@ abstract class ExpressionEmitter implements ExpressionVisitor<StringSink> {
       });
       final argumentCount = expression.positionalArguments.length +
           expression.namedArguments.length;
-      if (argumentCount > 1) {
+      if (argumentCount > 3) {
         out.write(', ');
       }
       return out..write(')');
@@ -540,7 +540,7 @@ abstract class ExpressionEmitter implements ExpressionVisitor<StringSink> {
       visitAll<Object?>(expression.values, out, (value) {
         _acceptLiteral(value, out);
       });
-      if (expression.values.length > 1) {
+      if (expression.values.length > 3) {
         out.write(', ');
       }
       return out..write(']');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: code_builder
-version: 4.3.1
+version: 4.4.0
 description: >-
   A fluent, builder-based library for generating valid Dart code
 repository: https://github.com/dart-lang/code_builder

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: code_builder
-version: 4.4.0
+version: 4.4.1-dev
 description: >-
   A fluent, builder-based library for generating valid Dart code
 repository: https://github.com/dart-lang/code_builder

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: code_builder
-version: 4.3.1-dev
+version: 4.3.1
 description: >-
   A fluent, builder-based library for generating valid Dart code
 repository: https://github.com/dart-lang/code_builder

--- a/test/e2e/injection_test.dart
+++ b/test/e2e/injection_test.dart
@@ -45,7 +45,7 @@ void main() {
           final Module _module;
 
           @override
-          Thing getThing() => Thing(_module.get1(), _module.get2(), );
+          Thing getThing() => Thing(_module.get1(), _module.get2());
         }
       '''),
     );
@@ -59,7 +59,7 @@ void main() {
           final _i2.Module _module;
 
           @override
-          _i3.Thing getThing() => _i3.Thing(_module.get1(), _module.get2(), );
+          _i3.Thing getThing() => _i3.Thing(_module.get1(), _module.get2());
         }
       ''', DartEmitter(allocator: Allocator.simplePrefixing())),
     );

--- a/test/specs/class_test.dart
+++ b/test/specs/class_test.dart
@@ -328,7 +328,7 @@ void main() {
           ])))),
       equalsDart(r'''
         class Foo {
-          Foo(a, b, {c, });
+          Foo(a, b, {c});
         }
       '''),
     );
@@ -355,7 +355,7 @@ void main() {
           ])))),
       equalsDart(r'''
         class Foo {
-          Foo(this.a, this.b, {this.c, });
+          Foo(this.a, this.b, {this.c});
         }
       '''),
     );
@@ -382,7 +382,77 @@ void main() {
           ])))),
       equalsDart(r'''
         class Foo {
-          Foo(super.a, super.b, {super.c, });
+          Foo(super.a, super.b, {super.c});
+        }
+      '''),
+    );
+  });
+
+  test('constructors with one parameter lack trailing commas', () {
+    expect(
+      Class((b) => b
+        ..name = 'Foo'
+        ..constructors.add(Constructor((b) => b
+          ..requiredParameters.addAll([
+            Parameter((b) => b..name = 'a'),
+          ])))),
+      equalsDart(r'''
+        class Foo {
+          Foo(a);
+        }
+      '''),
+    );
+  });
+
+  test('constructors with two parameters lack trailing commas', () {
+    expect(
+      Class((b) => b
+        ..name = 'Foo'
+        ..constructors.add(Constructor((b) => b
+          ..requiredParameters.addAll([
+            Parameter((b) => b..name = 'a'),
+            Parameter((b) => b..name = 'b'),
+          ])))),
+      equalsDart(r'''
+        class Foo {
+          Foo(a, b);
+        }
+      '''),
+    );
+  });
+
+  test('constructors with three parameters lack trailing commas', () {
+    expect(
+      Class((b) => b
+        ..name = 'Foo'
+        ..constructors.add(Constructor((b) => b
+          ..requiredParameters.addAll([
+            Parameter((b) => b..name = 'a'),
+            Parameter((b) => b..name = 'b'),
+            Parameter((b) => b..name = 'c'),
+          ])))),
+      equalsDart(r'''
+        class Foo {
+          Foo(a, b, c);
+        }
+      '''),
+    );
+  });
+
+  test('constructors with four parameters have trailing commas', () {
+    expect(
+      Class((b) => b
+        ..name = 'Foo'
+        ..constructors.add(Constructor((b) => b
+          ..requiredParameters.addAll([
+            Parameter((b) => b..name = 'a'),
+            Parameter((b) => b..name = 'b'),
+            Parameter((b) => b..name = 'c'),
+            Parameter((b) => b..name = 'd'),
+          ])))),
+      equalsDart(r'''
+        class Foo {
+          Foo(a, b, c, d, );
         }
       '''),
     );

--- a/test/specs/code/expression_test.dart
+++ b/test/specs/code/expression_test.dart
@@ -190,7 +190,7 @@ void main() {
         literal(2),
         literal(3),
       ]),
-      equalsDart('foo(1, 2, 3, )'),
+      equalsDart('foo(1, 2, 3)'),
     );
   });
 
@@ -209,7 +209,7 @@ void main() {
         'bar': literal(1),
         'baz': literal(2),
       }),
-      equalsDart('foo(bar: 1, baz: 2, )'),
+      equalsDart('foo(bar: 1, baz: 2)'),
     );
   });
 
@@ -221,7 +221,7 @@ void main() {
         'bar': literal(2),
         'baz': literal(3),
       }),
-      equalsDart('foo(1, bar: 2, baz: 3, )'),
+      equalsDart('foo(1, bar: 2, baz: 3)'),
     );
   });
 
@@ -373,7 +373,7 @@ void main() {
         literalString('foo'),
         Method((b) => b..body = literalTrue.code).closure,
       ]),
-      equalsDart("map.putIfAbsent('foo', () => true, )"),
+      equalsDart("map.putIfAbsent('foo', () => true)"),
     );
   });
 
@@ -385,7 +385,7 @@ void main() {
           ..types.add(refer('T'))
           ..body = literalTrue.code).genericClosure,
       ]),
-      equalsDart("map.putIfAbsent('foo', <T>() => true, )"),
+      equalsDart("map.putIfAbsent('foo', <T>() => true)"),
     );
   });
 

--- a/test/specs/enum_test.dart
+++ b/test/specs/enum_test.dart
@@ -335,7 +335,6 @@ void main() {
       const MyEnum([this.myInt]);
 
       final int? myInt;
-
       static const String myString = 'abc';
     }
     '''));

--- a/test/specs/enum_test.dart
+++ b/test/specs/enum_test.dart
@@ -201,10 +201,8 @@ void main() {
 
       const MyEnum();
 
-      const factory MyEnum.redirect([
-          int? myInt,
-          String? myString,
-      ]) = MyOtherEnum.named;
+      const factory MyEnum.redirect([int? myInt, String? myString])
+          = MyOtherEnum.named;
     }
     '''));
   });
@@ -248,10 +246,7 @@ void main() {
       b(1, 'abc'),
       c;
 
-      const MyEnum([
-          this.myInt,
-          this.myString,
-      ]);
+      const MyEnum([this.myInt, this.myString]);
 
       final int? myInt;
       final String? myString;

--- a/test/specs/enum_test.dart
+++ b/test/specs/enum_test.dart
@@ -254,7 +254,6 @@ void main() {
       ]);
 
       final int? myInt;
-
       final String? myString;
     }
     '''));

--- a/test/specs/method_test.dart
+++ b/test/specs/method_test.dart
@@ -495,7 +495,7 @@ void main() {
           ]),
       ),
       equalsDart(r'''
-        foo([a, b, ]);
+        foo([a, b]);
       '''),
     );
   });
@@ -610,7 +610,7 @@ void main() {
           ),
       ),
       equalsDart(r'''
-        foo(a, {b, });
+        foo(a, {b});
       '''),
     );
   });
@@ -626,6 +626,72 @@ void main() {
       ).closure,
       equalsDart(r'''
         (a) { }
+      '''),
+    );
+  });
+
+  test('methods with one parameter lack trailing commas', () {
+    expect(
+      Method(
+        (b) => b
+          ..name = 'fib'
+          ..requiredParameters.addAll([
+            Parameter((b) => b.name = 'a'),
+          ]),
+      ),
+      equalsDart(r'''
+        fib(a);
+      '''),
+    );
+  });
+
+  test('methods with two parameters lack trailing commas', () {
+    expect(
+      Method(
+        (b) => b
+          ..name = 'fib'
+          ..requiredParameters.addAll([
+            Parameter((b) => b.name = 'a'),
+            Parameter((b) => b.name = 'b'),
+          ]),
+      ),
+      equalsDart(r'''
+        fib(a, b);
+      '''),
+    );
+  });
+
+  test('methods with three parameters lack trailing commas', () {
+    expect(
+      Method(
+        (b) => b
+          ..name = 'fib'
+          ..requiredParameters.addAll([
+            Parameter((b) => b.name = 'a'),
+            Parameter((b) => b.name = 'b'),
+            Parameter((b) => b.name = 'c'),
+          ]),
+      ),
+      equalsDart(r'''
+        fib(a, b, c);
+      '''),
+    );
+  });
+
+  test('methods with four parameters have trailing commas', () {
+    expect(
+      Method(
+        (b) => b
+          ..name = 'fib'
+          ..requiredParameters.addAll([
+            Parameter((b) => b.name = 'a'),
+            Parameter((b) => b.name = 'b'),
+            Parameter((b) => b.name = 'c'),
+            Parameter((b) => b.name = 'd'),
+          ]),
+      ),
+      equalsDart(r'''
+        fib(a, b, c, d, );
       '''),
     );
   });

--- a/test/specs/method_test.dart
+++ b/test/specs/method_test.dart
@@ -464,7 +464,7 @@ void main() {
           ]),
       ),
       equalsDart(r'''
-        foo<T extends Iterable>(T t, X<T> x, );
+        foo<T extends Iterable>(T t, X<T> x);
       '''),
     );
   });


### PR DESCRIPTION
- reduce the use of trailing commas
- add blank lines between groups of fields
- rev the minor version of the package (I realized I added new API in the previous PRs)
- rev to a non-dev version in prep for publishing

The two whitespace changes aren't critical but they do make the (post-dartfmt) code I'm generating look better. That's dialing back the use of trailing commas for situations where you likely don't need them, and adding blank lines between different types of field groups (static fields and then instance fields).
