### PR TITLE
Add support for spreads in literal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,23 @@
-## 4.4.1-dev
+## 4.5.0-dev
+
+* Add `literalSpread` and `literalNullSafeSpread` to support adding spreads to
+  `literalMap`.
+
+```dart
+void main() {
+  // Creates a map
+  // {
+  //   ...one,
+  //   2: two,
+  //   ...?three,
+  // }
+  final map = literalMap({
+    literalSpread(): refer('one'),
+    2: refer('two'),
+    literalNullSafeSpread(): refer('three'),
+  });
+}
+```
 
 ## 4.4.0
 

--- a/lib/src/specs/expression.dart
+++ b/lib/src/specs/expression.dart
@@ -593,7 +593,9 @@ abstract class ExpressionEmitter implements ExpressionVisitor<StringSink> {
       visitAll<Object?>(expression.values.keys, out, (key) {
         final value = expression.values[key];
         _acceptLiteral(key, out);
-        out.write(': ');
+        if (key is! LiteralSpreadExpression) {
+          out.write(': ');
+        }
         _acceptLiteral(value, out);
       });
       if (expression.values.length > 1) {

--- a/lib/src/specs/expression/literal.dart
+++ b/lib/src/specs/expression/literal.dart
@@ -65,6 +65,20 @@ Expression literalString(String value, {bool raw = false}) {
   return LiteralExpression._("${raw ? 'r' : ''}'$escaped'");
 }
 
+/// Create a literal `...` operator for use when creating a Map literal.
+///
+/// *NOTE* This is used as a sentinel when constructing a `literalMap` or a
+/// or `literalConstMap` to signify that the value should be spread. Do NOT
+/// reuse the value when creating a Map with multiple spreads.
+Expression literalSpread() => LiteralSpreadExpression._(false);
+
+/// Create a literal `...?` operator for use when creating a Map literal.
+///
+/// *NOTE* This is used as a sentinel when constructing a `literalMap` or a
+/// or `literalConstMap` to signify that the value should be spread. Do NOT
+/// reuse the value when creating a Map with multiple spreads.
+Expression literalNullSafeSpread() => LiteralSpreadExpression._(true);
+
 /// Creates a literal list expression from [values].
 LiteralListExpression literalList(Iterable<Object?> values,
         [Reference? type]) =>
@@ -120,6 +134,11 @@ class LiteralExpression extends Expression {
 
   @override
   String toString() => literal;
+}
+
+class LiteralSpreadExpression extends LiteralExpression {
+  LiteralSpreadExpression._(bool nullAware)
+      : super._('...${nullAware ? '?' : ''}');
 }
 
 class LiteralListExpression extends Expression {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: code_builder
-version: 4.4.1-dev
+version: 4.5.0-dev
 description: >-
   A fluent, builder-based library for generating valid Dart code
 repository: https://github.com/dart-lang/code_builder

--- a/test/specs/code/expression_test.dart
+++ b/test/specs/code/expression_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:code_builder/code_builder.dart';
+import 'package:code_builder/src/specs/expression.dart';
 import 'package:test/test.dart';
 
 import '../../common.dart';
@@ -97,6 +98,18 @@ void main() {
         refer('Map').newInstance([]): null,
       }),
       equalsDart(r"{1: 'one', 2: two, three: 3, Map(): null, }"),
+    );
+  });
+
+  test('should emit a map with spreads', () {
+    expect(
+      literalMap({
+        literalSpread(): refer('one'),
+        2: refer('two'),
+        literalNullSafeSpread(): refer('three'),
+        refer('Map').newInstance([]): null,
+      }),
+      equalsDart('{...one, 2: two, ...?three, Map(): null, }'),
     );
   });
 


### PR DESCRIPTION
Adds a `trailing` parameter which allows the addition of a spread expression. The `Expression` isn't wrapped in a spread automatically because there are two types of spreads.