### PR TITLE
Failing test for assigning to nullable typed var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 4.4.1-dev
+
 ## 4.4.0
 
 * Mention how the `allocator` argument relates to imports in the `DartEmitter`

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: code_builder
-version: 4.4.0
+version: 4.4.1-dev
 description: >-
   A fluent, builder-based library for generating valid Dart code
 repository: https://github.com/dart-lang/code_builder

--- a/test/specs/code/expression_test.dart
+++ b/test/specs/code/expression_test.dart
@@ -639,6 +639,16 @@ void main() {
         equalsDart('final String foo = bar'));
   });
 
+  test('should emit a nullable typed final variable declaration', () {
+    final emitter = DartEmitter.scoped(useNullSafetySyntax: true);
+    expect(
+        declareFinal('foo',
+            type: TypeReference((b) => b
+              ..symbol = 'String'
+              ..isNullable = true)).assign(refer('bar')),
+        equalsDart('final String? foo = bar', emitter));
+  }, skip: 'https://github.com/dart-lang/code_builder/issues/315');
+
   test('should emit a late final variable declaration', () {
     expect(declareFinal('foo', late: true).assign(refer('bar')),
         equalsDart('late final foo = bar'));


### PR DESCRIPTION
Towards #315

Add a skipped test which demonstrates that the nullability of a type
reference is ignored when emitting a variable assignment.
