### PR TITLE
Show spread literals

### DIFF
--- a/lib/code_builder.dart
+++ b/lib/code_builder.dart
@@ -40,6 +40,8 @@ export 'src/specs/expression.dart'
         literalMap,
         literalConstMap,
         literalString,
+        literalSpread,
+        literalNullSafeSpread,
         literalTrue,
         literalFalse;
 export 'src/specs/extension.dart' show Extension, ExtensionBuilder;

--- a/test/specs/code/expression_test.dart
+++ b/test/specs/code/expression_test.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:code_builder/code_builder.dart';
-import 'package:code_builder/src/specs/expression.dart';
 import 'package:test/test.dart';
 
 import '../../common.dart';


### PR DESCRIPTION
Add `literalSpread` and `literalNullSafeSpread` to the exports for `expression.dart`.