### PR TITLE
Fix CHANGELOG.md and export record-related APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 4.6.0-dev
 
 * Add support for class modifiers.
+* Add support for records (both types and record literals).
 
 ## 4.5.0
 
@@ -24,7 +25,6 @@ void main() {
   });
 }
 ```
-* Add support for records (both types and record literals).
 
 ## 4.4.0
 

--- a/lib/code_builder.dart
+++ b/lib/code_builder.dart
@@ -33,6 +33,7 @@ export 'src/specs/expression.dart'
         literalBool,
         literalConstList,
         literalConstMap,
+        literalConstRecord,
         literalConstSet,
         literalFalse,
         literalList,
@@ -40,6 +41,7 @@ export 'src/specs/expression.dart'
         literalNull,
         literalNullSafeSpread,
         literalNum,
+        literalRecord,
         literalSet,
         literalSpread,
         literalString,
@@ -58,5 +60,6 @@ export 'src/specs/method.dart'
 export 'src/specs/mixin.dart' show Mixin, MixinBuilder;
 export 'src/specs/reference.dart' show Reference, refer;
 export 'src/specs/type_function.dart' show FunctionType, FunctionTypeBuilder;
+export 'src/specs/type_record.dart' show RecordType, RecordTypeBuilder;
 export 'src/specs/type_reference.dart' show TypeReference, TypeReferenceBuilder;
 export 'src/specs/typedef.dart' show TypeDef, TypeDefBuilder;

--- a/test/specs/code/expression_test.dart
+++ b/test/specs/code/expression_test.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:code_builder/code_builder.dart';
-import 'package:code_builder/src/specs/expression.dart';
 import 'package:test/test.dart';
 
 import '../../common.dart';

--- a/test/specs/record_type_test.dart
+++ b/test/specs/record_type_test.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:code_builder/code_builder.dart';
-import 'package:code_builder/src/specs/type_record.dart';
 import 'package:test/test.dart';
 
 import '../common.dart';


### PR DESCRIPTION
- Fixed changelog entry for records support (records didn't make it to 4.5.0).
- Exported record-related APIs.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

#### Contribution guidelines:

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

(note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback)
