### PR TITLE
Prepare to publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,9 @@
-## 4.6.0-dev
-
-* Add support for class modifiers.
-* Add support for records (both types and record literals).
-
 ## 4.5.0
 
 * Require Dart 2.19
 * Add support for emitting type parameters for typedefs.
+* Add support for class modifiers.
+* Add support for records (both types and record literals).
 * Add `literalSpread` and `literalNullSafeSpread` to support adding spreads to
   `literalMap`.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: code_builder
-version: 4.6.0-dev
+version: 4.5.0
 description: >-
   A fluent, builder-based library for generating valid Dart code
 repository: https://github.com/dart-lang/code_builder


### PR DESCRIPTION
Collapse changelog back to `4.5.0` version which was never published.
