### PR TITLE
added support of external keyword for field builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.7.0
+
+* Add support of external keyword for fieldBuilder
+
 ## 4.6.0-wip
 
 * Add support for named arguments in `enum` classes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,7 @@
-## 4.7.0
-
-* Add support of external keyword for fieldBuilder
-
 ## 4.6.0-wip
 
 * Add support for named arguments in `enum` classes
+* Add support for external keyword on fields.
 
 ## 4.5.0
 

--- a/lib/src/emitter.dart
+++ b/lib/src/emitter.dart
@@ -28,11 +28,11 @@ import 'visitors.dart';
 ///
 /// If [elements] is at least 2 elements, inserts [separator] delimiting them.
 StringSink visitAll<T>(
-    Iterable<T> elements,
-    StringSink output,
-    void Function(T) visit, [
-      String separator = ', ',
-    ]) {
+  Iterable<T> elements,
+  StringSink output,
+  void Function(T) visit, [
+  String separator = ', ',
+]) {
   // Basically, this whole method is an improvement on
   //   output.writeAll(specs.map((s) => s.accept(visitor));
   //
@@ -77,13 +77,13 @@ class DartEmitter extends Object
   /// not automatically emit import directives.
   DartEmitter(
       {this.allocator = Allocator.none,
-        this.orderDirectives = false,
-        bool useNullSafetySyntax = false})
+      this.orderDirectives = false,
+      bool useNullSafetySyntax = false})
       : _useNullSafetySyntax = useNullSafetySyntax;
 
   /// Creates a new instance of [DartEmitter] with simple automatic imports.
   factory DartEmitter.scoped(
-      {bool orderDirectives = false, bool useNullSafetySyntax = false}) =>
+          {bool orderDirectives = false, bool useNullSafetySyntax = false}) =>
       DartEmitter(
           allocator: Allocator.simplePrefixing(),
           orderDirectives: orderDirectives,
@@ -99,7 +99,7 @@ class DartEmitter extends Object
   /// Whether the provided [constructor] is considered a lambda method.
   static bool _isLambdaConstructor(Constructor constructor) =>
       constructor.lambda ??
-          constructor.factory && _isLambdaBody(constructor.body);
+      constructor.factory && _isLambdaBody(constructor.body);
 
   @override
   StringSink visitAnnotation(Expression spec, [StringSink? output]) {
@@ -502,9 +502,9 @@ class DartEmitter extends Object
     }
     out.write('(');
     final needsTrailingComma = spec.requiredParameters.length +
-        spec.optionalParameters.length +
-        spec.namedRequiredParameters.length +
-        spec.namedParameters.length >
+            spec.optionalParameters.length +
+            spec.namedRequiredParameters.length +
+            spec.namedParameters.length >
         1;
     visitAll<Reference>(spec.requiredParameters, out, (spec) {
       spec.accept(this, out);
@@ -569,10 +569,10 @@ class DartEmitter extends Object
       }
       out.write('{');
       visitAll<MapEntry<String, Reference>>(spec.namedFieldTypes.entries, out,
-              (entry) {
-            entry.value.accept(this, out);
-            out.write(' ${entry.key}');
-          });
+          (entry) {
+        entry.value.accept(this, out);
+        out.write(' ${entry.key}');
+      });
       out.write('}');
     } else if (spec.positionalFieldTypes.length == 1) {
       out.write(',');
@@ -701,11 +701,11 @@ class DartEmitter extends Object
 
   // Expose as a first-class visit function only if needed.
   void _visitParameter(
-      Parameter spec,
-      StringSink output, {
-        bool optional = false,
-        bool named = false,
-      }) {
+    Parameter spec,
+    StringSink output, {
+    bool optional = false,
+    bool named = false,
+  }) {
     spec.docs.forEach(output.writeln);
     for (var a in spec.annotations) {
       visitAnnotation(a, output);

--- a/lib/src/emitter.dart
+++ b/lib/src/emitter.dart
@@ -28,11 +28,11 @@ import 'visitors.dart';
 ///
 /// If [elements] is at least 2 elements, inserts [separator] delimiting them.
 StringSink visitAll<T>(
-  Iterable<T> elements,
-  StringSink output,
-  void Function(T) visit, [
-  String separator = ', ',
-]) {
+    Iterable<T> elements,
+    StringSink output,
+    void Function(T) visit, [
+      String separator = ', ',
+    ]) {
   // Basically, this whole method is an improvement on
   //   output.writeAll(specs.map((s) => s.accept(visitor));
   //
@@ -77,13 +77,13 @@ class DartEmitter extends Object
   /// not automatically emit import directives.
   DartEmitter(
       {this.allocator = Allocator.none,
-      this.orderDirectives = false,
-      bool useNullSafetySyntax = false})
+        this.orderDirectives = false,
+        bool useNullSafetySyntax = false})
       : _useNullSafetySyntax = useNullSafetySyntax;
 
   /// Creates a new instance of [DartEmitter] with simple automatic imports.
   factory DartEmitter.scoped(
-          {bool orderDirectives = false, bool useNullSafetySyntax = false}) =>
+      {bool orderDirectives = false, bool useNullSafetySyntax = false}) =>
       DartEmitter(
           allocator: Allocator.simplePrefixing(),
           orderDirectives: orderDirectives,
@@ -99,7 +99,7 @@ class DartEmitter extends Object
   /// Whether the provided [constructor] is considered a lambda method.
   static bool _isLambdaConstructor(Constructor constructor) =>
       constructor.lambda ??
-      constructor.factory && _isLambdaBody(constructor.body);
+          constructor.factory && _isLambdaBody(constructor.body);
 
   @override
   StringSink visitAnnotation(Expression spec, [StringSink? output]) {
@@ -386,6 +386,9 @@ class DartEmitter extends Object
     if (spec.late && _useNullSafetySyntax) {
       output.write('late ');
     }
+    if (spec.external) {
+      output.write('external ');
+    }
     switch (spec.modifier) {
       case FieldModifier.var$:
         if (spec.type == null) {
@@ -499,9 +502,9 @@ class DartEmitter extends Object
     }
     out.write('(');
     final needsTrailingComma = spec.requiredParameters.length +
-            spec.optionalParameters.length +
-            spec.namedRequiredParameters.length +
-            spec.namedParameters.length >
+        spec.optionalParameters.length +
+        spec.namedRequiredParameters.length +
+        spec.namedParameters.length >
         1;
     visitAll<Reference>(spec.requiredParameters, out, (spec) {
       spec.accept(this, out);
@@ -566,10 +569,10 @@ class DartEmitter extends Object
       }
       out.write('{');
       visitAll<MapEntry<String, Reference>>(spec.namedFieldTypes.entries, out,
-          (entry) {
-        entry.value.accept(this, out);
-        out.write(' ${entry.key}');
-      });
+              (entry) {
+            entry.value.accept(this, out);
+            out.write(' ${entry.key}');
+          });
       out.write('}');
     } else if (spec.positionalFieldTypes.length == 1) {
       out.write(',');
@@ -698,11 +701,11 @@ class DartEmitter extends Object
 
   // Expose as a first-class visit function only if needed.
   void _visitParameter(
-    Parameter spec,
-    StringSink output, {
-    bool optional = false,
-    bool named = false,
-  }) {
+      Parameter spec,
+      StringSink output, {
+        bool optional = false,
+        bool named = false,
+      }) {
     spec.docs.forEach(output.writeln);
     for (var a in spec.annotations) {
       visitAnnotation(a, output);

--- a/lib/src/specs/field.dart
+++ b/lib/src/specs/field.dart
@@ -53,9 +53,9 @@ abstract class Field extends Object
 
   @override
   R accept<R>(
-      SpecVisitor<R> visitor, [
-        R? context,
-      ]) =>
+    SpecVisitor<R> visitor, [
+    R? context,
+  ]) =>
       visitor.visitField(this, context);
 }
 

--- a/lib/src/specs/field.dart
+++ b/lib/src/specs/field.dart
@@ -41,6 +41,9 @@ abstract class Field extends Object
   /// Whether this field should be prefixed with `late`.
   bool get late;
 
+  /// Whether the field should be prefixed with `external`.
+  bool get external;
+
   /// Name of the field.
   String get name;
 
@@ -50,9 +53,9 @@ abstract class Field extends Object
 
   @override
   R accept<R>(
-    SpecVisitor<R> visitor, [
-    R? context,
-  ]) =>
+      SpecVisitor<R> visitor, [
+        R? context,
+      ]) =>
       visitor.visitField(this, context);
 }
 
@@ -85,6 +88,9 @@ abstract class FieldBuilder extends Object
 
   /// Whether this field should be prefixed with `late`.
   bool late = false;
+
+  /// Whether the field should be prefixed with `external`.
+  bool external = false;
 
   /// Name of the field.
   String? name;

--- a/lib/src/specs/field.g.dart
+++ b/lib/src/specs/field.g.dart
@@ -18,6 +18,8 @@ class _$Field extends Field {
   @override
   final bool late;
   @override
+  final bool external;
+  @override
   final String name;
   @override
   final Reference? type;
@@ -29,18 +31,20 @@ class _$Field extends Field {
 
   _$Field._(
       {required this.annotations,
-      required this.docs,
-      this.assignment,
-      required this.static,
-      required this.late,
-      required this.name,
-      this.type,
-      required this.modifier})
+        required this.docs,
+        this.assignment,
+        required this.static,
+        required this.late,
+        required this.external,
+        required this.name,
+        this.type,
+        required this.modifier})
       : super._() {
     BuiltValueNullFieldError.checkNotNull(annotations, r'Field', 'annotations');
     BuiltValueNullFieldError.checkNotNull(docs, r'Field', 'docs');
     BuiltValueNullFieldError.checkNotNull(static, r'Field', 'static');
     BuiltValueNullFieldError.checkNotNull(late, r'Field', 'late');
+    BuiltValueNullFieldError.checkNotNull(external, r'Field', 'external');
     BuiltValueNullFieldError.checkNotNull(name, r'Field', 'name');
     BuiltValueNullFieldError.checkNotNull(modifier, r'Field', 'modifier');
   }
@@ -61,6 +65,7 @@ class _$Field extends Field {
         assignment == other.assignment &&
         static == other.static &&
         late == other.late &&
+        external == other.external &&
         name == other.name &&
         type == other.type &&
         modifier == other.modifier;
@@ -74,6 +79,7 @@ class _$Field extends Field {
     _$hash = $jc(_$hash, assignment.hashCode);
     _$hash = $jc(_$hash, static.hashCode);
     _$hash = $jc(_$hash, late.hashCode);
+    _$hash = $jc(_$hash, external.hashCode);
     _$hash = $jc(_$hash, name.hashCode);
     _$hash = $jc(_$hash, type.hashCode);
     _$hash = $jc(_$hash, modifier.hashCode);
@@ -84,14 +90,15 @@ class _$Field extends Field {
   @override
   String toString() {
     return (newBuiltValueToStringHelper(r'Field')
-          ..add('annotations', annotations)
-          ..add('docs', docs)
-          ..add('assignment', assignment)
-          ..add('static', static)
-          ..add('late', late)
-          ..add('name', name)
-          ..add('type', type)
-          ..add('modifier', modifier))
+      ..add('annotations', annotations)
+      ..add('docs', docs)
+      ..add('assignment', assignment)
+      ..add('static', static)
+      ..add('late', late)
+      ..add('external', external)
+      ..add('name', name)
+      ..add('type', type)
+      ..add('modifier', modifier))
         .toString();
   }
 }
@@ -160,6 +167,18 @@ class _$FieldBuilder extends FieldBuilder {
   }
 
   @override
+  bool get external {
+    _$this;
+    return super.external;
+  }
+
+  @override
+  set external(bool external) {
+    _$this;
+    super.external = external;
+  }
+
+  @override
   String? get name {
     _$this;
     return super.name;
@@ -205,6 +224,7 @@ class _$FieldBuilder extends FieldBuilder {
       super.assignment = $v.assignment;
       super.static = $v.static;
       super.late = $v.late;
+      super.external = $v.external;
       super.name = $v.name;
       super.type = $v.type;
       super.modifier = $v.modifier;
@@ -238,9 +258,11 @@ class _$FieldBuilder extends FieldBuilder {
               static: BuiltValueNullFieldError.checkNotNull(
                   static, r'Field', 'static'),
               late:
-                  BuiltValueNullFieldError.checkNotNull(late, r'Field', 'late'),
+              BuiltValueNullFieldError.checkNotNull(late, r'Field', 'late'),
+              external: BuiltValueNullFieldError.checkNotNull(
+                  external, r'Field', 'external'),
               name:
-                  BuiltValueNullFieldError.checkNotNull(name, r'Field', 'name'),
+              BuiltValueNullFieldError.checkNotNull(name, r'Field', 'name'),
               type: type,
               modifier: BuiltValueNullFieldError.checkNotNull(
                   modifier, r'Field', 'modifier'));

--- a/lib/src/specs/field.g.dart
+++ b/lib/src/specs/field.g.dart
@@ -31,14 +31,14 @@ class _$Field extends Field {
 
   _$Field._(
       {required this.annotations,
-        required this.docs,
-        this.assignment,
-        required this.static,
-        required this.late,
-        required this.external,
-        required this.name,
-        this.type,
-        required this.modifier})
+      required this.docs,
+      this.assignment,
+      required this.static,
+      required this.late,
+      required this.external,
+      required this.name,
+      this.type,
+      required this.modifier})
       : super._() {
     BuiltValueNullFieldError.checkNotNull(annotations, r'Field', 'annotations');
     BuiltValueNullFieldError.checkNotNull(docs, r'Field', 'docs');
@@ -90,15 +90,15 @@ class _$Field extends Field {
   @override
   String toString() {
     return (newBuiltValueToStringHelper(r'Field')
-      ..add('annotations', annotations)
-      ..add('docs', docs)
-      ..add('assignment', assignment)
-      ..add('static', static)
-      ..add('late', late)
-      ..add('external', external)
-      ..add('name', name)
-      ..add('type', type)
-      ..add('modifier', modifier))
+          ..add('annotations', annotations)
+          ..add('docs', docs)
+          ..add('assignment', assignment)
+          ..add('static', static)
+          ..add('late', late)
+          ..add('external', external)
+          ..add('name', name)
+          ..add('type', type)
+          ..add('modifier', modifier))
         .toString();
   }
 }
@@ -258,11 +258,11 @@ class _$FieldBuilder extends FieldBuilder {
               static: BuiltValueNullFieldError.checkNotNull(
                   static, r'Field', 'static'),
               late:
-              BuiltValueNullFieldError.checkNotNull(late, r'Field', 'late'),
+                  BuiltValueNullFieldError.checkNotNull(late, r'Field', 'late'),
               external: BuiltValueNullFieldError.checkNotNull(
                   external, r'Field', 'external'),
               name:
-              BuiltValueNullFieldError.checkNotNull(name, r'Field', 'name'),
+                  BuiltValueNullFieldError.checkNotNull(name, r'Field', 'name'),
               type: type,
               modifier: BuiltValueNullFieldError.checkNotNull(
                   modifier, r'Field', 'modifier'));

--- a/test/specs/field_test.dart
+++ b/test/specs/field_test.dart
@@ -96,4 +96,20 @@ void main() {
       '''),
     );
   });
+
+  test('should create a external field', () {
+    expect(
+      Field((b) => b
+        ..name = 'value'
+        ..external = true
+        ..type = refer('double')
+        ..annotations.addAll([
+          refer('Float').call([])
+        ])),
+      equalsDart(r'''
+        @Float()
+        external double value;
+      '''),
+    );
+  });
 }

--- a/test/specs/field_test.dart
+++ b/test/specs/field_test.dart
@@ -103,9 +103,7 @@ void main() {
         ..name = 'value'
         ..external = true
         ..type = refer('double')
-        ..annotations.addAll([
-          refer('Float').call([])
-        ])),
+        ..annotations.addAll([refer('Float').call([])])),
       equalsDart(r'''
         @Float()
         external double value;


### PR DESCRIPTION
- Added support of external keyword for FieldBuilder
-  Issue #409 
- Added test case for external keyword inside field_test
- ```test('should create a external field', () {
    expect(
      Field((b) => b
        ..name = 'value'
        ..external = true
        ..type = refer('double')
        ..annotations.addAll([
          refer('Float').call([])
        ])),
      equalsDart(r'''
        @Float()
        external double value;
      '''),
    );
  });