### PR TITLE
Add Expression.parenthesized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Add support for named arguments in `enum` classes
 * Add support for external keyword on fields.
+* Add `Expression.parenthesized` to manually wrap an expression in parenthesis.
 
 ## 4.5.0
 

--- a/lib/code_builder.dart
+++ b/lib/code_builder.dart
@@ -25,6 +25,7 @@ export 'src/specs/expression.dart'
         InvokeExpressionType,
         LiteralExpression,
         LiteralListExpression,
+        ParenthesizedExpression,
         ToCodeExpression,
         declareConst,
         declareFinal,

--- a/lib/src/specs/expression.dart
+++ b/lib/src/specs/expression.dart
@@ -331,6 +331,9 @@ abstract class Expression implements Spec {
   /// May be overridden to support other types implementing [Expression].
   @visibleForOverriding
   Expression get expression => this;
+
+  /// Returns this expression wrapped in parenthesis.
+  ParenthesizedExpression get parenthesized => ParenthesizedExpression._(this);
 }
 
 /// Declare a const variable named [variableName].

--- a/test/specs/code/expression_test.dart
+++ b/test/specs/code/expression_test.dart
@@ -731,4 +731,13 @@ void main() {
             .assign(refer('bar')),
         equalsDart('late String foo = bar'));
   });
+
+  test('should emit a perenthesized epression', () {
+    expect(
+        refer('foo').ifNullThen(refer('FormatException')
+            .newInstance([literalString('missing foo')])
+            .thrown
+            .parenthesized),
+        equalsDart('foo ?? (throw FormatException(\'missing foo\'))'));
+  });
 }


### PR DESCRIPTION
We use `ParenthesizedExpression` internally in a few places where it's
know that they are required, but some corners of the syntax require
extra parenthesis in ways that are not feasible to detect in this
library. Allow for explicit manual parenthesis.
