### PR TITLE
Add missing operator and assignment expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 4.7.0-dev
+## 4.7.0-wip
 
 * Add `Expression.operatorSubtract`
 * Deprecate `Expression.operatorSubstract`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,18 +15,18 @@
 * Add `Expression.operatorShiftLeft`
 * Add `Expression.operatorShiftRight`
 * Add `Expression.operatorShiftRightUnsigned`
-* Add `Expression.assignAdd`
-* Add `Expression.assignSubtract`
-* Add `Expression.assignMultiply`
-* Add `Expression.assignDivide`
-* Add `Expression.assignIntDivide`
-* Add `Expression.assignEuclideanModulo`
-* Add `Expression.assignShiftLeft`
-* Add `Expression.assignShiftRight`
-* Add `Expression.assignShiftRightUnsigned`
-* Add `Expression.assignBitwiseAnd`
-* Add `Expression.assignBitwiseXor`
-* Add `Expression.assignBitwiseOr`
+* Add `Expression.addAssign`
+* Add `Expression.subtractAssign`
+* Add `Expression.multiplyAssign`
+* Add `Expression.divideAssign`
+* Add `Expression.intDivideAssign`
+* Add `Expression.euclideanModuloAssign`
+* Add `Expression.shiftLeftAssign`
+* Add `Expression.shiftRightAssign`
+* Add `Expression.shiftRightUnsignedAssign`
+* Add `Expression.bitwiseAndAssign`
+* Add `Expression.bitwiseXorAssign`
+* Add `Expression.bitwiseOrAssign`
 
 ## 4.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,33 @@
+## 4.7.0-dev
+
+* Add `Expression.operatorSubtract`
+* Deprecate `Expression.operatorSubstract`
+* Add `Expression.operatorIntDivide`
+* Add `Expression.operatorUnaryPrefixIncrement`
+* Add `Expression.operatorUnaryPostfixIncrement`
+* Add `Expression.operatorUnaryMinus`
+* Add `Expression.operatorUnaryPrefixDecrement`
+* Add `Expression.operatorUnaryPostfixDecrement`
+* Add `Expression.operatorBitwiseAnd`
+* Add `Expression.operatorBitwiseOr`
+* Add `Expression.operatorBitwiseXor`
+* Add `Expression.operatorUnaryBitwiseComplement`
+* Add `Expression.operatorShiftLeft`
+* Add `Expression.operatorShiftRight`
+* Add `Expression.operatorShiftRightUnsigned`
+* Add `Expression.assignAdd`
+* Add `Expression.assignSubtract`
+* Add `Expression.assignMultiply`
+* Add `Expression.assignDivide`
+* Add `Expression.assignIntDivide`
+* Add `Expression.assignEuclideanModulo`
+* Add `Expression.assignShiftLeft`
+* Add `Expression.assignShiftRight`
+* Add `Expression.assignShiftRightUnsigned`
+* Add `Expression.assignBitwiseAnd`
+* Add `Expression.assignBitwiseXor`
+* Add `Expression.assignBitwiseOr`
+
 ## 4.6.0
 
 * Add support for named arguments in `enum` classes

--- a/lib/src/specs/expression.dart
+++ b/lib/src/specs/expression.dart
@@ -13,15 +13,10 @@ import 'reference.dart';
 import 'type_function.dart';
 
 part 'expression/binary.dart';
-
 part 'expression/closure.dart';
-
 part 'expression/code.dart';
-
 part 'expression/invoke.dart';
-
 part 'expression/literal.dart';
-
 part 'expression/parenthesized.dart';
 
 /// Represents a [code] block that wraps an [Expression].

--- a/lib/src/specs/expression.dart
+++ b/lib/src/specs/expression.dart
@@ -514,26 +514,16 @@ class ToCodeExpression implements Code {
 /// **INTERNAL ONLY**.
 abstract class ExpressionVisitor<T> implements SpecVisitor<T> {
   T visitToCodeExpression(ToCodeExpression code, [T? context]);
-
   T visitBinaryExpression(BinaryExpression expression, [T? context]);
-
   T visitClosureExpression(ClosureExpression expression, [T? context]);
-
   T visitCodeExpression(CodeExpression expression, [T? context]);
-
   T visitInvokeExpression(InvokeExpression expression, [T? context]);
-
   T visitLiteralExpression(LiteralExpression expression, [T? context]);
-
   T visitLiteralListExpression(LiteralListExpression expression, [T? context]);
-
   T visitLiteralSetExpression(LiteralSetExpression expression, [T? context]);
-
   T visitLiteralMapExpression(LiteralMapExpression expression, [T? context]);
-
   T visitLiteralRecordExpression(LiteralRecordExpression expression,
       [T? context]);
-
   T visitParenthesizedExpression(ParenthesizedExpression expression,
       [T? context]);
 }

--- a/lib/src/specs/expression.dart
+++ b/lib/src/specs/expression.dart
@@ -147,12 +147,14 @@ abstract class Expression implements Spec {
       );
 
   /// Returns the result of `this` `-` [other].
-  // TODO(kevmoo): create a function spelled correctly and deprecate this one!
-  Expression operatorSubstract(Expression other) => BinaryExpression._(
+  Expression operatorSubtract(Expression other) => BinaryExpression._(
         expression,
         other,
         '-',
       );
+
+  @Deprecated('Use `operatorSubtract` instead')
+  Expression operatorSubstract(Expression other) => operatorSubtract(other);
 
   /// Returns the result of `this` `/` [other].
   Expression operatorDivide(Expression other) => BinaryExpression._(
@@ -175,6 +177,10 @@ abstract class Expression implements Spec {
         '%',
       );
 
+  /// Returns the result of `this` `~/` [other].
+  Expression operatorIntDivide(Expression other) =>
+      BinaryExpression._(expression, other, '~/');
+
   Expression conditional(Expression whenTrue, Expression whenFalse) =>
       BinaryExpression._(
         expression,
@@ -189,9 +195,105 @@ abstract class Expression implements Spec {
         'await',
       );
 
+  /// Returns the result of `++this`.
+  Expression operatorUnaryPrefixIncrement() =>
+      BinaryExpression._(_empty, expression, '++', addSpace: false);
+
+  /// Return the result of `this++`.
+  Expression operatorUnaryPostfixIncrement() =>
+      BinaryExpression._(expression, _empty, '++', addSpace: false);
+
+  /// Returns the result of `-this`.
+  Expression operatorUnaryMinus() =>
+      BinaryExpression._(_empty, expression, '-', addSpace: false);
+
+  /// Returns the result of `--this`.
+  Expression operatorUnaryPrefixDecrement() =>
+      BinaryExpression._(_empty, expression, '--', addSpace: false);
+
+  /// Return the result of `this--`.
+  Expression operatorUnaryPostfixDecrement() =>
+      BinaryExpression._(expression, _empty, '--', addSpace: false);
+
+  /// Returns the result of `this` `&` [other].
+  Expression operatorBitwiseAnd(Expression other) =>
+      BinaryExpression._(expression, other, '&');
+
+  /// Returns the result of `this` `|` [other].
+  Expression operatorBitwiseOr(Expression other) =>
+      BinaryExpression._(expression, other, '|');
+
+  /// Returns the result of `this` `^` [other].
+  Expression operatorBitwiseXor(Expression other) =>
+      BinaryExpression._(expression, other, '^');
+
+  /// Returns the result of `~this`.
+  Expression operatorUnaryBitwiseComplement() =>
+      BinaryExpression._(_empty, expression, '~', addSpace: false);
+
+  /// Returns the result of `this` `<<` [other].
+  Expression operatorShiftLeft(Expression other) =>
+      BinaryExpression._(expression, other, '<<');
+
+  /// Returns the result of `this` `>>` [other].
+  Expression operatorShiftRight(Expression other) =>
+      BinaryExpression._(expression, other, '>>');
+
+  /// Returns the result of `this` `>>>` [other].
+  Expression operatorShiftRightUnsigned(Expression other) =>
+      BinaryExpression._(expression, other, '>>>');
+
   /// Return `{this} = {other}`.
   Expression assign(Expression other) =>
       BinaryExpression._(this, other, '=', isConst: isConst);
+
+  /// Return `this` += [other].
+  Expression assignAdd(Expression other) =>
+      BinaryExpression._(this, other, '+=');
+
+  /// Return `this` -= [other].
+  Expression assignSubtract(Expression other) =>
+      BinaryExpression._(this, other, '-=');
+
+  /// Return `this` *= [other].
+  Expression assignMultiply(Expression other) =>
+      BinaryExpression._(this, other, '*=');
+
+  /// Return `this` /= [other].
+  Expression assignDivide(Expression other) =>
+      BinaryExpression._(this, other, '/=');
+
+  /// Return `this` ~/= [other].
+  Expression assignIntDivide(Expression other) =>
+      BinaryExpression._(this, other, '~/=');
+
+  /// Return `this` %= [other].
+  Expression assignEuclideanModulo(Expression other) =>
+      BinaryExpression._(this, other, '%=');
+
+  /// Return `this` <<= [other].
+  Expression assignShiftLeft(Expression other) =>
+      BinaryExpression._(this, other, '<<=');
+
+  /// Return `this` >>= [other].
+  Expression assignShiftRight(Expression other) =>
+      BinaryExpression._(this, other, '>>=');
+
+  /// Return `this` >>>= [other].
+  Expression assignShiftRightUnsigned(Expression other) =>
+      BinaryExpression._(this, other, '>>>=');
+
+  /// Return `this` &= [other].
+  Expression assignBitwiseAnd(Expression other) =>
+      BinaryExpression._(this, other, '&=');
+
+  /// Return `this` ^= [other].
+  Expression assignBitwiseXor(Expression other) =>
+      BinaryExpression._(this, other, '^=');
+
+  /// Return `this` |= [other].
+  Expression assignBitwiseOr(Expression other) =>
+      BinaryExpression._(this, other, '|=');
 
   /// Return `{this} ?? {other}`.
   Expression ifNullThen(Expression other) => BinaryExpression._(

--- a/lib/src/specs/expression.dart
+++ b/lib/src/specs/expression.dart
@@ -13,10 +13,15 @@ import 'reference.dart';
 import 'type_function.dart';
 
 part 'expression/binary.dart';
+
 part 'expression/closure.dart';
+
 part 'expression/code.dart';
+
 part 'expression/invoke.dart';
+
 part 'expression/literal.dart';
+
 part 'expression/parenthesized.dart';
 
 /// Represents a [code] block that wraps an [Expression].
@@ -248,51 +253,51 @@ abstract class Expression implements Spec {
       BinaryExpression._(this, other, '=', isConst: isConst);
 
   /// Return `this` += [other].
-  Expression assignAdd(Expression other) =>
+  Expression addAssign(Expression other) =>
       BinaryExpression._(this, other, '+=');
 
   /// Return `this` -= [other].
-  Expression assignSubtract(Expression other) =>
+  Expression subtractAssign(Expression other) =>
       BinaryExpression._(this, other, '-=');
 
   /// Return `this` *= [other].
-  Expression assignMultiply(Expression other) =>
+  Expression multiplyAssign(Expression other) =>
       BinaryExpression._(this, other, '*=');
 
   /// Return `this` /= [other].
-  Expression assignDivide(Expression other) =>
+  Expression divideAssign(Expression other) =>
       BinaryExpression._(this, other, '/=');
 
   /// Return `this` ~/= [other].
-  Expression assignIntDivide(Expression other) =>
+  Expression intDivideAssign(Expression other) =>
       BinaryExpression._(this, other, '~/=');
 
   /// Return `this` %= [other].
-  Expression assignEuclideanModulo(Expression other) =>
+  Expression euclideanModuloAssign(Expression other) =>
       BinaryExpression._(this, other, '%=');
 
   /// Return `this` <<= [other].
-  Expression assignShiftLeft(Expression other) =>
+  Expression shiftLeftAssign(Expression other) =>
       BinaryExpression._(this, other, '<<=');
 
   /// Return `this` >>= [other].
-  Expression assignShiftRight(Expression other) =>
+  Expression shiftRightAssign(Expression other) =>
       BinaryExpression._(this, other, '>>=');
 
   /// Return `this` >>>= [other].
-  Expression assignShiftRightUnsigned(Expression other) =>
+  Expression shiftRightUnsignedAssign(Expression other) =>
       BinaryExpression._(this, other, '>>>=');
 
   /// Return `this` &= [other].
-  Expression assignBitwiseAnd(Expression other) =>
+  Expression bitwiseAndAssign(Expression other) =>
       BinaryExpression._(this, other, '&=');
 
   /// Return `this` ^= [other].
-  Expression assignBitwiseXor(Expression other) =>
+  Expression bitwiseXorAssign(Expression other) =>
       BinaryExpression._(this, other, '^=');
 
   /// Return `this` |= [other].
-  Expression assignBitwiseOr(Expression other) =>
+  Expression bitwiseOrAssign(Expression other) =>
       BinaryExpression._(this, other, '|=');
 
   /// Return `{this} ?? {other}`.
@@ -509,16 +514,26 @@ class ToCodeExpression implements Code {
 /// **INTERNAL ONLY**.
 abstract class ExpressionVisitor<T> implements SpecVisitor<T> {
   T visitToCodeExpression(ToCodeExpression code, [T? context]);
+
   T visitBinaryExpression(BinaryExpression expression, [T? context]);
+
   T visitClosureExpression(ClosureExpression expression, [T? context]);
+
   T visitCodeExpression(CodeExpression expression, [T? context]);
+
   T visitInvokeExpression(InvokeExpression expression, [T? context]);
+
   T visitLiteralExpression(LiteralExpression expression, [T? context]);
+
   T visitLiteralListExpression(LiteralListExpression expression, [T? context]);
+
   T visitLiteralSetExpression(LiteralSetExpression expression, [T? context]);
+
   T visitLiteralMapExpression(LiteralMapExpression expression, [T? context]);
+
   T visitLiteralRecordExpression(LiteralRecordExpression expression,
       [T? context]);
+
   T visitParenthesizedExpression(ParenthesizedExpression expression,
       [T? context]);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: code_builder
-version: 4.7.0
+version: 4.8.0-wip
 description: >-
   A fluent, builder-based library for generating valid Dart code
 repository: https://github.com/dart-lang/code_builder

--- a/test/specs/code/expression_test.dart
+++ b/test/specs/code/expression_test.dart
@@ -650,6 +650,9 @@ void main() {
   });
 
   test('should emit an operator subtract call', () {
+    expect(refer('foo').operatorSubstract(refer('foo2')),
+        equalsDart('foo - foo2'));
+
     expect(
       refer('foo').operatorSubtract(refer('foo2')),
       equalsDart('foo - foo2'),

--- a/test/specs/code/expression_test.dart
+++ b/test/specs/code/expression_test.dart
@@ -666,81 +666,81 @@ void main() {
         refer('foo').operatorMultiply(refer('foo2')), equalsDart('foo * foo2'));
   });
 
-  test('should emit an euclidean modulo operator call', () {
+  test('should emit an operator euclidean modulo call', () {
     expect(refer('foo').operatorEuclideanModulo(refer('foo2')),
         equalsDart('foo % foo2'));
   });
 
-  test('should emit an int divide operator call', () {
+  test('should emit an operator int divide call', () {
     expect(
       refer('foo').operatorIntDivide(refer('foo2')),
       equalsDart('foo ~/ foo2'),
     );
   });
 
-  test('should emit an unary prefix increment operator call', () {
+  test('should emit an operator unary prefix increment call', () {
     expect(refer('foo').operatorUnaryPrefixIncrement(), equalsDart('++foo'));
   });
 
-  test('should emit an unary postfix increment operator call', () {
+  test('should emit an operator unary postfix increment call', () {
     expect(refer('foo').operatorUnaryPostfixIncrement(), equalsDart('foo++'));
   });
 
-  test('should emit an unary prefix minus operator call', () {
+  test('should emit an operator unary prefix minus call', () {
     expect(refer('foo').operatorUnaryMinus(), equalsDart('-foo'));
   });
 
-  test('should emit an unary prefix decrement operator call', () {
+  test('should emit an operator unary prefix decrement call', () {
     expect(refer('foo').operatorUnaryPrefixDecrement(), equalsDart('--foo'));
   });
 
-  test('should emit an unary postfix decrement operator call', () {
+  test('should emit an operator unary postfix decrement call', () {
     expect(refer('foo').operatorUnaryPostfixDecrement(), equalsDart('foo--'));
   });
 
-  test('should emit a bitwise and operator call', () {
+  test('should emit an operator bitwise and call', () {
     expect(
       refer('foo').operatorBitwiseAnd(refer('foo2')),
       equalsDart('foo & foo2'),
     );
   });
 
-  test('should emit a bitwise or operator call', () {
+  test('should emit an operator bitwise or call', () {
     expect(
       refer('foo').operatorBitwiseOr(refer('foo2')),
       equalsDart('foo | foo2'),
     );
   });
 
-  test('should emit a bitwise xor operator call', () {
+  test('should emit an operator bitwise xor call', () {
     expect(
       refer('foo').operatorBitwiseXor(refer('foo2')),
       equalsDart('foo ^ foo2'),
     );
   });
 
-  test('should emit a unary bitwise complement operator call', () {
+  test('should emit an operator unary bitwise complement call', () {
     expect(
       refer('foo').operatorUnaryBitwiseComplement(),
       equalsDart('~foo'),
     );
   });
 
-  test('should emit a shift left operator call', () {
+  test('should emit an operator shift left call', () {
     expect(
       refer('foo').operatorShiftLeft(refer('foo2')),
       equalsDart('foo << foo2'),
     );
   });
 
-  test('should emit a shift right operator call', () {
+  test('should emit an operator shift right call', () {
     expect(
       refer('foo').operatorShiftRight(refer('foo2')),
       equalsDart('foo >> foo2'),
     );
   });
 
-  test('should emit a shift right unsigned operator call', () {
+  test('should emit an operator shift right unsigned call', () {
     expect(
       refer('foo').operatorShiftRightUnsigned(refer('foo2')),
       equalsDart('foo >>> foo2'),
@@ -826,21 +826,21 @@ void main() {
     );
   });
 
-  test('should emit an subtraction assigment expression', () {
+  test('should emit a subtraction assigment expression', () {
     expect(
       refer('foo').assignSubtract(refer('bar')),
       equalsDart('foo -= bar'),
     );
   });
 
-  test('should emit an multiplication assigment expression', () {
+  test('should emit a multiplication assigment expression', () {
     expect(
       refer('foo').assignMultiply(refer('bar')),
       equalsDart('foo *= bar'),
     );
   });
 
-  test('should emit an division assigment expression', () {
+  test('should emit a division assigment expression', () {
     expect(
       refer('foo').assignDivide(refer('bar')),
       equalsDart('foo /= bar'),
@@ -854,49 +854,49 @@ void main() {
     );
   });
 
-  test('should emit an euclidean modulo assigment expression', () {
+  test('should emit a euclidean modulo assigment expression', () {
     expect(
       refer('foo').assignEuclideanModulo(refer('bar')),
       equalsDart('foo %= bar'),
     );
   });
 
-  test('should emit an shift left assigment expression', () {
+  test('should emit a shift left assigment expression', () {
     expect(
       refer('foo').assignShiftLeft(refer('bar')),
       equalsDart('foo <<= bar'),
     );
   });
 
-  test('should emit an shift right assigment expression', () {
+  test('should emit a shift right assigment expression', () {
     expect(
       refer('foo').assignShiftRight(refer('bar')),
       equalsDart('foo >>= bar'),
     );
   });
 
-  test('should emit an shift right unsigned assigment expression', () {
+  test('should emit a shift right unsigned assigment expression', () {
     expect(
       refer('foo').assignShiftRightUnsigned(refer('bar')),
       equalsDart('foo >>>= bar'),
     );
   });
 
-  test('should emit an bitwise and assigment expression', () {
+  test('should emit a bitwise and assigment expression', () {
     expect(
       refer('foo').assignBitwiseAnd(refer('bar')),
       equalsDart('foo &= bar'),
     );
   });
 
-  test('should emit an bitwise xor assigment expression', () {
+  test('should emit a bitwise xor assigment expression', () {
     expect(
       refer('foo').assignBitwiseXor(refer('bar')),
       equalsDart('foo ^= bar'),
     );
   });
 
-  test('should emit an bitwise or assigment expression', () {
+  test('should emit a bitwise or assigment expression', () {
     expect(
       refer('foo').assignBitwiseOr(refer('bar')),
       equalsDart('foo |= bar'),

--- a/test/specs/code/expression_test.dart
+++ b/test/specs/code/expression_test.dart
@@ -670,7 +670,7 @@ void main() {
         refer('foo').operatorMultiply(refer('foo2')), equalsDart('foo * foo2'));
   });
 
-  test('should emit an operator euclidean modulo call', () {
+  test('should emit an euclidean modulo operator call', () {
     expect(refer('foo').operatorEuclideanModulo(refer('foo2')),
         equalsDart('foo % foo2'));
   });

--- a/test/specs/code/expression_test.dart
+++ b/test/specs/code/expression_test.dart
@@ -825,84 +825,84 @@ void main() {
 
   test('should emit an addition assigment expression', () {
     expect(
-      refer('foo').assignAdd(refer('bar')),
+      refer('foo').addAssign(refer('bar')),
       equalsDart('foo += bar'),
     );
   });
 
   test('should emit a subtraction assigment expression', () {
     expect(
-      refer('foo').assignSubtract(refer('bar')),
+      refer('foo').subtractAssign(refer('bar')),
       equalsDart('foo -= bar'),
     );
   });
 
   test('should emit a multiplication assigment expression', () {
     expect(
-      refer('foo').assignMultiply(refer('bar')),
+      refer('foo').multiplyAssign(refer('bar')),
       equalsDart('foo *= bar'),
     );
   });
 
   test('should emit a division assigment expression', () {
     expect(
-      refer('foo').assignDivide(refer('bar')),
+      refer('foo').divideAssign(refer('bar')),
       equalsDart('foo /= bar'),
     );
   });
 
   test('should emit an int division assigment expression', () {
     expect(
-      refer('foo').assignIntDivide(refer('bar')),
+      refer('foo').intDivideAssign(refer('bar')),
       equalsDart('foo ~/= bar'),
     );
   });
 
   test('should emit a euclidean modulo assigment expression', () {
     expect(
-      refer('foo').assignEuclideanModulo(refer('bar')),
+      refer('foo').euclideanModuloAssign(refer('bar')),
       equalsDart('foo %= bar'),
     );
   });
 
   test('should emit a shift left assigment expression', () {
     expect(
-      refer('foo').assignShiftLeft(refer('bar')),
+      refer('foo').shiftLeftAssign(refer('bar')),
       equalsDart('foo <<= bar'),
     );
   });
 
   test('should emit a shift right assigment expression', () {
     expect(
-      refer('foo').assignShiftRight(refer('bar')),
+      refer('foo').shiftRightAssign(refer('bar')),
       equalsDart('foo >>= bar'),
     );
   });
 
   test('should emit a shift right unsigned assigment expression', () {
     expect(
-      refer('foo').assignShiftRightUnsigned(refer('bar')),
+      refer('foo').shiftRightUnsignedAssign(refer('bar')),
       equalsDart('foo >>>= bar'),
     );
   });
 
   test('should emit a bitwise AND assigment expression', () {
     expect(
-      refer('foo').assignBitwiseAnd(refer('bar')),
+      refer('foo').bitwiseAndAssign(refer('bar')),
       equalsDart('foo &= bar'),
     );
   });
 
   test('should emit a bitwise XOR assigment expression', () {
     expect(
-      refer('foo').assignBitwiseXor(refer('bar')),
+      refer('foo').bitwiseXorAssign(refer('bar')),
       equalsDart('foo ^= bar'),
     );
   });
 
   test('should emit a bitwise OR assigment expression', () {
     expect(
-      refer('foo').assignBitwiseOr(refer('bar')),
+      refer('foo').bitwiseOrAssign(refer('bar')),
       equalsDart('foo |= bar'),
     );
   });

--- a/test/specs/code/expression_test.dart
+++ b/test/specs/code/expression_test.dart
@@ -650,8 +650,10 @@ void main() {
   });
 
   test('should emit an operator subtract call', () {
-    expect(refer('foo').operatorSubstract(refer('foo2')),
-        equalsDart('foo - foo2'));
+    expect(
+      refer('foo').operatorSubtract(refer('foo2')),
+      equalsDart('foo - foo2'),
+    );
   });
 
   test('should emit an operator divide call', () {
@@ -667,6 +669,82 @@ void main() {
   test('should emit an euclidean modulo operator call', () {
     expect(refer('foo').operatorEuclideanModulo(refer('foo2')),
         equalsDart('foo % foo2'));
+  });
+
+  test('should emit an int divide operator call', () {
+    expect(
+      refer('foo').operatorIntDivide(refer('foo2')),
+      equalsDart('foo ~/ foo2'),
+    );
+  });
+
+  test('should emit an unary prefix increment operator call', () {
+    expect(refer('foo').operatorUnaryPrefixIncrement(), equalsDart('++foo'));
+  });
+
+  test('should emit an unary postfix increment operator call', () {
+    expect(refer('foo').operatorUnaryPostfixIncrement(), equalsDart('foo++'));
+  });
+
+  test('should emit an unary prefix minus operator call', () {
+    expect(refer('foo').operatorUnaryMinus(), equalsDart('-foo'));
+  });
+
+  test('should emit an unary prefix decrement operator call', () {
+    expect(refer('foo').operatorUnaryPrefixDecrement(), equalsDart('--foo'));
+  });
+
+  test('should emit an unary postfix decrement operator call', () {
+    expect(refer('foo').operatorUnaryPostfixDecrement(), equalsDart('foo--'));
+  });
+
+  test('should emit a bitwise and operator call', () {
+    expect(
+      refer('foo').operatorBitwiseAnd(refer('foo2')),
+      equalsDart('foo & foo2'),
+    );
+  });
+
+  test('should emit a bitwise or operator call', () {
+    expect(
+      refer('foo').operatorBitwiseOr(refer('foo2')),
+      equalsDart('foo | foo2'),
+    );
+  });
+
+  test('should emit a bitwise xor operator call', () {
+    expect(
+      refer('foo').operatorBitwiseXor(refer('foo2')),
+      equalsDart('foo ^ foo2'),
+    );
+  });
+
+  test('should emit a unary bitwise complement operator call', () {
+    expect(
+      refer('foo').operatorUnaryBitwiseComplement(),
+      equalsDart('~foo'),
+    );
+  });
+
+  test('should emit a shift left operator call', () {
+    expect(
+      refer('foo').operatorShiftLeft(refer('foo2')),
+      equalsDart('foo << foo2'),
+    );
+  });
+
+  test('should emit a shift right operator call', () {
+    expect(
+      refer('foo').operatorShiftRight(refer('foo2')),
+      equalsDart('foo >> foo2'),
+    );
+  });
+
+  test('should emit a shift right unsigned operator call', () {
+    expect(
+      refer('foo').operatorShiftRightUnsigned(refer('foo2')),
+      equalsDart('foo >>> foo2'),
+    );
   });
 
   test('should emit a const variable declaration', () {
@@ -739,5 +817,89 @@ void main() {
             .thrown
             .parenthesized),
         equalsDart('foo ?? (throw FormatException(\'missing foo\'))'));
+  });
+
+  test('should emit an addition assigment expression', () {
+    expect(
+      refer('foo').assignAdd(refer('bar')),
+      equalsDart('foo += bar'),
+    );
+  });
+
+  test('should emit an subtraction assigment expression', () {
+    expect(
+      refer('foo').assignSubtract(refer('bar')),
+      equalsDart('foo -= bar'),
+    );
+  });
+
+  test('should emit an multiplication assigment expression', () {
+    expect(
+      refer('foo').assignMultiply(refer('bar')),
+      equalsDart('foo *= bar'),
+    );
+  });
+
+  test('should emit an division assigment expression', () {
+    expect(
+      refer('foo').assignDivide(refer('bar')),
+      equalsDart('foo /= bar'),
+    );
+  });
+
+  test('should emit an int division assigment expression', () {
+    expect(
+      refer('foo').assignIntDivide(refer('bar')),
+      equalsDart('foo ~/= bar'),
+    );
+  });
+
+  test('should emit an euclidean modulo assigment expression', () {
+    expect(
+      refer('foo').assignEuclideanModulo(refer('bar')),
+      equalsDart('foo %= bar'),
+    );
+  });
+
+  test('should emit an shift left assigment expression', () {
+    expect(
+      refer('foo').assignShiftLeft(refer('bar')),
+      equalsDart('foo <<= bar'),
+    );
+  });
+
+  test('should emit an shift right assigment expression', () {
+    expect(
+      refer('foo').assignShiftRight(refer('bar')),
+      equalsDart('foo >>= bar'),
+    );
+  });
+
+  test('should emit an shift right unsigned assigment expression', () {
+    expect(
+      refer('foo').assignShiftRightUnsigned(refer('bar')),
+      equalsDart('foo >>>= bar'),
+    );
+  });
+
+  test('should emit an bitwise and assigment expression', () {
+    expect(
+      refer('foo').assignBitwiseAnd(refer('bar')),
+      equalsDart('foo &= bar'),
+    );
+  });
+
+  test('should emit an bitwise xor assigment expression', () {
+    expect(
+      refer('foo').assignBitwiseXor(refer('bar')),
+      equalsDart('foo ^= bar'),
+    );
+  });
+
+  test('should emit an bitwise or assigment expression', () {
+    expect(
+      refer('foo').assignBitwiseOr(refer('bar')),
+      equalsDart('foo |= bar'),
+    );
   });
 }

--- a/test/specs/code/expression_test.dart
+++ b/test/specs/code/expression_test.dart
@@ -650,6 +650,7 @@ void main() {
   });
 
   test('should emit an operator subtract call', () {
+    // ignore: deprecated_member_use_from_same_package
     expect(refer('foo').operatorSubstract(refer('foo2')),
         equalsDart('foo - foo2'));
 

--- a/test/specs/code/expression_test.dart
+++ b/test/specs/code/expression_test.dart
@@ -682,69 +682,69 @@ void main() {
     );
   });
 
-  test('should emit an operator unary prefix increment call', () {
+  test('should emit a unary prefix increment operator call', () {
     expect(refer('foo').operatorUnaryPrefixIncrement(), equalsDart('++foo'));
   });
 
-  test('should emit an operator unary postfix increment call', () {
+  test('should emit a unary postfix increment operator call', () {
     expect(refer('foo').operatorUnaryPostfixIncrement(), equalsDart('foo++'));
   });
 
-  test('should emit an operator unary prefix minus call', () {
+  test('should emit a unary prefix minus operator call', () {
     expect(refer('foo').operatorUnaryMinus(), equalsDart('-foo'));
   });
 
-  test('should emit an operator unary prefix decrement call', () {
+  test('should emit a unary prefix decrement operator call', () {
     expect(refer('foo').operatorUnaryPrefixDecrement(), equalsDart('--foo'));
   });
 
-  test('should emit an operator unary postfix decrement call', () {
+  test('should emit a unary postfix decrement operator call', () {
     expect(refer('foo').operatorUnaryPostfixDecrement(), equalsDart('foo--'));
   });
 
-  test('should emit an operator bitwise and call', () {
+  test('should emit a bitwise AND operator call', () {
     expect(
       refer('foo').operatorBitwiseAnd(refer('foo2')),
       equalsDart('foo & foo2'),
     );
   });
 
-  test('should emit an operator bitwise or call', () {
+  test('should emit a bitwise OR operator call', () {
     expect(
       refer('foo').operatorBitwiseOr(refer('foo2')),
       equalsDart('foo | foo2'),
     );
   });
 
-  test('should emit an operator bitwise xor call', () {
+  test('should emit a bitwise XOR operator call', () {
     expect(
       refer('foo').operatorBitwiseXor(refer('foo2')),
       equalsDart('foo ^ foo2'),
     );
   });
 
-  test('should emit an operator unary bitwise complement call', () {
+  test('should emit a unary bitwise complement operator call', () {
     expect(
       refer('foo').operatorUnaryBitwiseComplement(),
       equalsDart('~foo'),
     );
   });
 
-  test('should emit an operator shift left call', () {
+  test('should emit a shift left operator call', () {
     expect(
       refer('foo').operatorShiftLeft(refer('foo2')),
       equalsDart('foo << foo2'),
     );
   });
 
-  test('should emit an operator shift right call', () {
+  test('should emit a shift right operator call', () {
     expect(
       refer('foo').operatorShiftRight(refer('foo2')),
       equalsDart('foo >> foo2'),
     );
   });
 
-  test('should emit an operator shift right unsigned call', () {
+  test('should emit a shift right unsigned operator call', () {
     expect(
       refer('foo').operatorShiftRightUnsigned(refer('foo2')),
       equalsDart('foo >>> foo2'),
@@ -886,21 +886,21 @@ void main() {
     );
   });
 
-  test('should emit a bitwise and assigment expression', () {
+  test('should emit a bitwise AND assigment expression', () {
     expect(
       refer('foo').assignBitwiseAnd(refer('bar')),
       equalsDart('foo &= bar'),
     );
   });
 
-  test('should emit a bitwise xor assigment expression', () {
+  test('should emit a bitwise XOR assigment expression', () {
     expect(
       refer('foo').assignBitwiseXor(refer('bar')),
       equalsDart('foo ^= bar'),
     );
   });
 
-  test('should emit a bitwise or assigment expression', () {
+  test('should emit a bitwise OR assigment expression', () {
     expect(
       refer('foo').assignBitwiseOr(refer('bar')),
       equalsDart('foo |= bar'),


### PR DESCRIPTION
I have recently struggled to clean up a package that I maintain using `Expression` operators instead of using `Code` blocks full of strings, i.e. `Code('$a ^ $b')` and have discovered that quite a few operators are missing from the `Expression` class. So I've added all the missing operators and assignments found on https://dart.dev/language/operators.

- added operators

  | method | generates |
  | :--- | :---: |
  | `Expression.operatorIntDivide` | `this ~/ other` |
  | `Expression.operatorUnaryPrefixIncrement` | `++this` |
  | `Expression.operatorUnaryPostfixIncrement` | `this++` |
  | `Expression.operatorUnaryMinus` | `-this` |
  | `Expression.operatorUnaryPrefixDecrement` | `--this` |
  | `Expression.operatorUnaryPostfixDecrement` | `this--` |
  | `Expression.operatorBitwiseAnd` | `this & other` |
  | `Expression.operatorBitwiseOr` | `this \| other` |
  | `Expression.operatorBitwiseXor` | `this ^ other` |
  | `Expression.operatorUnaryBitwiseComplement` | `~this` |
  | `Expression.operatorShiftLeft` | `this << other` |
  | `Expression.operatorShiftRight` | `this >> other` |
  | `Expression.operatorShiftRightUnsigned` | `this >>> other` |

- added assignments

  | method | generates |
  | :--- | :---: |
  | `Expression.addAssign` | `this += other` |
  | `Expression.subtractAssign` | `this -= other` |
  | `Expression.multiplyAssign` | `this *= other` |
  | `Expression.divideAssign` | `this /= other` |
  | `Expression.intDivideAssign` | `this ~/= other` |
  | `Expression.euclideanModuloAssign` | `this %= other` |
  | `Expression.shiftLeftAssign` | `this <<= other` |
  | `Expression.shiftRightAssign` | `this >>= other` |
  | `Expression.shiftRightUnsignedAssign` | `this >>>= other` |
  | `Expression.bitwiseAndAssign` | `this &= other` |
  | `Expression.bitwiseXorAssign` | `this ^= other` |
  | `Expression.bitwiseOrAssign` | `this \|= other` |


- deprecated the misnamed `Expression.operatorSubstract` method and created a correctly named `Expression.operatorSubtract` method.

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
