### PR TITLE
Allow passing an `Expression` through `literal`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Add `Expression.bitwiseAndAssign`
 * Add `Expression.bitwiseXorAssign`
 * Add `Expression.bitwiseOrAssign`
+* Allow passing an `Expression` through `literal` without an exception.
 
 ## 4.7.0
 

--- a/lib/src/specs/expression/literal.dart
+++ b/lib/src/specs/expression/literal.dart
@@ -8,30 +8,15 @@ part of '../expression.dart';
 ///
 /// Unsupported inputs invoke the [onError] callback.
 Expression literal(Object? literal, {Expression Function(Object)? onError}) {
-  if (literal is bool) {
-    return literalBool(literal);
-  }
-  if (literal is num) {
-    return literalNum(literal);
-  }
-  if (literal is String) {
-    return literalString(literal);
-  }
-  if (literal is List) {
-    return literalList(literal);
-  }
-  if (literal is Set) {
-    return literalSet(literal);
-  }
-  if (literal is Map) {
-    return literalMap(literal);
-  }
-  if (literal == null) {
-    return literalNull;
-  }
-  if (onError != null) {
-    return onError(literal);
-  }
+  if (literal is Expression) return literal;
+  if (literal is bool) return literalBool(literal);
+  if (literal is num) return literalNum(literal);
+  if (literal is String) return literalString(literal);
+  if (literal is List) return literalList(literal);
+  if (literal is Set) return literalSet(literal);
+  if (literal is Map) return literalMap(literal);
+  if (literal == null) return literalNull;
+  if (onError != null) return onError(literal);
   throw UnsupportedError('Not a supported literal type: $literal.');
 }
 

--- a/lib/src/specs/expression/literal.dart
+++ b/lib/src/specs/expression/literal.dart
@@ -6,8 +6,10 @@ part of '../expression.dart';
 
 /// Converts a runtime Dart [literal] value into an [Expression].
 ///
-/// If the [literal] is already an [Expression] it is returned without change.
 /// Supported Dart types are translated into literal expressions.
+/// If the [literal] is already an [Expression] it is returned without change to
+/// allow operating on a collection of mixed simple literals and more complex
+/// expressions.
 /// Unsupported inputs invoke the [onError] callback.
 Expression literal(Object? literal, {Expression Function(Object)? onError}) {
   if (literal is Expression) return literal;

--- a/lib/src/specs/expression/literal.dart
+++ b/lib/src/specs/expression/literal.dart
@@ -6,6 +6,8 @@ part of '../expression.dart';
 
 /// Converts a runtime Dart [literal] value into an [Expression].
 ///
+/// If the [literal] is already an [Expression] it is returned without change.
+/// Supported Dart types are translated into literal expressions.
 /// Unsupported inputs invoke the [onError] callback.
 Expression literal(Object? literal, {Expression Function(Object)? onError}) {
   if (literal is Expression) return literal;

--- a/test/specs/code/expression_test.dart
+++ b/test/specs/code/expression_test.dart
@@ -14,6 +14,48 @@ void main() {
     expect(literalNull, equalsDart('null'));
   });
 
+  group('literal', () {
+    test('forwards values that are already expressions', () {
+      expect(literal(refer('foo')), equalsDart('foo'));
+      expect(literal([refer('foo')]), equalsDart('[foo]'));
+    });
+    group('wraps', () {
+      test('bool values', () {
+        expect(literal(true), equalsDart('true'));
+      });
+      test('numeric values', () {
+        expect(literal(1), equalsDart('1'));
+        expect(literal(1.0), equalsDart('1.0'));
+      });
+      test('string values', () {
+        expect(literal('foo'), equalsDart("'foo'"));
+      });
+      test('list values', () {
+        expect(literal([1]), equalsDart('[1]'));
+      });
+      test('set values', () {
+        expect(literal({1}), equalsDart('{1}'));
+      });
+      test('map values', () {
+        expect(literal({'foo': 1}), equalsDart("{'foo': 1}"));
+      });
+      test('null', () {
+        expect(literal(null), equalsDart('null'));
+      });
+    });
+    test('uses `onError` for unhandled types', () {
+      expect(
+          literal(Uri.https('google.com'), onError: (value) {
+            if (value is Uri) {
+              return refer('Uri')
+                  .newInstanceNamed('parse', [literalString(value.toString())]);
+            }
+            throw UnsupportedError('Not supported: $value');
+          }),
+          equalsDart("Uri.parse('https://google.com')"));
+    });
+  });
+
   test('should emit a String', () {
     expect(literalString(r'$monkey'), equalsDart(r"'$monkey'"));
   });
@@ -124,6 +166,10 @@ void main() {
       ]),
       equalsDart('[[], {}, true, null, Map(), ]'),
     );
+  });
+
+  test('can toString a list literal with an expression as a value', () {
+    expect(literalList([refer('foo')]).toString, isNot(throwsA(anything)));
   });
 
   test('should emit a set of other literals and expressions', () {


### PR DESCRIPTION
The `LiteralListExpression` allows a mix of Dart values which could be
passed to `literal` and values which are already a `Spec` (typically an
`Expression`). Both types are handled by `_acceptLiteral` in the visitor
implementation.

https://github.com/dart-lang/code_builder/blob/eb70874cf05427879ec47d8726eb3173e11880e3/lib/src/specs/expression.dart#L622-L628

The `toString()` for `LiteralListExpression` calls `literal` on each
value in the list, which previously would throw if it was passed an
`Expression`. Some tests for builders and their implementation details
use `.toString()` in their user facing failure messages. When there is
an exception creating the message for a failure, it can mask the cause
of the failure.

Allow more flexibility for this `toString` by allowing `Expression`
instances to flow through `literal` unchanged. This still does not
handle non-expression `Spec` instances, but those are not likely to come
up in practice.

Collapse the conditional returns in `literal` to a single line each. The
pattern is easier to read with less vertical space.

Add tests for `literal` passing each type it accepts, and a test for the
error behavior.

Add a regression test for the `toString` of a list literal not throwing
when one of the values of the list is an `Expression`.
