### PR TITLE
Export representation declaration types, upgrade dart_style to 2.3.4, and publish 4.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
-## 4.10.0-wip
+## 4.10.0
 
 * Add `Library.docs` to support emitting doc comments on libraries.
+* Export `RepresentationDeclaration` and `RepresentationDeclarationBuilder` so
+  they can be used when generating extension types.
+* Upgrade to `dart_style` 2.3.4.
 
 ## 4.9.0
 

--- a/lib/code_builder.dart
+++ b/lib/code_builder.dart
@@ -48,7 +48,12 @@ export 'src/specs/expression.dart'
         literalString,
         literalTrue;
 export 'src/specs/extension.dart' show Extension, ExtensionBuilder;
-export 'src/specs/extension_type.dart' show ExtensionType, ExtensionTypeBuilder;
+export 'src/specs/extension_type.dart'
+    show
+        ExtensionType,
+        ExtensionTypeBuilder,
+        RepresentationDeclaration,
+        RepresentationDeclarationBuilder;
 export 'src/specs/field.dart' show Field, FieldBuilder, FieldModifier;
 export 'src/specs/library.dart' show Library, LibraryBuilder;
 export 'src/specs/method.dart'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: code_builder
-version: 4.10.0-wip
+version: 4.10.0
 description: >-
   A fluent, builder-based library for generating valid Dart code
 repository: https://github.com/dart-lang/code_builder
@@ -19,6 +19,6 @@ dev_dependencies:
   build_runner: ^2.0.3
   built_value_generator: ^8.0.0
   dart_flutter_team_lints: ^1.0.0
-  dart_style: ^2.3.3
+  dart_style: ^2.3.4
   source_gen: ^1.0.0
   test: ^1.16.0

--- a/test/specs/extension_type_test.dart
+++ b/test/specs/extension_type_test.dart
@@ -3,18 +3,12 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:code_builder/code_builder.dart';
-import 'package:code_builder/src/specs/extension_type.dart';
 import 'package:test/test.dart';
 
-// import '../common.dart';
+import '../common.dart';
 
 void main() {
-  // TODO(srujzs): Uncomment this and the import once we have dart_style 2.3.4.
-  // When 2.3.4 is published, extension type formatting will be enabled and
-  // these expectations will start failing. To avoid that, we don't use dart
-  // format temporarily. Once 2.3.4 is published, we can update the expectations
-  // in this file and re-enable dart format.
-  // useDartfmt();
+  useDartfmt();
 
   test('minimum extension type', () {
     expect(


### PR DESCRIPTION
RepresentationDeclaration and RepresentationDeclarationBuilder were never exported in 4.8.0. This also cleans up a TODO to use dart format for extension type tests and preps for publish.