### PR TITLE
feat: merge simplePrefixing allocator ignore with other file ignores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.11.0-wip
+
+* Merge `no_leading_underscores_for_library_prefixes` from the simplePrefixing
+  allocator with other file ignores.
+
 ## 4.10.0
 
 * Add `Library.docs` to support emitting doc comments on libraries.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: code_builder
-version: 4.10.0
+version: 4.11.0-wip
 description: >-
   A fluent, builder-based library for generating valid Dart code
 repository: https://github.com/dart-lang/code_builder

--- a/test/directive_test.dart
+++ b/test/directive_test.dart
@@ -39,6 +39,7 @@ void main() {
       library,
       equalsDart(r'''
           // ignore_for_file: no_leading_underscores_for_library_prefixes
+
           import '../relative.dart' as _i1;
           import 'package:foo/foo.dart' as _i2;
           import 'package:foo/bar.dart' as _i3;
@@ -59,6 +60,7 @@ void main() {
       library,
       equalsDart(r'''
           // ignore_for_file: no_leading_underscores_for_library_prefixes
+          
           import 'dart:collection' as _i4;
 
           import 'package:foo/bar.dart' as _i3;

--- a/test/specs/library_test.dart
+++ b/test/specs/library_test.dart
@@ -225,6 +225,7 @@ void main() {
             ..assignment = Code.scope((a) => '${a($LinkedHashMap)}()')))),
         equalsDart(r'''
           // ignore_for_file: no_leading_underscores_for_library_prefixes
+          
           import 'dart:collection' as _i1;
           
           final test = _i1.LinkedHashMap();
@@ -309,5 +310,28 @@ void main() {
       '''),
       );
     });
+
+    test('should emit a source file with library allocation + prefixing', () {
+      expect(
+        Library((b) => b
+          ..docs.add(
+            '/// My favorite library.',
+          )
+          ..body.add(Field((b) => b
+            ..name = 'test'
+            ..modifier = FieldModifier.final$
+            ..assignment = Code.scope((a) => '${a($LinkedHashMap)}()')))),
+        equalsDart(r'''
+          // ignore_for_file: no_leading_underscores_for_library_prefixes
+          
+          /// My favorite library.
+          library;
+          
+          import 'dart:collection' as _i1;
+          
+          final test = _i1.LinkedHashMap();
+        ''', DartEmitter(allocator: Allocator.simplePrefixing())),
+      );
+    }, skip: true);
   });
 }


### PR DESCRIPTION
Using `Allocator.simplePrefixing()` with a library decalaration resulted in bad formatted code:

```dart
Library((b) => b
  ..docs.add(
    '/// My favorite library.',
  )
  ..body.add(Field((b) => b
    ..name = 'test'
    ..modifier = FieldModifier.final$
    ..assignment = Code.scope((a) => '${a($LinkedHashMap)}()'))))
```

was generating:

```dart
/// My favorite library.
library; // ignore_for_file: no_leading_underscores_for_library_prefixes

import 'dart:collection' as _i1;

final test = _i1.LinkedHashMap();
```

This PR merges the `no_leading_underscores_for_library_prefixes` ignore with the other file level ignores for better readable code. 

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
