### PR TITLE
fix a test expectation for extension types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 4.10.1-wip
+
 ## 4.10.0
 
 * Add `Library.docs` to support emitting doc comments on libraries.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,10 @@
 name: code_builder
-version: 4.10.0
-description: >-
-  A fluent, builder-based library for generating valid Dart code
+version: 4.10.1-wip
+description: A fluent, builder-based library for generating valid Dart code.
 repository: https://github.com/dart-lang/code_builder
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: ^3.0.0
 
 dependencies:
   built_collection: ^5.0.0
@@ -18,7 +17,7 @@ dev_dependencies:
   build: ^2.0.0
   build_runner: ^2.0.3
   built_value_generator: ^8.0.0
-  dart_flutter_team_lints: ^1.0.0
+  dart_flutter_team_lints: ^2.0.0
   dart_style: ^2.3.4
   source_gen: ^1.0.0
   test: ^1.16.0

--- a/test/common.dart
+++ b/test/common.dart
@@ -9,7 +9,7 @@ final DartFormatter _dartfmt = DartFormatter();
 String _format(String source) {
   try {
     return _dartfmt.format(source);
-  } on FormatException catch (_) {
+  } on FormatterException catch (_) {
     return _dartfmt.formatStatement(source);
   }
 }

--- a/test/specs/extension_type_test.dart
+++ b/test/specs/extension_type_test.dart
@@ -186,7 +186,10 @@ void main() {
       equalsDart(r'''
         extension type Foo._(int bar) {
           Foo(this.bar);
-          factory Foo.named(int baz) { return Foo(baz); }
+
+          factory Foo.named(int baz) {
+            return Foo(baz);
+          }
         }
       '''),
     );


### PR DESCRIPTION
- fix a test expectation for extension types (this should address the current CI failure)
- update to the latest `dart_flutter_team_lints`
- catch the correct exception that dart_style throws (note that it doesn't look like this affected any tests)

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
