### PR TITLE
TypeReference for a class shouldn't add a ? when calling constructor or class property.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .packages
 .pub
 pubspec.lock
+.DS_Store

--- a/lib/src/specs/expression.dart
+++ b/lib/src/specs/expression.dart
@@ -11,6 +11,7 @@ import 'code.dart';
 import 'method.dart';
 import 'reference.dart';
 import 'type_function.dart';
+import 'type_reference.dart';
 
 part 'expression/binary.dart';
 part 'expression/closure.dart';
@@ -577,7 +578,12 @@ abstract mixin class ExpressionEmitter
       [StringSink? output]) {
     final out = output ??= StringBuffer();
     return _writeConstExpression(out, expression.isConst, () {
-      expression.target.accept(this, out);
+      final target = expression.target;
+      if (target is TypeReference) {
+        target.rebuild((t) => t..isNullable = false).accept(this, out);
+      } else {
+        target.accept(this, out);
+      }
       if (expression.name != null) {
         out
           ..write('.')

--- a/lib/src/specs/expression.dart
+++ b/lib/src/specs/expression.dart
@@ -544,7 +544,12 @@ abstract mixin class ExpressionEmitter
   StringSink visitBinaryExpression(BinaryExpression expression,
       [StringSink? output]) {
     output ??= StringBuffer();
-    expression.left.accept(this, output);
+    final left = expression.left;
+    if (left is TypeReference) {
+      left.rebuild((t) => t..isNullable = false).accept(this, output);
+    } else {
+      left.accept(this, output);
+    }
     if (expression.addSpace) {
       output.write(' ');
     }

--- a/test/specs/type_reference_test.dart
+++ b/test/specs/type_reference_test.dart
@@ -57,8 +57,7 @@ void main() {
       expect(
         TypeReference((t) => t
           ..symbol = 'Foo'
-          ..isNullable = true)
-          .newInstanceNamed('bar', []),
+          ..isNullable = true).newInstanceNamed('bar', []),
         equalsDart('Foo.bar()', emitter),
       );
     });

--- a/test/specs/type_reference_test.dart
+++ b/test/specs/type_reference_test.dart
@@ -52,5 +52,15 @@ void main() {
         equalsDart(r'List<int?>', emitter),
       );
     });
+
+    test('should create a call to named constructor despite isNullable', () {
+      expect(
+        TypeReference((t) => t
+          ..symbol = 'Foo'
+          ..isNullable = true)
+          .newInstanceNamed('bar', []),
+        equalsDart('Foo.bar()', emitter),
+      );
+    });
   });
 }

--- a/test/specs/type_reference_test.dart
+++ b/test/specs/type_reference_test.dart
@@ -61,5 +61,14 @@ void main() {
         equalsDart('Foo.bar()', emitter),
       );
     });
+
+    test('should create a call to static property despite isNullable', () {
+      expect(
+        TypeReference((t) => t
+          ..symbol = 'Foo'
+          ..isNullable = true).property('bar').call([]),
+        equalsDart('Foo.bar()', emitter),
+      );
+    });
   });
 }


### PR DESCRIPTION
When building code for `TypeReference.newInstance/Named` and the type had `isNullable = true` the resulting code becomes `Foo?.namedConstructor()` which for my use case was not what I wanted.

Here is my use case:

```dart
// useNullSafetySyntax = true

final class PluginField extends BaseField {
  PluginField.fromJson(Map<String, dynamic> data, String name)
      : isRequired = data["required"],
        super.fromJson(data, name);
  final bool isRequired;

  @override
  late final TypeReference type = TypeReference((t) {
    t.symbol = "$Plugin";
    t.isNullable = !isRequired;
  });

  @override
  Expression buildInitializer(CodeExpression valueExpression) {
    final expression = type.newInstanceNamed("fromJson", [valueExpression]);
    if (isRequired) return expression;
    return valueExpression.isNotA(refer("$Map")).conditional(literalNull, expression);
  }
}

class Plugin {
  Plugin.fromJson(Map<String, dynamic> data) : name = data["name"];
  final String name;
}
```

`type` in this case is shared between a caller building a declaration off of it and `buildInitializer` building initializer code in a constructor.

The resulting code before this PR for `buildInitializer` was `Plugin?.fromJson(data["value"])` when `isRequired = false` (`isNullable = true`).

I think it makes sense to have a `TypeReference` not add a `?` onto the type when calling a constructor or static property but to add it when being used to declare a property.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
