### PR TITLE
Update dart_style to pass in a language version to DartFormatter.

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        sdk: [3.3.0, dev]
+        sdk: [3.5.0, dev]
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
       - uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   # Check code formatting and static analysis on a single OS (linux)
-  # against Dart dev and 2.12.0.
+  # against Dart dev and an earlier stable version.
   analyze:
     runs-on: ubuntu-latest
     strategy:
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        sdk: [3.1.0, dev]
+        sdk: [3.3.0, dev]
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
       - uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 4.10.1-wip
 
-* Require Dart `^3.1.0`
-* Upgrade to dart_style `2.3.7`.
+* Require Dart `^3.5.0`
+* Upgrade to `dart_style` 2.3.7.
 
 ## 4.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 4.10.1-wip
 
 * Require Dart `^3.1.0`
+* Upgrade to dart_style `2.3.7`.
 
 ## 4.10.0
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,10 @@ void main() {
       ..name = 'eat'
       ..body = const Code("print('Yum!');"))));
   final emitter = DartEmitter();
-  print(DartFormatter().format('${animal.accept(emitter)}'));
+  print(
+    DartFormatter(languageVersion: DartFormatter.latestLanguageVersion)
+        .format('${animal.accept(emitter)}'),
+  );
 }
 ```
 
@@ -57,7 +60,10 @@ void main() {
           ..returns = refer('Other', 'package:b/b.dart')),
       ]));
   final emitter = DartEmitter.scoped();
-  print(DartFormatter().format('${library.accept(emitter)}'));
+  print(
+    DartFormatter(languageVersion: DartFormatter.latestLanguageVersion)
+        .format('${library.accept(emitter)}'),
+  );
 }
 ```
 
@@ -103,7 +109,7 @@ run from the snapshot instead of from source to avoid problems with deleted
 files. These steps must be run without deleting the source files.
 
 ```bash
-./tool/regenerate.sh 
+./tool/regenerate.sh
 ```
 
 [build_runner]: https://pub.dev/packages/build_runner

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -18,7 +18,6 @@ linter:
     - missing_whitespace_between_adjacent_strings
     - no_adjacent_strings_in_list
     - no_runtimeType_toString
-    - package_api_docs
     - prefer_const_declarations
     - prefer_expression_function_bodies
     - prefer_final_locals

--- a/example/example.dart
+++ b/example/example.dart
@@ -5,7 +5,9 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:dart_style/dart_style.dart';
 
-final _dartfmt = DartFormatter();
+final _dartfmt = DartFormatter(
+  languageVersion: DartFormatter.latestLanguageVersion,
+);
 
 void main() {
   print('animalClass():\n${'=' * 40}\n${animalClass()}');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: A fluent, builder-based library for generating valid Dart code.
 repository: https://github.com/dart-lang/code_builder
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.5.0
 
 dependencies:
   built_collection: ^5.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,6 @@ dev_dependencies:
   build_runner: ^2.0.3
   built_value_generator: ^8.0.0
   dart_flutter_team_lints: ^3.0.0
-  dart_style: ^2.3.4
+  dart_style: ^2.3.7
   source_gen: ^1.0.0
   test: ^1.16.0

--- a/test/common.dart
+++ b/test/common.dart
@@ -5,12 +5,15 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:dart_style/dart_style.dart';
 
-final DartFormatter _dartfmt = DartFormatter();
 String _format(String source) {
+  final formatter = DartFormatter(
+    languageVersion: DartFormatter.latestLanguageVersion,
+  );
+
   try {
-    return _dartfmt.format(source);
+    return formatter.format(source);
   } on FormatterException catch (_) {
-    return _dartfmt.formatStatement(source);
+    return formatter.formatStatement(source);
   }
 }
 


### PR DESCRIPTION
We're in [the process of](https://github.com/dart-lang/dart_style/issues/1403) moving dart_style to [a new formatting style](https://github.com/dart-lang/dart_style/issues/1253). That involves making the formatter [aware of the language version of what it's formatting](https://github.com/dart-lang/dart_style/issues/1402).

That in turn means that the library API now lets you pass in a language version. In dart_style 2.3.7 [you can pass in a language version but the parameter is optional](https://pub.dev/documentation/dart_style/latest/dart_style/DartFormatter/DartFormatter.html). In the forthcoming 3.0.0 release, that parameter will become mandatory.

This updates every call to `DartFormatter()` to pass in the latest language version. If there's a more specific version that should be used, let me know and I'll update the PR.

Thanks!
